### PR TITLE
integrator instance, not class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "astropy >= 5.3",
   "beartype",
   "diffrax",
-  "equinox",
+  "equinox != 0.11.3",
   "jax",
   "jaxlib",
   "typing_extensions",

--- a/src/galax/dynamics/_orbit.py
+++ b/src/galax/dynamics/_orbit.py
@@ -2,11 +2,13 @@
 
 __all__ = ["Orbit"]
 
+import equinox as eqx
 from typing_extensions import override
 
 from galax.potential._potential.base import AbstractPotentialBase
-from galax.typing import BatchFloatScalar
+from galax.typing import BatchFloatScalar, BatchVec3
 from galax.utils._jax import partial_jit
+from galax.utils.dataclasses import converter_float_array
 
 from ._core import AbstractPhaseSpacePosition
 
@@ -18,6 +20,15 @@ class Orbit(AbstractPhaseSpacePosition):
     function of time.
 
     """
+
+    q: BatchVec3 = eqx.field(converter=converter_float_array)
+    """Positions (x, y, z)."""
+
+    p: BatchVec3 = eqx.field(converter=converter_float_array)
+    r"""Conjugate momenta (v_x, v_y, v_z)."""
+
+    t: BatchFloatScalar = eqx.field(converter=converter_float_array)
+    """Array of times."""
 
     potential: AbstractPotentialBase
     """Potential in which the orbit was integrated."""

--- a/src/galax/dynamics/mockstream/_mockstream_generator.py
+++ b/src/galax/dynamics/mockstream/_mockstream_generator.py
@@ -2,7 +2,6 @@
 
 __all__ = ["MockStreamGenerator"]
 
-from collections.abc import Mapping
 from dataclasses import KW_ONLY
 from typing import Any, TypeAlias
 
@@ -53,11 +52,7 @@ class MockStreamGenerator(eqx.Module):  # type: ignore[misc]
     stream_integrator: AbstractIntegrator = eqx.field(
         default=DiffraxIntegrator(), static=True
     )
-
-    stream_integrator_kw: Mapping[str, Any] | None = eqx.field(
-        default=None, static=True, converter=_converter_immutabledict_or_none
-    )
-    """Keyword arguments for the stream integrator."""
+    """Integrator for the stream."""
 
     # ==========================================================================
 

--- a/src/galax/integrate/_base.py
+++ b/src/galax/integrate/_base.py
@@ -6,12 +6,12 @@ from typing import Any, Protocol, runtime_checkable
 import equinox as eqx
 from jaxtyping import Array, Float
 
-from galax.typing import FloatScalar, Vec6, Vec7
+from galax.typing import FloatScalar, Vec6
 
 
 @runtime_checkable
 class FCallable(Protocol):
-    def __call__(self, t: FloatScalar, qp: Vec6, args: tuple[Any, ...]) -> Vec7:
+    def __call__(self, t: FloatScalar, qp: Vec6, args: tuple[Any, ...]) -> Vec6:
         """Integration function.
 
         Parameters
@@ -25,22 +25,28 @@ class FCallable(Protocol):
 
         Returns
         -------
-        Array[float, (7,)]
-            [qp, t].
+        Array[float, (6,)]
+            [v (3,), a (3,)].
         """
         ...
 
 
 class AbstractIntegrator(eqx.Module):  # type: ignore[misc]
-    """Integrator Class."""
+    """Integrator Class.
 
-    F: FCallable
-    """The function to integrate."""
-    # TODO: should this be moved to be the first argument of the run method?
+    The integrators are classes that are used to integrate the equations of
+    motion.
+    They must not be stateful since they are used in a functional way.
+    """
+
+    # F: FCallable
+    # """The function to integrate."""
+    # # TODO: should this be moved to be the first argument of the run method?
 
     @abc.abstractmethod
     def run(
         self,
+        F: FCallable,
         qp0: Vec6,
         t0: FloatScalar,
         t1: FloatScalar,
@@ -54,6 +60,8 @@ class AbstractIntegrator(eqx.Module):  # type: ignore[misc]
 
         Parameters
         ----------
+        F : FCallable
+            The function to integrate.
         qp0 : Array[float, (6,)]
             Initial conditions ``[q, p]``.
         t0 : float

--- a/src/galax/integrate/_base.py
+++ b/src/galax/integrate/_base.py
@@ -39,10 +39,6 @@ class AbstractIntegrator(eqx.Module):  # type: ignore[misc]
     They must not be stateful since they are used in a functional way.
     """
 
-    # F: FCallable
-    # """The function to integrate."""
-    # # TODO: should this be moved to be the first argument of the run method?
-
     @abc.abstractmethod
     def run(
         self,

--- a/src/galax/integrate/_builtin.py
+++ b/src/galax/integrate/_builtin.py
@@ -21,6 +21,8 @@ from galax.integrate._base import AbstractIntegrator
 from galax.typing import FloatScalar, Vec6
 from galax.utils import ImmutableDict
 
+from ._base import FCallable
+
 
 class DiffraxIntegrator(AbstractIntegrator):
     """Thin wrapper around ``diffrax.diffeqsolve``."""
@@ -45,13 +47,14 @@ class DiffraxIntegrator(AbstractIntegrator):
 
     def run(
         self,
+        F: FCallable,
         qp0: Vec6,
         t0: FloatScalar,
         t1: FloatScalar,
         ts: Float[Array, "T"] | None,
     ) -> Float[Array, "R 7"]:
         solution = diffeqsolve(
-            terms=ODETerm(self.F),
+            terms=ODETerm(F),
             solver=self.Solver(**self.solver_kw),
             t0=t0,
             t1=t1,

--- a/src/galax/potential/_potential/base.py
+++ b/src/galax/potential/_potential/base.py
@@ -290,8 +290,8 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta):  # type: ignore[m
     # Integrating orbits
 
     @partial_jit()
-    def _integrator_F(self, t: FloatScalar, xv: Vec6, args: tuple[Any, ...]) -> Vec6:
-        return xp.hstack([xv[3:6], self.acceleration(xv[0:3], t)])  # v, a
+    def _integrator_F(self, t: FloatScalar, qp: Vec6, args: tuple[Any, ...]) -> Vec6:
+        return xp.hstack([qp[3:6], self.acceleration(qp[0:3], t)])  # v, a
 
     @partial_jit(static_argnames=("integrator"))
     def integrate_orbit(
@@ -307,5 +307,5 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta):  # type: ignore[m
 
         integrator_ = default_integrator if integrator is None else replace(integrator)
 
-        ws = integrator_.run(self._integrator_F, qp0, t0, t1, ts)  # type: ignore[arg-type]
+        ws = integrator_.run(self._integrator_F, qp0, t0, t1, ts)
         return Orbit(q=ws[:, :3], p=ws[:, 3:-1], t=ws[:, -1], potential=self)

--- a/src/galax/potential/_potential/base.py
+++ b/src/galax/potential/_potential/base.py
@@ -293,7 +293,7 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta):  # type: ignore[m
     def _integrator_F(self, t: FloatScalar, xv: Vec6, args: tuple[Any, ...]) -> Vec6:
         return xp.hstack([xv[3:6], self.acceleration(xv[0:3], t)])  # v, a
 
-    @partial_jit(static_argnames=("Integrator", "integrator_kw"))
+    @partial_jit(static_argnames=("integrator"))
     def integrate_orbit(
         self,
         qp0: Vec6,

--- a/src/galax/potential/_potential/base.py
+++ b/src/galax/potential/_potential/base.py
@@ -1,8 +1,7 @@
 __all__ = ["AbstractPotentialBase"]
 
 import abc
-from collections.abc import Mapping
-from dataclasses import fields
+from dataclasses import fields, replace
 from typing import TYPE_CHECKING, Any
 
 import astropy.units as u
@@ -32,6 +31,9 @@ from galax.utils.dataclasses import ModuleMeta
 
 if TYPE_CHECKING:
     from galax.dynamics._orbit import Orbit
+
+
+default_integrator = DiffraxIntegrator()
 
 
 class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta):  # type: ignore[misc]
@@ -289,23 +291,21 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta):  # type: ignore[m
 
     @partial_jit()
     def _integrator_F(self, t: FloatScalar, xv: Vec6, args: tuple[Any, ...]) -> Vec6:
-        return xp.hstack([xv[3:6], self.acceleration(xv[:3], t)])
+        return xp.hstack([xv[3:6], self.acceleration(xv[0:3], t)])  # v, a
 
     @partial_jit(static_argnames=("Integrator", "integrator_kw"))
     def integrate_orbit(
         self,
         qp0: Vec6,
-        t0: FloatScalar,
+        t0: FloatScalar,  # TODO: better time parsing
         t1: FloatScalar,
         ts: Float[Array, "time"] | None,
         *,
-        Integrator: type[AbstractIntegrator] | None = None,
-        integrator_kw: Mapping[str, Any] | None = None,
+        integrator: AbstractIntegrator | None = None,
     ) -> "Orbit":
         from galax.dynamics._orbit import Orbit
 
-        integrator_cls = Integrator if Integrator is not None else DiffraxIntegrator
+        integrator_ = default_integrator if integrator is None else replace(integrator)
 
-        integrator = integrator_cls(self._integrator_F, **(integrator_kw or {}))
-        ws = integrator.run(qp0, t0, t1, ts)
+        ws = integrator_.run(self._integrator_F, qp0, t0, t1, ts)  # type: ignore[arg-type]
         return Orbit(q=ws[:, :3], p=ws[:, 3:-1], t=ws[:, -1], potential=self)


### PR DESCRIPTION
Instead of passing the integrator class and kwargs, you now pass an integrator instance. The integrators are equinox Modules (ie dataclasses) so the state is now reset by calling `replace` for each integration.