### PR TITLE
Change Integrator.run to call

### DIFF
--- a/src/galax/dynamics/mockstream/_mockstream_generator.py
+++ b/src/galax/dynamics/mockstream/_mockstream_generator.py
@@ -11,7 +11,7 @@ import jax.numpy as xp
 from jax.lib.xla_bridge import get_backend
 
 from galax.dynamics._orbit import Orbit
-from galax.integrate._base import AbstractIntegrator
+from galax.integrate._base import Integrator
 from galax.integrate._builtin import DiffraxIntegrator
 from galax.potential._potential.base import AbstractPotentialBase
 from galax.typing import (
@@ -46,14 +46,12 @@ class MockStreamGenerator(eqx.Module):  # type: ignore[misc]
     """Potential in which the progenitor orbits and creates a stream."""
 
     _: KW_ONLY
-    progenitor_integrator: AbstractIntegrator = eqx.field(
+    progenitor_integrator: Integrator = eqx.field(
         default=DiffraxIntegrator(), static=True
     )
     """Integrator for the progenitor orbit."""
 
-    stream_integrator: AbstractIntegrator = eqx.field(
-        default=DiffraxIntegrator(), static=True
-    )
+    stream_integrator: Integrator = eqx.field(default=DiffraxIntegrator(), static=True)
     """Integrator for the stream."""
 
     # ==========================================================================

--- a/src/galax/integrate/_base.py
+++ b/src/galax/integrate/_base.py
@@ -1,4 +1,4 @@
-__all__ = ["AbstractIntegrator"]
+__all__ = ["Integrator", "AbstractIntegrator"]
 
 import abc
 from typing import Any, Protocol, runtime_checkable
@@ -7,6 +7,7 @@ import equinox as eqx
 from jaxtyping import Array, Float
 
 from galax.typing import FloatScalar, Vec6
+from galax.utils.dataclasses import _DataclassInstance
 
 
 @runtime_checkable
@@ -31,31 +32,73 @@ class FCallable(Protocol):
         ...
 
 
-class AbstractIntegrator(eqx.Module, strict=True):  # type: ignore[call-arg, misc]
-    """Integrator Class.
+@runtime_checkable
+class Integrator(_DataclassInstance, Protocol):
+    """:class:`typing.Protocol` for integrators.
 
     The integrators are classes that are used to integrate the equations of
     motion.
     They must not be stateful since they are used in a functional way.
     """
 
+    def __call__(
+        self, F: FCallable, qp0: Vec6, /, ts: Float[Array, "T"] | None
+    ) -> Float[Array, "R 7"]:
+        """Integrate.
+
+        Parameters
+        ----------
+        F : FCallable, positional-only
+            The function to integrate.
+            (t, qp, args) -> (v, a).
+        qp0 : Array[float, (6,)], positional-only
+            Initial conditions ``[q, p]``.
+
+        ts : Array[float, (T,)] | None
+            Times to return the computation.
+            It's necessary to at least provide the initial and final times.
+
+        Returns
+        -------
+        Array[float, (R, 7)]
+            The solution of the integrator [q, p, t], where q, p are the
+            generalized 3-coordinates.
+        """
+        ...
+
+
+class AbstractIntegrator(eqx.Module, strict=True):  # type: ignore[call-arg, misc]
+    """Abstract base class for integrators.
+
+    This class is the base for the hierarchy of concrete integrator classes
+    provided in this package. It is not necessary, but it is recommended, to
+    inherit from this class to implement an integrator. The Protocol
+    :class:`Integrator` must be implemented.
+
+    The integrators are classes that are used to integrate the equations of
+    motion.  They must not be stateful since they are used in a functional way.
+    """
+
     @abc.abstractmethod
-    def run(
+    def __call__(
         self,
         F: FCallable,
         qp0: Vec6,
+        /,
         ts: Float[Array, "T"],
     ) -> Float[Array, "T 7"]:
         """Run the integrator.
 
         Parameters
         ----------
-        F : FCallable
+        F : FCallable, positional-only
             The function to integrate.
-        qp0 : Array[float, (6,)]
+        qp0 : Array[float, (6,)], positional-only
             Initial conditions ``[q, p]``.
+
         ts : Array[float, (T,)] | None
             Times to return the computation.
+            It's necessary to at least provide the initial and final times.
 
         Returns
         -------

--- a/src/galax/integrate/_builtin.py
+++ b/src/galax/integrate/_builtin.py
@@ -47,7 +47,7 @@ class DiffraxIntegrator(AbstractIntegrator):
     )
 
     @vectorize_method(excluded=(0,), signature="(6),(T)->(T,7)")
-    def run(
+    def __call__(
         self, F: FCallable, qp0: Vec6, ts: Float[Array, "T"], /
     ) -> Float[Array, "T 7"]:
         solution = diffeqsolve(

--- a/src/galax/potential/_potential/base.py
+++ b/src/galax/potential/_potential/base.py
@@ -11,7 +11,7 @@ from astropy.constants import G as _G
 from jax import grad, hessian, jacfwd
 from jaxtyping import Array, Float
 
-from galax.integrate._base import AbstractIntegrator
+from galax.integrate._base import Integrator
 from galax.integrate._builtin import DiffraxIntegrator
 from galax.typing import (
     BatchableFloatOrIntScalarLike,
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from galax.dynamics._orbit import Orbit
 
 
-default_integrator = DiffraxIntegrator()
+default_integrator: Integrator = DiffraxIntegrator()
 
 
 class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # type: ignore[misc]
@@ -302,7 +302,7 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
         qp0: BatchVec6,
         t: Float[Array, "time"],
         *,
-        integrator: AbstractIntegrator | None = None,
+        integrator: Integrator | None = None,
     ) -> "Orbit":
         """Integrate an orbit in the potential.
 
@@ -386,5 +386,5 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
 
         integrator_ = default_integrator if integrator is None else replace(integrator)
 
-        ws = integrator_.run(self._integrator_F, qp0, t)
+        ws = integrator_(self._integrator_F, qp0, t)
         return Orbit(q=ws[..., :3], p=ws[..., 3:-1], t=t, potential=self)


### PR DESCRIPTION
`Integrator.run` -> `Integrator.__call__` means that we can build a Protocol outside of the `abstract-final` Integrator hierarchy that describes an arbitrary, e.g. user-defined, integrator. 

Currently this is still limited to `dataclasses.dataclass` objects (see `AbstractPotential.integrate_orbit`), but it would be good to relax that limitation so that in the future even a function object could be used as an integrator.