### PR TITLE
MockstreamGenerator returns mockstreams

### DIFF
--- a/src/galax/dynamics/mockstream/_core.py
+++ b/src/galax/dynamics/mockstream/_core.py
@@ -6,7 +6,7 @@ import equinox as eqx
 import jax.numpy as xp
 
 from galax.dynamics._core import AbstractPhaseSpacePositionBase
-from galax.typing import BatchFloatScalar, BatchVec7
+from galax.typing import BatchFloatScalar, BatchVec3, BatchVec7
 from galax.utils import partial_jit
 from galax.utils._shape import atleast_batched, batched_shape
 from galax.utils.dataclasses import converter_float_array
@@ -22,6 +22,12 @@ class MockStream(AbstractPhaseSpacePositionBase):
       trailing arm, 3-body ejecta, etc.
     - GR 4-vector stuff
     """
+
+    q: BatchVec3 = eqx.field(converter=converter_float_array)
+    """Positions (x, y, z)."""
+
+    p: BatchVec3 = eqx.field(converter=converter_float_array)
+    r"""Conjugate momenta (v_x, v_y, v_z)."""
 
     release_time: BatchFloatScalar = eqx.field(converter=converter_float_array)
     """Release time of the stream particles [Myr]."""


### PR DESCRIPTION
Not arrays.
This is much closer to `gala`, which returns a single Mockstream for the whole stream (versus the 2 returned here).
Worth doing incrementally. I have this notion of some `CompositeMockstream` class that can hold the various pieces of a stream. Gala currently merges the arms into 1 object.
With `CompositeMockstream` e.g. if we do a sim with an ex-situ then in-situ stream from the same progenitor it would contain 4 Mockstream components. 