### PR TITLE
ENH: normalize whitespace in doctests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from doctest import ELLIPSIS
+from doctest import ELLIPSIS, NORMALIZE_WHITESPACE
 
 from sybil import Sybil
 from sybil.parsers.rest import DocTestParser, PythonCodeBlockParser, SkipParser
 
 pytest_collect_file = Sybil(
     parsers=[
-        DocTestParser(optionflags=ELLIPSIS),
+        DocTestParser(optionflags=ELLIPSIS | NORMALIZE_WHITESPACE),
         PythonCodeBlockParser(),
         SkipParser(),
     ],


### PR DESCRIPTION
Passes the `doctest.NORMALIZE_WHITESPACE` int to the Sybil parser.