### PR TITLE
Fix return end time twice in orbit integration

### DIFF
--- a/src/galax/integrate/_builtin.py
+++ b/src/galax/integrate/_builtin.py
@@ -61,7 +61,7 @@ class DiffraxIntegrator(AbstractIntegrator):
             y0=qp0,
             dt0=None,
             args=(),
-            saveat=DiffraxSaveAt(t0=False, t1=True, ts=ts, dense=False),
+            saveat=DiffraxSaveAt(t0=False, t1=False, ts=ts, dense=False),
             stepsize_controller=self.stepsize_controller,
             **self.diffeq_kw,
         )

--- a/tests/unit/potential/test_base.py
+++ b/tests/unit/potential/test_base.py
@@ -130,4 +130,5 @@ class TestAbstractPotentialBase:
 
         orbit = pot.integrate_orbit(xv, t0=min(ts), t1=max(ts), ts=ts)
         assert isinstance(orbit, gd.Orbit)
-        assert orbit.shape == (101, 7)
+        assert orbit.shape == (len(ts), 7)
+        assert xp.array_equal(orbit.t, ts)


### PR DESCRIPTION
A mistake in the `DiffraxSaveAt` argument.