### PR TITLE
Orbit integration with a PSP

### DIFF
--- a/src/galax/coordinates/_warnings.py
+++ b/src/galax/coordinates/_warnings.py
@@ -1,9 +1,0 @@
-"""galax: Galactic Dynamix in Jax."""
-
-__all__: list[str] = []
-
-
-# TODO: make public
-# TODO: customize the automatic message
-class IgnoredTimeWarning(UserWarning):
-    """Warning for ignored time."""

--- a/src/galax/coordinates/_warnings.py
+++ b/src/galax/coordinates/_warnings.py
@@ -1,0 +1,9 @@
+"""galax: Galactic Dynamix in Jax."""
+
+__all__: list[str] = []
+
+
+# TODO: make public
+# TODO: customize the automatic message
+class IgnoredTimeWarning(UserWarning):
+    """Warning for ignored time."""

--- a/src/galax/dynamics/_dynamics/orbit.py
+++ b/src/galax/dynamics/_dynamics/orbit.py
@@ -331,7 +331,7 @@ def compute_orbit(
         sure to set the initial time to the desired value. See the `t` argument
         for more details.
 
-        - :class:`~galax.dynamics.PhaseSpacePosition`[float, (*batch,)]:
+        - :class:`~galax.dynamics.PhaseSpaceTimePosition`[float, (*batch,)]:
             The full phase-space position, including position, velocity, and
             time. `w0` will be integrated from ``w0.t`` to ``t[0]``, then
             integrated from ``t[0]`` to ``t[1]``, returning the orbit calculated
@@ -369,7 +369,7 @@ def compute_orbit(
     See Also
     --------
     integrate_orbit
-        A lower-level function that integrates an orbit
+        A lower-level function that integrates an orbit.
 
     Examples
     --------
@@ -414,12 +414,31 @@ def compute_orbit(
 
     >>> w0 = gc.PhaseSpaceTimePosition(q=[[10., 0., 0.], [10., 0., 0.]],
     ...                                p=[[0., 0.1, 0.], [0., 0.2, 0.]],
-                                       t=[-100, -150])
+    ...                                t=[-100, -150])
     >>> orbit = compute_orbit(potential, w0, ts)
     >>> orbit
     Orbit(
         q=f64[2,10,3], p=f64[2,10,3], t=f64[10], potential=KeplerPotential(...)
     )
+
+    :class:`~galax.dynamics.PhaseSpaceTimePosition` has a ``t`` argument for the
+    time at which the position is given. As noted earlier, this can be used to
+    integrate from a different time than the initial time of the position:
+
+    >>> w0 = gc.PhaseSpaceTimePosition(q=[10., 0., 0.], p=[0., 0.1, 0.], t=0)
+    >>> ts = xp.linspace(300, 1000, 8)  # (0.3 to 1 Gyr, 10 steps)
+    >>> orbit = compute_orbit(potential, w0, ts)
+    >>> orbit.q[0]  # doctest: +SKIP
+    Array([ 9.779, -0.3102,  0.        ], dtype=float64)
+
+    Note that IS NOT the same as ``w0``. ``w0`` is integrated from ``t=0`` to
+    ``t=300`` and then from ``t=300`` to ``t=1000``.
+
+    .. note::
+
+        If you want to reproduce :mod:`gala`'s behavior, you can use
+        :class:`~galax.dynamics.PhaseSpacePosition` which does not have a time
+        and will assume ``w0`` is defined at `t`[0].
     """
     # Determine the integrator
     # Reboot the integrator to avoid stateful issues

--- a/src/galax/dynamics/_dynamics/orbit.py
+++ b/src/galax/dynamics/_dynamics/orbit.py
@@ -1,6 +1,6 @@
 """galax: Galactic Dynamix in Jax."""
 
-__all__ = ["Orbit", "integrate_orbit"]
+__all__ = ["Orbit", "integrate_orbit", "compute_orbit"]
 
 import warnings
 from dataclasses import replace
@@ -9,7 +9,9 @@ from typing import TYPE_CHECKING, Any, final, overload
 
 import equinox as eqx
 import jax
+import jax.experimental.array_api as xp
 import jax.numpy as jnp
+import jaxtyping as jt
 from astropy.units import Quantity
 
 from galax.coordinates import (
@@ -20,7 +22,15 @@ from galax.coordinates import (
 from galax.coordinates._utils import Shaped, getitem_vec1time_index
 from galax.coordinates._warnings import IgnoredTimeWarning
 from galax.potential._potential.base import AbstractPotentialBase
-from galax.typing import BatchFloatScalar, BatchVec6, BroadBatchVecTime3, Vec1, VecTime
+from galax.typing import (
+    BatchFloatScalar,
+    BatchVec6,
+    BroadBatchFloatScalar,
+    BroadBatchVecTime3,
+    FloatScalar,
+    Vec1,
+    VecTime,
+)
 from galax.utils._shape import batched_shape
 from galax.utils.dataclasses import converter_float_array
 
@@ -210,6 +220,14 @@ def integrate_orbit(
         If `w0` is a :class:`~galax.coordinates.PhaseSpaceTimePosition`, a
         warning is raised to indicate that the time is ignored.
 
+    See Also
+    --------
+    compute_orbit
+        A higher-level function that computes an orbit. The main difference is
+        that `compute_orbit` allows for the phase-space position to also include
+        a time, which allows for the phase-space position to be defined at a
+        different time than the initial time of the integration.
+
     Examples
     --------
     We start by integrating a single orbit in the potential of a point mass.  A
@@ -228,10 +246,9 @@ def integrate_orbit(
     We can then integrate an initial phase-space position in this potential to
     get an orbit:
 
-    >>> w0 = gc.PhaseSpacePosition(xp.asarray([10., 0., 0.]),  # (x, v) [galactic]
-    ...                            xp.asarray([0., 0.1, 0.]))
+    >>> w0 = gc.PhaseSpacePosition(q=[10., 0., 0.], p=[0., 0.1, 0.])
     >>> ts = xp.linspace(0., 1000, 4)  # (1 Gyr, 4 steps)
-    >>> orbit = potential.integrate_orbit(w0, ts)
+    >>> orbit = integrate_orbit(potential, w0, ts)
     >>> orbit
     Orbit(
         q=f64[4,3], p=f64[4,3], t=f64[4], potential=KeplerPotential(...)
@@ -241,7 +258,7 @@ def integrate_orbit(
     return times. Changing the number of times is easy:
 
     >>> ts = xp.linspace(0., 1000, 10)  # (1 Gyr, 10 steps)
-    >>> orbit = potential.integrate_orbit(w0, ts)
+    >>> orbit = integrate_orbit(potential, w0, ts)
     >>> orbit
     Orbit(
         q=f64[10,3], p=f64[10,3], t=f64[10], potential=KeplerPotential(...)
@@ -249,9 +266,9 @@ def integrate_orbit(
 
     We can also integrate a batch of orbits at once:
 
-    >>> w0 = gc.PhaseSpacePosition(xp.asarray([[10., 0., 0.], [10., 0., 0.]]),
-    ...                            xp.asarray([[0., 0.1, 0.], [0., 0.2, 0.]]))
-    >>> orbit = potential.integrate_orbit(w0, ts)
+    >>> w0 = gc.PhaseSpacePosition(q=[[10., 0., 0.], [10., 0., 0.]],
+    ...                            p=[[0., 0.1, 0.], [0., 0.2, 0.]])
+    >>> orbit = integrate_orbit(potential, w0, ts)
     >>> orbit
     Orbit(
         q=f64[2,10,3], p=f64[2,10,3], t=f64[10], potential=KeplerPotential(...)
@@ -282,3 +299,158 @@ def integrate_orbit(
 
     # Construct the orbit object
     return Orbit(q=ws[..., 0:3], p=ws[..., 3:6], t=t, potential=pot)
+
+
+_select_w0 = jnp.vectorize(jax.lax.select, signature="(),(6),(6)->(6)")
+
+
+def _psp2t(
+    pspt: BroadBatchFloatScalar, t0: FloatScalar
+) -> jt.Shaped[FloatScalar, "*#batch 2"]:
+    """Start at PSP time end at t0 for integration from t0."""
+    return xp.stack((pspt, xp.full_like(pspt, t0)), axis=-1)
+
+
+@partial(jax.jit, static_argnames=("integrator",))
+def compute_orbit(
+    pot: AbstractPotentialBase,
+    w0: PhaseSpacePosition | PhaseSpaceTimePosition | BatchVec6,
+    t: VecTime | Quantity,
+    *,
+    integrator: Integrator | None = None,
+) -> Orbit:
+    """Compute an orbit in a potential.
+
+    Parameters
+    ----------
+    pot : :class:`~galax.potential.AbstractPotentialBase`
+        The potential in which to integrate the orbit.
+    w0 : PhaseSpaceTimePosition | PhaseSpacePosition | Array[float, (*batch, 6)]
+        The phase-space position (includes velocity and time) from which to
+        integrate. Integration includes the time of the initial position, so be
+        sure to set the initial time to the desired value. See the `t` argument
+        for more details.
+
+        - :class:`~galax.dynamics.PhaseSpacePosition`[float, (*batch,)]:
+            The full phase-space position, including position, velocity, and
+            time. `w0` will be integrated from ``w0.t`` to ``t[0]``, then
+            integrated from ``t[0]`` to ``t[1]``, returning the orbit calculated
+            at `t`.
+        - :class:`~galax.coordinates.PhaseSpacePosition`[float, (*batch,)]:
+            The phase-space position. `w0` will be integrated from ``t[0]`` to
+            ``t[1]`` assuming that `w0` is defined at ``t[0]``, returning the
+            orbit calculated at `t`.
+        - Array[float, (*batch, 6)]:
+            A :class:`~galax.coordinates.PhaseSpacePosition` will be
+            constructed, interpreting the array as the  'q', 'p' (each
+            Array[float, (*batch, 3)]) arguments, with 't' set to ``t[0]``.
+    t: Array[float, (time,)]
+        Array of times at which to compute the orbit. The first element should
+        be the initial time and the last element should be the final time and
+        the array should be monotonically moving from the first to final time.
+        See the Examples section for options when constructing this argument.
+
+        .. note::
+
+            This is NOT the timesteps to use for integration, which are
+            controlled by the `integrator`; the default integrator
+            :class:`~galax.integrator.DiffraxIntegrator` uses adaptive
+            timesteps.
+
+    integrator : :class:`~galax.integrate.Integrator`, keyword-only
+        Integrator to use.  If `None`, the default integrator
+        :class:`~galax.integrator.DiffraxIntegrator` is used.
+
+    Returns
+    -------
+    orbit : :class:`~galax.dynamics.Orbit`
+        The integrated orbit evaluated at the given times.
+
+    See Also
+    --------
+    integrate_orbit
+        A lower-level function that integrates an orbit
+
+    Examples
+    --------
+    We start by integrating a single orbit in the potential of a point mass.  A
+    few standard imports are needed:
+
+    >>> import astropy.units as u
+    >>> import jax.experimental.array_api as xp  # preferred over `jax.numpy`
+    >>> import galax.coordinates as gc
+    >>> import galax.potential as gp
+    >>> from galax.units import galactic
+
+    We can then create the point-mass' potential, with galactic units:
+
+    >>> potential = gp.KeplerPotential(m=1e12 * u.Msun, units=galactic)
+
+    We can then integrate an initial phase-space position in this potential to
+    get an orbit:
+
+    >>> w0 = gc.PhaseSpaceTimePosition(q=[10., 0., 0.], p=[0., 0.1, 0.], t=-100)
+    >>> ts = xp.linspace(0., 1000, 4)  # (1 Gyr, 4 steps)
+    >>> orbit = compute_orbit(potential, w0, ts)
+    >>> orbit
+    Orbit(
+        q=f64[4,3], p=f64[4,3], t=f64[4], potential=KeplerPotential(...)
+    )
+
+    Note how there are 4 points in the orbit, corresponding to the 4 requested
+    return times. These are the times at which the orbit is evaluated, not the
+    times at which the orbit is integrated. The phase-space position `w0` is
+    defined at `t=-100`, but the orbit is integrated from `t=0` to `t=1000`.
+    Changing the number of times is easy:
+
+    >>> ts = xp.linspace(0., 1000, 10)  # (1 Gyr, 10 steps)
+    >>> orbit = compute_orbit(potential, w0, ts)
+    >>> orbit
+    Orbit(
+        q=f64[10,3], p=f64[10,3], t=f64[10], potential=KeplerPotential(...)
+    )
+
+    We can also integrate a batch of orbits at once:
+
+    >>> w0 = gc.PhaseSpaceTimePosition(q=[[10., 0., 0.], [10., 0., 0.]],
+    ...                                p=[[0., 0.1, 0.], [0., 0.2, 0.]],
+                                       t=[-100, -150])
+    >>> orbit = compute_orbit(potential, w0, ts)
+    >>> orbit
+    Orbit(
+        q=f64[2,10,3], p=f64[2,10,3], t=f64[10], potential=KeplerPotential(...)
+    )
+    """
+    # Determine the integrator
+    # Reboot the integrator to avoid stateful issues
+    integrator = replace(integrator) if integrator is not None else _default_integrator
+
+    # Parse w0
+    if isinstance(w0, PhaseSpaceTimePosition):
+        pspt0 = w0
+    elif isinstance(w0, PhaseSpacePosition):
+        pspt0 = PhaseSpaceTimePosition(q=w0.t, p=w0.p, t=t[0])
+    else:
+        pspt0 = PhaseSpaceTimePosition(q=w0[..., 0:3], p=w0[..., 3:6], t=t[0])
+
+    # Need to integrate `w0.t` to `t[0]`.
+    # The integral int_a_a is not well defined (can be inf) so we need to
+    # handle this case separately.
+    # TODO: it may be better to handle this in the integrator itself (by
+    # passing either `wt` instead of `w` or the initial time as a separate
+    # argument).
+    # fmt: off
+    w0_ = pspt0.w()
+    qp0 = _select_w0(
+        pspt0.t == t[0],  # don't integrate if already at the desired time
+        w0_,  #               [batch, final t, positions (w/out time)] ⬇
+        integrator(pot._integrator_F, w0_, _psp2t(pspt0.t, t[0]))[..., -1, :-1],  # noqa: SLF001
+    )
+    # fmt: on
+
+    # Integrate the orbit
+    w = integrator(pot._integrator_F, qp0, t)  # noqa: SLF001
+    # TODO: ꜛ reduce repeat dimensions of `time`.
+
+    # Construct the orbit object
+    return Orbit(q=w[..., 0:3], p=w[..., 3:6], t=t, potential=pot)

--- a/src/galax/potential/_potential/base.py
+++ b/src/galax/potential/_potential/base.py
@@ -15,7 +15,7 @@ from astropy.coordinates import BaseRepresentation
 from astropy.units import Quantity
 from jax import grad, hessian, jacfwd
 
-from galax.coordinates import PhaseSpacePosition
+from galax.coordinates import PhaseSpacePosition, PhaseSpaceTimePosition
 from galax.potential._potential.param.attr import ParametersAttribute
 from galax.potential._potential.param.utils import all_parameters
 from galax.typing import (
@@ -329,7 +329,7 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
     @partial(jax.jit, static_argnames=("integrator",))
     def integrate_orbit(
         self,
-        w0: PhaseSpacePosition | BatchVec6,
+        w0: PhaseSpacePosition | PhaseSpaceTimePosition | BatchVec6,
         t: VecTime | Quantity,
         *,
         integrator: "Integrator | None" = None,
@@ -341,7 +341,7 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
 
         Parameters
         ----------
-        w0 : PhaseSpacePosition | Array[float, (*batch, 6)]
+        w0 : PhaseSpacePosition | PhaseSpaceTimePosition | Array[float, (*batch, 6)]
             The phase-space position (includes velocity) from which to
             integrate.
 
@@ -349,6 +349,11 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
                 The phase-space position. `w0` will be integrated from ``t[0]``
                 to ``t[1]`` assuming that `w0` is defined at ``t[0]``, returning
                 the orbit calculated at `t`.
+            - :class:`~galax.coordinates.PhaseSpaceTimePosition`:
+                The phase-space position, including a time. The time will be
+                ignored and the orbit will be integrated from ``t[0]`` to
+                ``t[1]``, returning the orbit calculated at `t`. Note: this will
+                raise a warning.
             - Array[float, (*batch, 6)]:
                 A :class:`~galax.coordinates.PhaseSpacePosition` will be
                 constructed, interpreting the array as the  'q', 'p' (each

--- a/src/galax/potential/_potential/base.py
+++ b/src/galax/potential/_potential/base.py
@@ -337,8 +337,8 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
         """Integrate an orbit in the potential, from `w0` at time ``t[0]``.
 
         See :func:`~galax.dynamics.integrate_orbit` for more details and
-        examples. If you want to use a time-aware orbit calculator, use
-        :meth:`~galax.potential.AbstractPotentialBase.compute_orbit`.
+        examples. If you want to use a time-aware orbit calculator see
+        :meth:`~galax.potential.AbstractPotentialBase.evaluate_orbit`.
 
         Parameters
         ----------
@@ -385,12 +385,12 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
 
         See Also
         --------
-        :meth:`~galax.potential.AbstractPotentialBase.compute_orbit`
+        :meth:`~galax.potential.AbstractPotentialBase.evaluate_orbit`
             A higher-level function that computes the orbit using time
             information from `w0`.
-        galax.dynamics.compute_orbit
+        galax.dynamics.evaluate_orbit
             The function which
-            :meth:`~galax.potential.AbstractPotentialBase.compute_orbit` calls.
+            :meth:`~galax.potential.AbstractPotentialBase.evaluate_orbit` calls.
         galax.dynamics.integrate_orbit
             The function for which this method is a wrapper. It has more details
             and examples.
@@ -399,7 +399,7 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
 
         return cast("Orbit", integrate_orbit(self, w0, t, integrator=integrator))
 
-    def compute_orbit(
+    def evaluate_orbit(
         self,
         w0: PhaseSpacePosition | PhaseSpaceTimePosition | BatchVec6,
         t: VecTime | Quantity,
@@ -408,34 +408,46 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
     ) -> "Orbit":
         """Compute an orbit in a potential.
 
+        This method is similar to
+        :meth:`~galax.potential.AbstractPotentialBase.integrate_orbit`, but can
+        behave differently when ``w0`` is a
+        :class:`~galax.coordinates.PhaseSpacePositionTime`.
+        :class:`~galax.coordinates.PhaseSpacePositionTime` includes a time in
+        addition to the position (and velocity) information, enabling the orbit
+        to be evaluated over a time range that is different from the initial
+        time of the position. See the Examples section of
+        :func:`~galax.dynamics.evaluate_orbit` for more details.
+
         Parameters
         ----------
         pot : :class:`~galax.potential.AbstractPotentialBase`
-            The potential in which to integrate the orbit.
-        w0 : PhaseSpaceTimePosition | PhaseSpacePosition | Array[float, (*batch, 6)]
+            The potential in which to compute the orbit.
+        w0 : PhaseSpaceTimePosition | PhaseSpacePosition | Array[float, (*batch,
+        6)]
             The phase-space position (includes velocity and time) from which to
-            integrate. Integration includes the time of the initial position, so be
-            sure to set the initial time to the desired value. See the `t` argument
-            for more details.
+            integrate. Integration includes the time of the initial position, so
+            be sure to set the initial time to the desired value. See the `t`
+            argument for more details.
 
             - :class:`~galax.dynamics.PhaseSpacePosition`[float, (*batch,)]:
                 The full phase-space position, including position, velocity, and
                 time. `w0` will be integrated from ``w0.t`` to ``t[0]``, then
-                integrated from ``t[0]`` to ``t[1]``, returning the orbit calculated
-                at `t`.
+                integrated from ``t[0]`` to ``t[1]``, returning the orbit
+                calculated at `t`.
             - :class:`~galax.coordinates.PhaseSpacePosition`[float, (*batch,)]:
-                The phase-space position. `w0` will be integrated from ``t[0]`` to
-                ``t[1]`` assuming that `w0` is defined at ``t[0]``, returning the
-                orbit calculated at `t`.
+                The phase-space position. `w0` will be integrated from ``t[0]``
+                to ``t[1]`` assuming that `w0` is defined at ``t[0]``, returning
+                the orbit calculated at `t`.
             - Array[float, (*batch, 6)]:
                 A :class:`~galax.coordinates.PhaseSpacePosition` will be
                 constructed, interpreting the array as the  'q', 'p' (each
                 Array[float, (*batch, 3)]) arguments, with 't' set to ``t[0]``.
         t: Array[float, (time,)]
-            Array of times at which to compute the orbit. The first element should
-            be the initial time and the last element should be the final time and
-            the array should be monotonically moving from the first to final time.
-            See the Examples section for options when constructing this argument.
+            Array of times at which to compute the orbit. The first element
+            should be the initial time and the last element should be the final
+            time and the array should be monotonically moving from the first to
+            final time.  See the Examples section for options when constructing
+            this argument.
 
             .. note::
 
@@ -455,10 +467,10 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
 
         See Also
         --------
-        galax.dynamics.compute_orbit
+        galax.dynamics.evaluate_orbit
             The function for which this method is a wrapper. It has more details
             and examples.
         """
-        from galax.dynamics._dynamics.orbit import compute_orbit
+        from galax.dynamics._dynamics.orbit import evaluate_orbit
 
-        return cast("Orbit", compute_orbit(self, w0, t, integrator=integrator))
+        return cast("Orbit", evaluate_orbit(self, w0, t, integrator=integrator))


### PR DESCRIPTION
PhaseSpacePosition has a time attribute. `compute_orbit` now understands that the orbit should be integrated from that time.
This is a major conceptual difference from `gala`. In `galax` the time argument in the orbit integration isn't for taking time-steps in the integrator but for the return times of the orbit (the integrator is free to do it's own thing or be set by integrator-specific arguments). Since PSP has a time, we are always integrating from the PSP, returning the Orbit at the return times.

E.g. evaluating orbits for 2 time arrays:

``t1 = np.linspace(0, 10, 100) * u.Myr``
``t2 = np.linspace(-2, 10, 100) * u.Myr``

Here's `gala` `integrate_orbit`:

![a76471a6-9f11-4d29-ab38-f3ec6f3a753a](https://github.com/GalacticDynamics/galax/assets/8949649/07d98729-a891-4b58-820e-d8b2d4e98558)

The PSP is taken to be at ``t1[0]`` or ``t2[0]`` so both orbits start from the same position, regardless of the difference in time.


Here's `galax` (same spatial coordinate + time=0) `compute_orbit`:

![a6015471-b822-4dc6-ae45-b9e591a29e1b](https://github.com/GalacticDynamics/galax/assets/8949649/b63498a1-1a41-4cc5-96de-9f570934dec9)

The PSP I made has `PSP.t=0` so the orbits start from that position+time and are forward and/or backward integrated.

This even enables `PSP.t` to not be in the return time range `t[0]` to `t[-1]`

![3f7a203f-496a-4512-804d-79cbef4f2eab](https://github.com/GalacticDynamics/galax/assets/8949649/cd6eed46-8937-415f-9bea-5f77083afc44)

We can see that `galax` always integrates with reference to the PSP.

