### PR TITLE
MockStream understands PSP

### DIFF
--- a/src/galax/dynamics/_dynamics/mockstream/utils.py
+++ b/src/galax/dynamics/_dynamics/mockstream/utils.py
@@ -1,0 +1,46 @@
+"""galax: Galactic Dynamix in Jax."""
+
+__all__: list[str] = []
+
+from functools import partial
+from typing import Any, Protocol, TypeVar, cast, runtime_checkable
+
+import jax
+import jax.experimental.array_api as xp
+from jaxtyping import Array, Bool, Shaped
+
+T = TypeVar("T")
+T_co = TypeVar("T_co", covariant=True)
+
+
+@partial(jax.jit, static_argnames="axis")
+def interleave_concat(
+    a: Shaped[Array, "..."], b: Shaped[Array, "..."], /, axis: int
+) -> Shaped[Array, "..."]:
+    a_shp = a.shape
+    return xp.stack((a, b), axis=axis + 1).reshape(
+        *a_shp[:axis], 2 * a_shp[axis], *a_shp[axis + 1 :]
+    )
+
+
+# -------------------------------------------------------------------
+
+
+@runtime_checkable
+class SupportsGetItem(Protocol[T_co]):
+    """Protocol for types that support the `__getitem__` method."""
+
+    def __getitem__(self, key: Any) -> T_co:
+        ...
+
+
+def _identity(x: T) -> T:
+    return x
+
+
+def _reverse(x: SupportsGetItem[T]) -> T:
+    return x[::-1]
+
+
+def cond_reverse(pred: Bool[Array, ""], x: T) -> T:
+    return cast(T, jax.lax.cond(pred, _reverse, _identity, x))

--- a/src/galax/dynamics/_dynamics/orbit.py
+++ b/src/galax/dynamics/_dynamics/orbit.py
@@ -175,7 +175,7 @@ def integrate_orbit(
     ----------
     pot : :class:`~galax.potential.AbstractPotentialBase`
         The potential in which to integrate the orbit.
-    w0 : PhaseSpacePosition | PhaseSpaceTimePosition | Array[float, (*batch, 6)]
+    w0 : PhaseSpacePosition | Array[float, (*batch,6)]
         The phase-space position (includes velocity) from which to integrate.
 
         - :class:`~galax.coordinates.PhaseSpacePosition`[float, (*batch,)]:
@@ -457,7 +457,7 @@ def evaluate_orbit(
     if isinstance(w0, PhaseSpaceTimePosition):
         pspt0 = w0
     elif isinstance(w0, PhaseSpacePosition):
-        pspt0 = PhaseSpaceTimePosition(q=w0.t, p=w0.p, t=t[0])
+        pspt0 = PhaseSpaceTimePosition(q=w0.q, p=w0.p, t=t[0])
     else:
         pspt0 = PhaseSpaceTimePosition(q=w0[..., 0:3], p=w0[..., 3:6], t=t[0])
 

--- a/src/galax/potential/_potential/base.py
+++ b/src/galax/potential/_potential/base.py
@@ -422,8 +422,7 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
         ----------
         pot : :class:`~galax.potential.AbstractPotentialBase`
             The potential in which to compute the orbit.
-        w0 : PhaseSpaceTimePosition | PhaseSpacePosition | Array[float, (*batch,
-        6)]
+        w0 : PhaseSpaceTimePosition
             The phase-space position (includes velocity and time) from which to
             integrate. Integration includes the time of the initial position, so
             be sure to set the initial time to the desired value. See the `t`


### PR DESCRIPTION
This PR enables MockStreamGenerator to accept a PSP. Using a conditional time reversal and `evaluate_orbit` this also enables the auto back-integration of the progenitor, like in `gala`.

![CleanShot 2024-02-07 at 12 31 28@2x](https://github.com/GalacticDynamics/galax/assets/8949649/95f01d09-8b5e-418f-af75-3d8d41740668)
