### PR TITLE
Reference Frame Transformation Operators

### DIFF
--- a/src/galax/coordinates/operators/base.py
+++ b/src/galax/coordinates/operators/base.py
@@ -134,7 +134,7 @@ class AbstractOperator(eqx.Module):  # type: ignore[misc]
         >>> t = Quantity(0.0, "Gyr")
 
         >>> op(pos, t)
-        (Cartesian3DVector( ... ),
+        (Quantity['length'](Array([2., 4., 6.], dtype=float64), unit='kpc'),
          Quantity['time'](Array(0., dtype=float64, ...), unit='Gyr'))
         """
         cart, t = self(Cartesian3DVector.constructor(q), t)
@@ -197,9 +197,7 @@ class AbstractOperator(eqx.Module):  # type: ignore[misc]
 
         >>> newpos = op(pos)
         >>> newpos
-        FourVector( t=Quantity[PhysicalType('time')](...), q=Cartesian3DVector( ... ) )
-        >>> newpos.q.x
-        Quantity['length'](Array(2., dtype=float64), unit='kpc')
+        Quantity['length'](Array([0., 2., 4., 6.], dtype=float64), unit='kpc')
         """
         return convert(self(FourVector.constructor(q)), Quantity)
 

--- a/src/galax/coordinates/operators/galilean.py
+++ b/src/galax/coordinates/operators/galilean.py
@@ -107,6 +107,25 @@ class GalileanSpatialTranslationOperator(AbstractGalileanOperator):
     >>> op(q, t)
     (Cartesian3DVector( ... ), Quantity['time'](Array(0, dtype=int64, ...), unit='Gyr'))
 
+    Translation operators can be used to translate potentials:
+
+    >>> import galax.potential as gp
+    >>> pot = gp.KeplerPotential(m=Quantity(1e12, "Msun"), units="galactic")
+    >>> translated_pot = gp.PotentialFrame(pot, shift_op)
+    >>> translated_pot
+    PotentialFrame(
+      potential=KeplerPotential( ... ),
+      operator=OperatorSequence( ... GalileanSpatialTranslationOperator( ... ), ) )
+    )
+
+    # >>> q = Quantity([0, 0, 0], "kpc")
+    # >>> translated_pot(q, t=0)
+    # Array(-1.20227527, dtype=float64)
+
+    # Let's check that the potential is indeed translated:
+
+    # >>> pot(q - shift, t=0)
+    # Array(-1.20227527, dtype=float64)
     """
 
     translation: Abstract3DVector = eqx.field(

--- a/src/galax/coordinates/operators/galilean.py
+++ b/src/galax/coordinates/operators/galilean.py
@@ -111,21 +111,12 @@ class GalileanSpatialTranslationOperator(AbstractGalileanOperator):
 
     >>> import galax.potential as gp
     >>> pot = gp.KeplerPotential(m=Quantity(1e12, "Msun"), units="galactic")
-    >>> translated_pot = gp.PotentialFrame(pot, shift_op)
+    >>> translated_pot = gp.PotentialFrame(pot, op)
     >>> translated_pot
     PotentialFrame(
       potential=KeplerPotential( ... ),
       operator=OperatorSequence( ... GalileanSpatialTranslationOperator( ... ), ) )
     )
-
-    # >>> q = Quantity([0, 0, 0], "kpc")
-    # >>> translated_pot(q, t=0)
-    # Array(-1.20227527, dtype=float64)
-
-    # Let's check that the potential is indeed translated:
-
-    # >>> pot(q - shift, t=0)
-    # Array(-1.20227527, dtype=float64)
     """
 
     translation: Abstract3DVector = eqx.field(

--- a/src/galax/dynamics/_dynamics/mockstream/_moving.py
+++ b/src/galax/dynamics/_dynamics/mockstream/_moving.py
@@ -1,0 +1,40 @@
+"""Moving object. TEMPORARY CLASS.
+
+This class adds time-dependent translations to a potential.
+It is NOT careful about the implied changes to velocity, etc.
+"""
+
+__all__: list[str] = []
+
+
+from collections.abc import Callable
+from typing import Literal, final
+
+import equinox as eqx
+
+from galax.coordinates.operators import AbstractOperator
+from galax.typing import FloatScalar, RealScalar, Vec3
+
+
+@final
+class TimeDependentSpatialTranslationOperator(AbstractOperator):
+    r"""Operator for time-dependent translation."""
+
+    translation: Callable[[FloatScalar], Vec3] = eqx.field()
+    """The spatial translation."""
+
+    def __call__(self, q: Vec3, t: RealScalar) -> tuple[Vec3, RealScalar]:
+        """Do."""
+        return (q + self.translation(t), t)
+
+    @property
+    def is_inertial(self) -> Literal[False]:
+        """Galilean translation is an inertial frame-preserving transformation."""
+        return False
+
+    @property
+    def inverse(self) -> "TimeDependentSpatialTranslationOperator":
+        """The inverse of the operator."""
+        return TimeDependentSpatialTranslationOperator(
+            translation=lambda t: -self.translation(t)
+        )

--- a/src/galax/potential/__init__.pyi
+++ b/src/galax/potential/__init__.pyi
@@ -29,6 +29,8 @@ __all__ = [
     "TriaxialHernquistPotential",
     # special
     "MilkyWayPotential",
+    # frame
+    "PotentialFrame",
 ]
 
 from ._potential import io
@@ -45,6 +47,7 @@ from ._potential.builtin import (
 )
 from ._potential.composite import AbstractCompositePotential, CompositePotential
 from ._potential.core import AbstractPotential
+from ._potential.frame import PotentialFrame
 from ._potential.param import (
     AbstractParameter,
     ConstantParameter,

--- a/src/galax/potential/_potential/base.py
+++ b/src/galax/potential/_potential/base.py
@@ -126,6 +126,7 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
     # ---------------------------------------
     # Potential energy
 
+    # TODO: inputs w/ units
     # @partial(jax.jit)
     # @vectorize_method(signature="(3),()->()")
     @abc.abstractmethod

--- a/src/galax/potential/_potential/builtin.py
+++ b/src/galax/potential/_potential/builtin.py
@@ -55,6 +55,7 @@ class BarPotential(AbstractPotential):
     _: KW_ONLY
     units: UnitSystem = eqx.field(converter=unitsystem, static=True)
 
+    # TODO: inputs w/ units
     @partial(jax.jit)
     @vectorize_method(signature="(3),()->()")
     def _potential_energy(self, q: Vec3, /, t: RealScalarLike) -> FloatScalar:
@@ -102,7 +103,7 @@ class HernquistPotential(AbstractPotential):
     units: UnitSystem = eqx.field(converter=unitsystem, static=True)
 
     @partial(jax.jit)
-    def _potential_energy(
+    def _potential_energy(  # TODO: inputs w/ units
         self, q: BatchVec3, /, t: BatchableRealScalarLike
     ) -> BatchFloatScalar:
         r = xp.linalg.vector_norm(q, axis=-1)
@@ -122,7 +123,7 @@ class IsochronePotential(AbstractPotential):
     units: UnitSystem = eqx.field(converter=unitsystem, static=True)
 
     @partial(jax.jit)
-    def _potential_energy(
+    def _potential_energy(  # TODO: inputs w/ units
         self, q: BatchVec3, /, t: BatchableRealScalarLike
     ) -> BatchFloatScalar:
         r = xp.linalg.vector_norm(q, axis=-1)
@@ -146,7 +147,7 @@ class KeplerPotential(AbstractPotential):
     units: UnitSystem = eqx.field(converter=unitsystem, static=True)
 
     @partial(jax.jit)
-    def _potential_energy(
+    def _potential_energy(  # TODO: inputs w/ units
         self, q: BatchVec3, /, t: BatchableRealScalarLike
     ) -> BatchFloatScalar:
         r = xp.linalg.vector_norm(q, axis=-1)
@@ -166,6 +167,7 @@ class MiyamotoNagaiPotential(AbstractPotential):
     _: KW_ONLY
     units: UnitSystem = eqx.field(converter=unitsystem, static=True)
 
+    # TODO: inputs w/ units
     @partial(jax.jit)
     @vectorize_method(signature="(3),()->()")
     def _potential_energy(self, q: Vec3, /, t: RealScalarLike) -> FloatScalar:
@@ -191,7 +193,7 @@ class NFWPotential(AbstractPotential):
     units: UnitSystem = eqx.field(converter=unitsystem, static=True)
 
     @partial(jax.jit)
-    def _potential_energy(
+    def _potential_energy(  # TODO: inputs w/ units
         self, q: BatchVec3, /, t: BatchableRealScalarLike
     ) -> BatchFloatScalar:
         v_h2 = -self._G * self.m(t) / self.r_s(t)
@@ -211,7 +213,7 @@ class NullPotential(AbstractPotential):
     units: UnitSystem = eqx.field(converter=unitsystem, static=True)
 
     @partial(jax.jit)
-    def _potential_energy(
+    def _potential_energy(  # TODO: inputs w/ units
         self,
         q: BatchVec3,
         /,
@@ -292,7 +294,7 @@ class TriaxialHernquistPotential(AbstractPotential):
     """The unit system to use for the potential."""
 
     @partial(jax.jit)
-    def _potential_energy(
+    def _potential_energy(  # TODO: inputs w/ units
         self, q: BatchVec3, /, t: BatchableRealScalarLike
     ) -> BatchFloatScalar:
         c, q1, q2 = self.c(t), self.q1(t), self.q2(t)

--- a/src/galax/potential/_potential/composite.py
+++ b/src/galax/potential/_potential/composite.py
@@ -28,7 +28,7 @@ class AbstractCompositePotential(
     # === Potential ===
 
     @partial(jax.jit)
-    def _potential_energy(
+    def _potential_energy(  # TODO: inputs w/ units
         self, q: BatchVec3, /, t: BatchableRealScalarLike
     ) -> BatchFloatScalar:
         return xp.sum(

--- a/src/galax/potential/_potential/core.py
+++ b/src/galax/potential/_potential/core.py
@@ -26,6 +26,7 @@ class AbstractPotential(AbstractPotentialBase, strict=True):
     ###########################################################################
     # Abstract methods that must be implemented by subclasses
 
+    # TODO: inputs w/ units
     @abc.abstractmethod
     def _potential_energy(self, q: Vec3, /, t: RealScalar) -> FloatScalar:
         raise NotImplementedError

--- a/src/galax/potential/_potential/frame.py
+++ b/src/galax/potential/_potential/frame.py
@@ -1,0 +1,231 @@
+"""The frame of the potential."""
+
+__all__ = ["PotentialFrame"]
+
+
+from dataclasses import replace
+from typing import cast, final
+
+import equinox as eqx
+
+from jax_quantity import Quantity
+
+from galax.coordinates.operators import OperatorSequence, simplify_op
+from galax.potential._potential.base import AbstractPotentialBase
+from galax.typing import (
+    BatchableRealScalarLike,
+    BatchFloatScalar,
+    BatchVec3,
+    RealScalar,
+)
+from galax.units import UnitSystem
+
+
+@final
+class PotentialFrame(AbstractPotentialBase):
+    """Reference frame of the potential.
+
+    Examples
+    --------
+    In this example, we create a triaxial Hernquist potential and apply a few
+    coordinate transformations.
+
+    First some imports:
+
+    >>> from jax_quantity import Quantity
+    >>> import galax.coordinates as gc
+    >>> import galax.coordinates.operators as gco
+    >>> import galax.potential as gp
+
+    Now we define a triaxial Hernquist potential with a time-dependent mass:
+
+    >>> mfunc = gp.UserParameter(lambda t: 1e12 * (1 + t / 10), unit="Msun")
+    >>> pot = gp.TriaxialHernquistPotential(m=mfunc, c=Quantity(1, "kpc"),
+    ...                                     q1=1, q2=0.5, units="galactic")
+
+    Let's see the triaxiality of the potential:
+
+    >>> t = Quantity(0, "Gyr")
+    >>> w1 = gc.PhaseSpaceTimePosition(q=Quantity([1, 0, 0], "kpc"),
+    ...                                p=Quantity([0, 1, 0], "km/s"),
+    ...                                t=t)
+
+    The triaxiality can be seen in the potential energy of the three positions:
+
+    >>> pot.potential_energy(w1)
+    Quantity['specific energy'](Array(-2.24925108, dtype=float64), unit='kpc2 / Myr2')
+
+    >>> pot.potential_energy(Quantity([0, 1, 0], "kpc"), t)
+    Quantity['specific energy'](Array(-2.24925108, dtype=float64), unit='kpc2 / Myr2')
+
+    >>> pot.potential_energy(Quantity([0, 0, 1], "kpc"), t)
+    Quantity['specific energy'](Array(-1.49950072, dtype=float64), unit='kpc2 / Myr2')
+
+    Let's apply a spatial translation to the potential:
+
+    >>> op1 = gco.GalileanSpatialTranslationOperator(Quantity([3, 0, 0], "kpc"))
+    >>> op1
+    GalileanSpatialTranslationOperator( translation=Cartesian3DVector( ... ) )
+
+    >>> framedpot1 = gp.PotentialFrame(potential=pot, operator=op1)
+    >>> framedpot1
+    PotentialFrame(
+      potential=TriaxialHernquistPotential( ... ),
+      operator=OperatorSequence(
+        operators=( GalileanSpatialTranslationOperator( ... ), )
+      )
+    )
+
+    Now the potential energy is different because the potential has been
+    translated by 3 kpc in the x-direction:
+
+    >>> framedpot1.potential_energy(w1)
+    Quantity['specific energy'](Array(-1.49950072, dtype=float64), unit='kpc2 / Myr2')
+
+    This is the same as evaluating the untranslated potential at [-2, 0, 0] kpc:
+
+    >>> pot.potential_energy(Quantity([-2, 0, 0], "kpc"), Quantity(0, "Gyr"))
+    Quantity['specific energy'](Array(-1.49950072, dtype=float64), unit='kpc2 / Myr2')
+
+    We can also apply a time translation to the potential:
+
+    >>> op2 = gco.GalileanTranslationOperator(Quantity([1_000, 0, 0, 0], "kpc"))
+    >>> op2.translation.t.to("Myr")
+    Quantity['time'](Array(3.26156378, dtype=float64), unit='Myr')
+
+    >>> framedpot2 = gp.PotentialFrame(potential=pot, operator=op2)
+
+    We can see that the potential energy is the same as before, since we have
+    been evaluating the potential at ``w1.t=t=0``:
+
+    >>> framedpot2.potential_energy(w1)
+    Quantity['specific energy'](Array(-1.51564349, dtype=float64), unit='kpc2 / Myr2')
+
+    But if we evaluate the potential at a different time, the potential energy
+    will be different:
+
+    >>> from dataclasses import replace
+    >>> w2 = replace(w1, t=Quantity(10, "Myr"))
+    >>> framedpot2.potential_energy(w2)
+    Quantity['specific energy'](Array(-3.76489457, dtype=float64), unit='kpc2 / Myr2')
+
+    Now let's boost the potential by 200 km/s in the y-direction:
+
+    >>> op3 = gco.GalileanBoostOperator(Quantity([0, 200, 0], "km/s"))
+    >>> op3
+    GalileanBoostOperator( velocity=CartesianDifferential3D( ... ) )
+
+    >>> framedpot3 = gp.PotentialFrame(potential=pot, operator=op3)
+    >>> framedpot3.potential_energy(w2)
+    Quantity['specific energy'](Array(-2.74567841, dtype=float64), unit='kpc2 / Myr2')
+
+    Alternatively we can rotate the potential by 90 degrees about the y-axis:
+
+    >>> import array_api_jax_compat as xp
+    >>> theta = Quantity(90, "deg")
+    >>> Ry = xp.asarray([[xp.cos(theta),  0, xp.sin(theta)],
+    ...                  [0,              1, 0            ],
+    ...                  [-xp.sin(theta), 0, xp.cos(theta)]])
+    >>> op4 = gco.GalileanRotationOperator(Ry)
+    >>> op4
+    GalileanRotationOperator(rotation=f64[3,3])
+
+    >>> framedpot4 = gp.PotentialFrame(potential=pot, operator=op4)
+    >>> framedpot4.potential_energy(w1)
+    Quantity['specific energy'](Array(-1.49950072, dtype=float64), unit='kpc2 / Myr2')
+
+    >>> framedpot4.potential_energy(Quantity([0, 0, 1], "kpc"), t)
+    Quantity['specific energy'](Array(-2.24925108, dtype=float64), unit='kpc2 / Myr2')
+
+    If you look all the way back to the first examples, you will see that the
+    potential energy at [1, 0, 0] and [0, 0, 1] have swapped, as expected for
+    a 90 degree rotation about the y-axis!
+
+    Lastly, we can apply a sequence of transformations to the potential. There
+    are two ways to do this. The first is to create a pre-defined composite
+    operator, like a :class:`~galax.coordinates.operators.GalileanOperator`:
+
+    >>> op5 = gco.GalileanOperator(rotation=op4, translation=op2, velocity=op3)
+    >>> op5
+    GalileanOperator(
+      rotation=GalileanRotationOperator(rotation=f64[3,3]),
+      translation=GalileanTranslationOperator( ... ),
+      velocity=GalileanBoostOperator( ... )
+    )
+
+    >>> framedpot5 = gp.PotentialFrame(potential=pot, operator=op5)
+    >>> framedpot5.potential_energy(w2)
+    Quantity['specific energy'](Array(-1.95035509, dtype=float64), unit='kpc2 / Myr2')
+
+    The second way is to create a custom sequence of operators. In this case we
+    will make a sequence that mimics the previous example:
+
+    >>> op6 = op4 | op2 | op3
+    >>> framedpot6 = gp.PotentialFrame(potential=pot, operator=op6)
+    >>> framedpot6.potential_energy(w2)
+    Quantity['specific energy'](Array(-1.95035509, dtype=float64), unit='kpc2 / Myr2')
+    """
+
+    potential: AbstractPotentialBase
+
+    operator: OperatorSequence = eqx.field(default=(), converter=OperatorSequence)
+    """Transformation to reference frame of the potential.
+
+    The default is no transformation, ie the coordinates are specified in the
+    'simulation' frame.
+    """
+
+    @property
+    def units(self) -> UnitSystem:
+        """The unit system of the potential."""
+        return cast(UnitSystem, self.potential.units)
+
+    def _potential_energy(  # TODO: inputs w/ units
+        self, q: BatchVec3, /, t: BatchableRealScalarLike | RealScalar
+    ) -> BatchFloatScalar:
+        """Compute the potential energy at the given position(s).
+
+        This method applies the frame operators to the coordinates and then
+        evaluates the potential energy at the transformed coordinates.
+
+        Parameters
+        ----------
+        q : Array[float, (3,)]
+            The position(s) at which to compute the potential energy.
+        t : float
+            The time at which to compute the potential energy.
+
+        Returns
+        -------
+        Array[float, (...)]
+            The potential energy at the given position(s).
+        """
+        # Transform the position, time.
+        qp, tp = self.operator.inverse(
+            Quantity(q, self.units["length"]), Quantity(t, self.units["time"])
+        )
+        # Evaluate the potential energy at the transformed position, time.
+        return self.potential._potential_energy(qp.value, tp.value)  # noqa: SLF001
+
+    # ruff: noqa: ERA001
+    # def _gradient(
+    #     self, q: BatchVec3, /, t: BatchableRealScalarLike | RealScalar
+    # ) -> BatchVec3:  # TODO: inputs w/ units
+    #     """See ``gradient``."""
+    #     # Transform the position, time.
+    #     qp, tp = self.operator.inverse(
+    #         Quantity(q, self.units["length"]), Quantity(t, self.units["time"])
+    #     )
+    #     # Evaluate the gradient at the transformed position, time.
+    #     gradp = self.potential._gradient(qp.value, tp.value)
+    #     grad, _ = self.operator(Quantity(gradp, self.units["acceleration"]), tp)
+    #     return grad.value
+
+
+#####################################################################
+
+
+@simplify_op.register
+def _simplify_op(frame: PotentialFrame, /) -> PotentialFrame:
+    """Simplify the operators in an PotentialFrame."""
+    return replace(frame, operator=simplify_op(frame.operator))

--- a/tests/smoke/potential/test_package.py
+++ b/tests/smoke/potential/test_package.py
@@ -1,5 +1,13 @@
 import galax.potential as gp
-from galax.potential._potential import base, builtin, composite, core, param, special
+from galax.potential._potential import (
+    base,
+    builtin,
+    composite,
+    core,
+    frame,
+    param,
+    special,
+)
 
 
 def test_all() -> None:
@@ -13,4 +21,5 @@ def test_all() -> None:
         *core.__all__,
         *param.__all__,
         *special.__all__,
+        *frame.__all__,
     }

--- a/tests/unit/potential/builtin/test_nfw.py
+++ b/tests/unit/potential/builtin/test_nfw.py
@@ -157,4 +157,4 @@ class TestNFWPotential(
         rpot = gp.io.gala_to_galax(galax_to_gala(pot))
 
         # quick test that the potential energies are the same
-        assert jnp.array_equal(pot(x, t=0), rpot(x, t=0))
+        assert jnp.array_equal(pot(x, t=0).value, rpot(x, t=0).value)

--- a/tests/unit/potential/test_base.py
+++ b/tests/unit/potential/test_base.py
@@ -44,7 +44,7 @@ class TestAbstractPotentialBase(GalaIOMixin):
 
             @partial(jax.jit)
             @vectorize_method(signature="(3),()->()")
-            def _potential_energy(
+            def _potential_energy(  # TODO: inputs w/ units
                 self, q: BatchVec3, t: BatchableRealScalarLike
             ) -> BatchFloatScalar:
                 return xp.sum(q, axis=-1)
@@ -119,6 +119,7 @@ class TestAbstractPotentialBase(GalaIOMixin):
         class TestPotential(AbstractPotentialBase):
             units: UnitSystem = eqx.field(default=galactic, static=True)
 
+            # TODO: inputs w/ units
             def _potential_energy(self, q: Vec3, /, t: RealScalar) -> FloatScalar:
                 return xp.sum(q, axis=-1)
 

--- a/tests/unit/potential/test_core.py
+++ b/tests/unit/potential/test_core.py
@@ -32,7 +32,7 @@ class TestAbstractPotential(AbstractPotentialBase_Test, FieldUnitSystemMixin):
 
             @partial(jax.jit)
             @vectorize_method(signature="(3),()->()")
-            def _potential_energy(
+            def _potential_energy(  # TODO: inputs w/ units
                 self, q: BatchVec3, t: BatchableRealScalarLike
             ) -> BatchFloatScalar:
                 return xp.sum(q, axis=-1)
@@ -59,7 +59,9 @@ class TestAbstractPotential(AbstractPotentialBase_Test, FieldUnitSystemMixin):
         class TestPotential(gp.AbstractPotentialBase):
             units: UnitSystem = field(default_factory=lambda: dimensionless)
 
-            def _potential_energy(self, q, t):
+            def _potential_energy(  # TODO: inputs w/ units
+                self, q: BatchVec3, t: BatchableRealScalarLike
+            ) -> BatchFloatScalar:
                 return xp.sum(q, axis=-1)
 
         pot = TestPotential()


### PR DESCRIPTION
This PR introduces / will introduce 2 concepts:

1. Operators for frame transformations: e.g. translations, rotations, boosts.
    - These have both active vs passive / apply vs unapply modes.
    - A set of operations can be piped together into a Sequence
    - An astropy reference frame transformation is an operator sequence with particular values! I'm not sure if it will make it into this PR, but we will have an import/export option from/to Astropy CoordinateFrame objects.

2. `PotentialFrame` class that allows a a potential to be expressed in a frame relative to the simulation frame, e.g. translated to have a potential not centered at the origin. The `PotentialFrame` class knows how to "boost" coordinates into the correct frame, then evaluate the potential in that frame.