### PR TITLE
refactor: use lazy_loader with subpackages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,7 +79,7 @@ repos:
     hooks:
       - id: mypy
         files: src
-        exclude: ^src/galax/__init__\.py$
+        exclude: ^(src/galax/__init__\.py|src/galax/.*?/__init__\.py)$
         additional_dependencies:
           - pytest
 

--- a/src/galax/__init__.py
+++ b/src/galax/__init__.py
@@ -17,3 +17,5 @@ from . import coordinates, dynamics, potential, typing, units, utils
 from ._version import __version__
 
 config.update("jax_enable_x64", True)  # noqa: FBT003
+
+del config

--- a/src/galax/__init__.py
+++ b/src/galax/__init__.py
@@ -1,23 +1,19 @@
 """Copyright (c) 2023 galax maintainers. All rights reserved."""
-# ruff:noqa: F401
 
-import os
+__all__ = [
+    "__version__",
+    "__version_tuple__",
+    "coordinates",
+    "potential",
+    "dynamics",
+    "units",
+    "utils",
+    "typing",
+]
 
 from jax import config
-from jaxtyping import install_import_hook
-from lazy_loader import attach_stub as _attach_stub
+
+from . import coordinates, dynamics, potential, typing, units, utils
+from ._version import __version__
 
 config.update("jax_enable_x64", True)  # noqa: FBT003
-
-_RUNTIME_TYPECHECKER = (
-    "beartype.beartype"
-    if (os.environ.get("GALAX_ENABLE_RUNTIME_TYPECHECKS", "1") == "1")
-    else None
-)
-
-with install_import_hook("galax", _RUNTIME_TYPECHECKER):
-    __getattr__, __dir__, __all__ = _attach_stub(__name__, __file__)
-
-
-# Install the runtime typechecker
-install_import_hook("galax", _RUNTIME_TYPECHECKER)

--- a/src/galax/coordinates/__init__.py
+++ b/src/galax/coordinates/__init__.py
@@ -1,13 +1,13 @@
-""":mod:`galax.coordinates`."""
+"""Copyright (c) 2023 galax maintainers. All rights reserved."""
 
-from . import _base, _psp, _pspt, _utils
-from ._base import *
-from ._psp import *
-from ._pspt import *
-from ._utils import *
+from jaxtyping import install_import_hook
+from lazy_loader import attach_stub
 
-__all__: list[str] = []
-__all__ += _base.__all__
-__all__ += _psp.__all__
-__all__ += _pspt.__all__
-__all__ += _utils.__all__
+from galax.setup_package import RUNTIME_TYPECHECKER
+
+with install_import_hook("galax.coordinates", RUNTIME_TYPECHECKER):
+    __getattr__, __dir__, __all__ = attach_stub(__name__, __file__)
+
+
+# Clean up the namespace
+del install_import_hook, attach_stub, RUNTIME_TYPECHECKER

--- a/src/galax/coordinates/__init__.pyi
+++ b/src/galax/coordinates/__init__.pyi
@@ -1,0 +1,17 @@
+# TODO: use star imports when
+# https://github.com/scientific-python/lazy_loader/issues/94 is resolved
+
+__all__ = [
+    # _base
+    "AbstractPhaseSpacePositionBase",
+    # _psp
+    "AbstractPhaseSpacePosition",
+    "PhaseSpacePosition",
+    # _pspt
+    "AbstractPhaseSpaceTimePosition",
+    "PhaseSpaceTimePosition",
+]
+
+from ._base import AbstractPhaseSpacePositionBase
+from ._psp import AbstractPhaseSpacePosition, PhaseSpacePosition
+from ._pspt import AbstractPhaseSpaceTimePosition, PhaseSpaceTimePosition

--- a/src/galax/coordinates/_pspt.py
+++ b/src/galax/coordinates/_pspt.py
@@ -27,6 +27,8 @@ from ._base import AbstractPhaseSpacePositionBase
 from ._utils import getitem_broadscalartime_index
 
 if TYPE_CHECKING:
+    from typing import Self
+
     from galax.potential._potential.base import AbstractPotentialBase
 
 

--- a/src/galax/dynamics/__init__.py
+++ b/src/galax/dynamics/__init__.py
@@ -1,13 +1,13 @@
 """:mod:`galax.dynamics`."""
 
-from ._dynamics import integrate, mockstream, orbit
-from ._dynamics.mockstream import *
-from ._dynamics.orbit import *
+from jaxtyping import install_import_hook
+from lazy_loader import attach_stub
 
-__all__ = ["integrate", "mockstream"]
-__all__ += orbit.__all__
-__all__ += mockstream.__all__
+from galax.setup_package import RUNTIME_TYPECHECKER
+
+with install_import_hook("galax.dynamics", RUNTIME_TYPECHECKER):
+    __getattr__, __dir__, __all__ = attach_stub(__name__, __file__)
 
 
 # Cleanup
-del orbit
+del install_import_hook, RUNTIME_TYPECHECKER

--- a/src/galax/dynamics/__init__.pyi
+++ b/src/galax/dynamics/__init__.pyi
@@ -1,0 +1,26 @@
+# TODO: use star imports when
+# https://github.com/scientific-python/lazy_loader/issues/94 is resolved
+
+__all__ = [
+    # Modules
+    "integrate",
+    "mockstream",
+    # orbit
+    "Orbit",
+    "integrate_orbit",
+    "evaluate_orbit",
+    # mockstream
+    "MockStream",
+    "MockStreamGenerator",
+    # mockstream.df
+    "AbstractStreamDF",
+    "FardalStreamDF",
+]
+
+from ._dynamics import integrate, mockstream
+from ._dynamics.mockstream import (
+    MockStream,
+    MockStreamGenerator,
+)
+from ._dynamics.mockstream.df import AbstractStreamDF, FardalStreamDF
+from ._dynamics.orbit import Orbit, evaluate_orbit, integrate_orbit

--- a/src/galax/potential/__init__.py
+++ b/src/galax/potential/__init__.py
@@ -1,23 +1,13 @@
-"""galax: Galactic Dynamix in Jax."""
+""":mod:`galax.dynamics`."""
 
-from ._potential import base, builtin, composite, core, io, param, special, utils
-from ._potential.base import *
-from ._potential.builtin import *
-from ._potential.composite import *
-from ._potential.core import *
-from ._potential.param import *
-from ._potential.special import *
-from ._potential.utils import *
+from jaxtyping import install_import_hook
+from lazy_loader import attach_stub
 
-__all__: list[str] = ["io"]
-__all__ += base.__all__
-__all__ += core.__all__
-__all__ += composite.__all__
-__all__ += param.__all__
-__all__ += builtin.__all__
-__all__ += special.__all__
-__all__ += utils.__all__
+from galax.setup_package import RUNTIME_TYPECHECKER
+
+with install_import_hook("galax.potential", RUNTIME_TYPECHECKER):
+    __getattr__, __dir__, __all__ = attach_stub(__name__, __file__)
 
 
 # Cleanup
-del base, builtin, composite, core, param, special, utils
+del install_import_hook, RUNTIME_TYPECHECKER

--- a/src/galax/potential/__init__.py
+++ b/src/galax/potential/__init__.py
@@ -1,4 +1,4 @@
-""":mod:`galax.dynamics`."""
+""":mod:`galax.potential`."""
 
 from jaxtyping import install_import_hook
 from lazy_loader import attach_stub

--- a/src/galax/potential/__init__.pyi
+++ b/src/galax/potential/__init__.pyi
@@ -1,0 +1,54 @@
+# TODO: use star imports when
+# https://github.com/scientific-python/lazy_loader/issues/94 is resolved
+
+__all__ = [
+    # Modules
+    "io",
+    # base
+    "AbstractPotentialBase",
+    # core
+    "AbstractPotential",
+    # composite
+    "AbstractCompositePotential",
+    "CompositePotential",
+    # param
+    "ParametersAttribute",
+    "ParameterCallable",
+    "AbstractParameter",
+    "ConstantParameter",
+    "UserParameter",
+    "ParameterField",
+    # builtin
+    "BarPotential",
+    "HernquistPotential",
+    "IsochronePotential",
+    "KeplerPotential",
+    "MiyamotoNagaiPotential",
+    "NFWPotential",
+    "NullPotential",
+    # special
+    "MilkyWayPotential",
+]
+
+from ._potential import io
+from ._potential.base import AbstractPotentialBase
+from ._potential.builtin import (
+    BarPotential,
+    HernquistPotential,
+    IsochronePotential,
+    KeplerPotential,
+    MiyamotoNagaiPotential,
+    NFWPotential,
+    NullPotential,
+)
+from ._potential.composite import AbstractCompositePotential, CompositePotential
+from ._potential.core import AbstractPotential
+from ._potential.param import (
+    AbstractParameter,
+    ConstantParameter,
+    ParameterCallable,
+    ParameterField,
+    ParametersAttribute,
+    UserParameter,
+)
+from ._potential.special import MilkyWayPotential

--- a/src/galax/potential/_potential/__init__.py
+++ b/src/galax/potential/_potential/__init__.py
@@ -1,1 +1,4 @@
 """``galax`` Potentials."""
+# ruff:noqa: F401
+
+from . import io

--- a/src/galax/potential/_potential/base.py
+++ b/src/galax/potential/_potential/base.py
@@ -51,7 +51,7 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
     _: KW_ONLY
     units: eqx.AbstractVar[UnitSystem]
 
-    def __init_subclass__(cls) -> None:
+    def __init_subclass__(cls, **kwargs: Any) -> None:
         """Initialize the subclass."""
         # Replace the ``parameters`` attribute with a mapping of the values
         type(cls).__setattr__(

--- a/src/galax/potential/_potential/composite.py
+++ b/src/galax/potential/_potential/composite.py
@@ -1,4 +1,4 @@
-__all__ = ["CompositePotential"]
+__all__ = ["AbstractCompositePotential", "CompositePotential"]
 
 
 import uuid

--- a/src/galax/potential/_potential/param/__init__.py
+++ b/src/galax/potential/_potential/param/__init__.py
@@ -1,7 +1,11 @@
-from . import core, field
+from . import attr, core, field, utils
+from .attr import *
 from .core import *
 from .field import *
+from .utils import *
 
 __all__: list[str] = []
+__all__ += attr.__all__
 __all__ += core.__all__
 __all__ += field.__all__
+__all__ += utils.__all__

--- a/src/galax/setup_package.py
+++ b/src/galax/setup_package.py
@@ -1,0 +1,13 @@
+"""Copyright (c) 2023 galax maintainers. All rights reserved."""
+
+import os
+
+from jax import config
+
+config.update("jax_enable_x64", True)  # noqa: FBT003
+
+RUNTIME_TYPECHECKER = (
+    "beartype.beartype"
+    if (os.environ.get("GALAX_ENABLE_RUNTIME_TYPECHECKS", "1") == "1")
+    else None
+)

--- a/tests/smoke/potential/test_package.py
+++ b/tests/smoke/potential/test_package.py
@@ -1,5 +1,5 @@
 import galax.potential as gp
-from galax.potential import _potential
+from galax.potential._potential import base, builtin, composite, core, param, special
 
 
 def test_all() -> None:
@@ -7,10 +7,10 @@ def test_all() -> None:
     # Test detailed contents (not order)
     assert set(gp.__all__) == {
         "io",
-        *_potential.base.__all__,
-        *_potential.builtin.__all__,
-        *_potential.composite.__all__,
-        *_potential.core.__all__,
-        *_potential.param.__all__,
-        *_potential.special.__all__,
+        *base.__all__,
+        *builtin.__all__,
+        *composite.__all__,
+        *core.__all__,
+        *param.__all__,
+        *special.__all__,
     }

--- a/tests/smoke/test_package.py
+++ b/tests/smoke/test_package.py
@@ -14,6 +14,7 @@ def test_all() -> None:
         "__version__",
         "__version_tuple__",
         # modules
+        "coordinates",
         "dynamics",
         "potential",
         "typing",


### PR DESCRIPTION
This follows the normal usage of `galax`, e.g. `import galax.dynamics as gd`.
The  current format destroys the lazy import right away.


Unfortunately https://github.com/scientific-python/lazy_loader/issues/94 means we can't do star imports in the stub files. When that's resolved everything will be a lot simpler.