### PR TITLE
feat: ConstantRotationZOperator for solid-body rotation

### DIFF
--- a/src/galax/coordinates/operators/__init__.py
+++ b/src/galax/coordinates/operators/__init__.py
@@ -3,12 +3,13 @@
 E.g. a translation.
 """
 
-from . import base, composite, funcs, galilean, identity, sequential
+from . import base, composite, funcs, galilean, identity, rotating, sequential
 from .base import *
 from .composite import *
 from .funcs import *
 from .galilean import *
 from .identity import *
+from .rotating import *
 from .sequential import *
 
 __all__: list[str] = []
@@ -17,4 +18,5 @@ __all__ += composite.__all__
 __all__ += sequential.__all__
 __all__ += identity.__all__
 __all__ += galilean.__all__
+__all__ += rotating.__all__
 __all__ += funcs.__all__

--- a/src/galax/coordinates/operators/galilean.py
+++ b/src/galax/coordinates/operators/galilean.py
@@ -1179,7 +1179,7 @@ class GalileanOperator(AbstractCompositeOperator, AbstractGalileanOperator):
 
 
 @simplify_op.register
-def _simplify_op(
+def _simplify_op_spatialtranslation(
     op: GalileanSpatialTranslationOperator, /, **kwargs: Any
 ) -> AbstractOperator:
     """Simplify a spatial translation operator."""
@@ -1190,7 +1190,9 @@ def _simplify_op(
 
 
 @simplify_op.register
-def _simplify_op(op: GalileanTranslationOperator, /, **kwargs: Any) -> AbstractOperator:
+def _simplify_op_tranlation(
+    op: GalileanTranslationOperator, /, **kwargs: Any
+) -> AbstractOperator:
     """Simplify a translation operator."""
     # Check if the translation is zero.
     if jnp.allclose(convert(op.translation, Quantity).value, xp.zeros((4,)), **kwargs):
@@ -1202,7 +1204,7 @@ def _simplify_op(op: GalileanTranslationOperator, /, **kwargs: Any) -> AbstractO
 
 
 @simplify_op.register
-def _simplify_op(op: GalileanBoostOperator, /, **kwargs: Any) -> AbstractOperator:
+def _simplify_op_boost(op: GalileanBoostOperator, /, **kwargs: Any) -> AbstractOperator:
     """Simplify a boost operator."""
     # Check if the velocity is zero.
     if jnp.allclose(convert(op.velocity, Quantity).value, xp.zeros((3,)), **kwargs):
@@ -1211,14 +1213,16 @@ def _simplify_op(op: GalileanBoostOperator, /, **kwargs: Any) -> AbstractOperato
 
 
 @simplify_op.register
-def _simplify_op(op: GalileanRotationOperator, /, **kwargs: Any) -> AbstractOperator:
+def _simplify_op_rotation(
+    op: GalileanRotationOperator, /, **kwargs: Any
+) -> AbstractOperator:
     if jnp.allclose(op.rotation, xp.eye(3), **kwargs):
         return IdentityOperator()
     return op
 
 
 @simplify_op.register
-def _simplify_op(op: GalileanOperator, /, **kwargs: Any) -> AbstractOperator:
+def _simplify_op_galilean(op: GalileanOperator, /, **kwargs: Any) -> AbstractOperator:
     """Simplify a Galilean operator."""
     # Check if all the sub-operators can be simplified to the identity.
     if all(

--- a/src/galax/coordinates/operators/rotating.py
+++ b/src/galax/coordinates/operators/rotating.py
@@ -1,0 +1,352 @@
+"""Corotating reference frame."""
+
+__all__ = ["ConstantRotationOperator"]
+
+
+from dataclasses import replace
+from typing import Literal, final
+
+from jaxtyping import Float, Shaped
+from plum import convert
+
+import array_api_jax_compat as xp
+from coordinax import Abstract3DVector, Cartesian3DVector, CartesianDifferential3D
+from jax_quantity import Quantity
+
+from .base import AbstractOperator, op_call_dispatch
+from galax.coordinates._psp.base import AbstractPhaseSpacePositionBase
+
+
+def rot_x(
+    theta: Shaped[Quantity["angle"], ""],
+) -> Float[Quantity["dimensionless"], "3 3"]:
+    """Rotation matrix for rotation around the x-axis.
+
+    Parameters
+    ----------
+    theta : Quantity[float, "angle"]
+        The angle of rotation.
+
+    Returns
+    -------
+    tuple[Quantity[float, "angle"], Quantity[float, "angle"]]
+        The sine and cosine of the angle.
+    """
+    return xp.asarray(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, xp.cos(theta), -xp.sin(theta)],
+            [0.0, xp.sin(theta), xp.cos(theta)],
+        ]
+    )
+
+
+def rot_y(
+    theta: Shaped[Quantity["angle"], ""],
+) -> Float[Quantity["dimensionless"], "3 3"]:
+    """Rotation matrix for rotation around the y-axis.
+
+    Parameters
+    ----------
+    theta : Quantity[float, "angle"]
+        The angle of rotation.
+
+    Returns
+    -------
+    tuple[Quantity[float, "angle"], Quantity[float, "angle"]]
+        The sine and cosine of the angle.
+    """
+    return xp.asarray(
+        [
+            [xp.cos(theta), 0.0, xp.sin(theta)],
+            [0.0, 1.0, 0.0],
+            [-xp.sin(theta), 0.0, xp.cos(theta)],
+        ]
+    )
+
+
+def rot_z(
+    theta: Shaped[Quantity["angle"], ""],
+) -> Float[Quantity["dimensionless"], "3 3"]:
+    """Rotation matrix for rotation around the z-axis.
+
+    Parameters
+    ----------
+    theta : Quantity[float, "angle"]
+        The angle of rotation.
+
+    Returns
+    -------
+    tuple[Quantity[float, "angle"], Quantity[float, "angle"]]
+        The sine and cosine of the angle.
+    """
+    return xp.asarray(
+        [
+            [xp.cos(theta), -xp.sin(theta), 0],
+            [xp.sin(theta), xp.cos(theta), 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+
+
+@final
+class ConstantRotationOperator(AbstractOperator):
+    r"""Operator for constant rotation in the x-y plane.
+
+    The coordinate transform is given by:
+
+    .. math::
+
+        (t,\mathbf{x}) \mapsto (t, \mathbf{x} (1 + Omega_z ))
+
+    where :math:`\mathbf {Omega}` is the angular velocity vector in the z
+    direction.
+
+    Parameters
+    ----------
+    Omega_x, Omega_y, Omega_z : Quantity[float, "angular speed"]
+        The angular speed about the x, y, and z axes.
+
+    Examples
+    --------
+    First some imports:
+
+    >>> from jax_quantity import Quantity
+    >>> import galax.coordinates as gc
+    >>> from galax.coordinates.operators import ConstantRotationOperator
+
+    We define a rotation of 90 degrees every gigayear about the z axis.
+
+    >>> op = ConstantRotationOperator(Omega_z=Quantity(90, "deg / Gyr"))
+
+    We can apply the rotation to a position.
+
+    >>> pspt = gc.PhaseSpaceTimePosition(q=Quantity([1, 0, 0], "kpc"),
+    ...                                  p=Quantity([0, 0, 0], "kpc/Gyr"),
+    ...                                  t=Quantity(1, "Gyr"))
+
+    >>> newpsp = op(pspt)
+
+    For display purposes, we convert the resulting position to an Array.
+
+    >>> from plum import convert
+    >>> convert(newpsp.q, Quantity).value.round(2)
+    Array([0., 1., 0.], dtype=float64)
+
+    This rotation is time dependent.
+
+    >>> convert(op(pspt, Quantity(2, "Gyr"))[0].q, Quantity).value.round(2)
+    Array([-1.,  0.,  0.], dtype=float64)
+
+    We can also apply the rotation to a
+    :class:`~galax.corodinates.PhaseSpacePosition`.
+
+    >>> psp = gc.PhaseSpacePosition(q=Quantity([1, 0, 0], "kpc"),
+    ...                             p=Quantity([0, 0, 0], "kpc/Gyr"))
+    >>> t = Quantity(1, "Gyr")
+
+    >>> newpsp, newt = op(psp, t)
+    >>> convert(newpsp.q, Quantity).value.round(2)
+    Array([0., 1., 0.], dtype=float64)
+
+    We can also apply the rotation to a :class:`~galax.coordinax.FourVector`.
+
+    >>> import coordinax as cx
+    >>> v4 = cx.FourVector(t=t, q =Quantity([1, 0, 0], "kpc"))
+
+    >>> newv4 = op(v4)
+    >>> convert(newv4.q, Quantity).value.round(2)
+    Array([0., 1., 0.], dtype=float64)
+
+    We can also apply the rotation to a :class:`~coordinax.Abstract3DVector`.
+
+    >>> q = cx.Cartesian3DVector.constructor(Quantity([1, 0, 0], "kpc"))
+    >>> newq, newt = op(q, t)
+    >>> convert(newq, Quantity).value.round(2)
+    Array([0., 1., 0.], dtype=float64)
+
+    We can also apply the rotation to a :class:`~jax_quantity.Quantity`, which
+    is interpreted as a :class:`~coordinax.Cartesian3DVector` if it has shape
+    ``(*batch, 3)`` and a :class:`~coordinax.FourVector` if it has shape
+    ``(*batch, 4)``.
+
+    >>> q = Quantity([1, 0, 0], "kpc")
+    >>> newq, newt = op(q, t)
+    >>> newq.value.round(2)
+    Array([0., 1., 0.], dtype=float64)
+    """
+
+    # TODO: add a converter for 1/s -> rad / s.
+    Omega_x: Quantity["angular speed"] = Quantity(0, "mas / yr")
+    """The angular speed about the x axis."""
+
+    Omega_y: Quantity["angular speed"] = Quantity(0, "mas / yr")
+    """The angular speed about the y axis."""
+
+    Omega_z: Quantity["angular speed"] = Quantity(0, "mas / yr")
+    """The angular speed about the z axis."""
+
+    # -------------------------------------------
+
+    @property
+    def is_inertial(self) -> Literal[False]:
+        """Galilean translation is an inertial frame-preserving transformation.
+
+        Examples
+        --------
+        >>> from jax_quantity import Quantity
+        >>> from galax.coordinates.operators import ConstantRotationOperator
+
+        >>> op = ConstantRotationOperator(Quantity(360, "deg / Gyr"))
+        >>> op.is_inertial
+        False
+        """
+        return False
+
+    @property
+    def inverse(self) -> "ConstantRotationOperator":
+        """The inverse of the operator.
+
+        Examples
+        --------
+        >>> from jax_quantity import Quantity
+        >>> from coordinax import Cartesian3DVector
+        >>> from galax.coordinates.operators import ConstantRotationOperator
+
+        >>> op = ConstantRotationOperator(Omega_z=Quantity(360, "deg / Gyr"))
+        >>> op.inverse
+        ConstantRotationOperator(
+            Omega_x=Quantity[...]( value=i64[], unit=Unit("mas / yr") ),
+            Omega_y=Quantity[...]( value=i64[], unit=Unit("mas / yr") ),
+            Omega_z=Quantity[...]( value=i64[], unit=Unit("deg / Gyr") )
+        )
+        """
+        return ConstantRotationOperator(
+            Omega_x=-self.Omega_x, Omega_y=-self.Omega_y, Omega_z=-self.Omega_z
+        )
+
+    # -------------------------------------------
+
+    @op_call_dispatch(precedence=1)
+    def __call__(
+        self: "ConstantRotationOperator",
+        q: Quantity["length"],
+        t: Quantity["time"],
+        /,
+    ) -> tuple[Quantity["length"], Quantity["time"]]:
+        """Apply the translation to the Cartesian coordinates.
+
+        Examples
+        --------
+        >>> from jax_quantity import Quantity
+        >>> from galax.coordinates.operators import ConstantRotationOperator
+
+        >>> op = ConstantRotationOperator(Omega_z=Quantity(90, "deg / Gyr"))
+
+        >>> q = Quantity([1, 0, 0], "kpc")
+        >>> t = Quantity(1, "Gyr")
+        >>> newq, newt = op(q, t)
+        >>> newq.value.round(2)
+        Array([0., 1., 0.], dtype=float64)
+
+        >>> newt
+        Quantity['time'](Array(1, dtype=int64, ...), unit='Gyr')
+
+        This rotation is time dependent. If we rotate by 2 Gyr, we go another
+        90 degrees.
+
+        >>> op(q, Quantity(2, "Gyr"))[0].value.round(2)
+        Array([-1.,  0.,  0.], dtype=float64)
+
+        """  # TODO: use xp.round when available
+        Rx = rot_x(self.Omega_x * t)
+        Ry = rot_y(self.Omega_y * t)
+        Rz = rot_z(self.Omega_z * t)
+        return (Rx @ Ry @ Rz @ q, t)
+
+    @op_call_dispatch(precedence=1)
+    def __call__(
+        self: "ConstantRotationOperator",
+        vec: Abstract3DVector,
+        t: Quantity["time"],
+        /,
+    ) -> tuple[Abstract3DVector, Quantity["time"]]:
+        """Apply the translation to the coordinates.
+
+        Examples
+        --------
+        >>> from plum import convert
+        >>> from jax_quantity import Quantity
+        >>> from coordinax import Cartesian3DVector
+        >>> from galax.coordinates.operators import ConstantRotationOperator
+
+        >>> op = ConstantRotationOperator(Omega_z=Quantity(90, "deg / Gyr"))
+
+        >>> q = Cartesian3DVector.constructor(Quantity([1, 0, 0], "kpc"))
+        >>> t = Quantity(1, "Gyr")
+        >>> newq, newt = op(q, t)
+        >>> convert(newq, Quantity).value.round(2)
+        Array([0., 1., 0.], dtype=float64)
+
+        >>> newt
+        Quantity['time'](Array(1, dtype=int64, ...), unit='Gyr')
+
+        This rotation is time dependent.
+
+        >>> convert(op(q, Quantity(2, "Gyr"))[0], Quantity).value.round(2)
+        Array([-1., 0., 0.], dtype=float64)
+
+        """
+        q = convert(vec.represent_as(Cartesian3DVector), Quantity)
+        qp, tp = self(q, t)
+        vecp = Cartesian3DVector.constructor(qp).represent_as(type(vec))
+        return (vecp, tp)
+
+    @op_call_dispatch
+    def __call__(
+        self: "ConstantRotationOperator",
+        psp: AbstractPhaseSpacePositionBase,
+        t: Quantity["time"],
+        /,
+    ) -> tuple[AbstractPhaseSpacePositionBase, Quantity["time"]]:
+        """Apply the translation to the coordinates.
+
+        Examples
+        --------
+        >>> from plum import convert
+        >>> from jax_quantity import Quantity
+        >>> from galax.coordinates import PhaseSpacePosition
+        >>> from galax.coordinates.operators import ConstantRotationOperator
+
+        >>> op = ConstantRotationOperator(Omega_z=Quantity(90, "deg / Gyr"))
+
+        >>> psp = PhaseSpacePosition(q=Quantity([1, 0, 0], "kpc"),
+        ...                          p=Quantity([0, 0, 0], "kpc/Gyr"))
+
+        >>> t = Quantity(1, "Gyr")
+        >>> newpsp, newt = op(psp, t)
+        >>> convert(newpsp.q, Quantity).value.round(2)
+        Array([0., 1., 0.], dtype=float64)
+
+        >>> newt
+        Quantity['time'](Array(1, dtype=int64, ...), unit='Gyr')
+
+        This rotation is time dependent.
+
+        >>> convert(op(psp, Quantity(2, "Gyr"))[0].q, Quantity).value.round(2)
+        Array([-1.,  0.,  0.], dtype=float64)
+
+        """
+        # Shifting the position and time
+        q, t = self(psp.q, t)
+        # Transforming the momentum. The actual value of momentum is not
+        # affected by the translation, however for non-Cartesian coordinates the
+        # representation of the momentum in will be different.  First transform
+        # the momentum to Cartesian coordinates at the original position. Then
+        # transform the momentum back to the original representation, but at the
+        # translated position.
+        p = psp.p.represent_as(CartesianDifferential3D, psp.q).represent_as(
+            type(psp.p), q
+        )
+        # Reasseble and return
+        return (replace(psp, q=q, p=p), t)

--- a/src/galax/potential/_potential/frame.py
+++ b/src/galax/potential/_potential/frame.py
@@ -138,8 +138,8 @@ class PotentialFrame(AbstractPotentialBase):
     Quantity['specific energy'](Array(-2.24925108, dtype=float64), unit='kpc2 / Myr2')
 
     If you look all the way back to the first examples, you will see that the
-    potential energy at [1, 0, 0] and [0, 0, 1] have swapped, as expected for
-    a 90 degree rotation about the y-axis!
+    potential energy at [1, 0, 0] and [0, 0, 1] have swapped, as expected for a
+    90 degree rotation about the y-axis!
 
     Lastly, we can apply a sequence of transformations to the potential. There
     are two ways to do this. The first is to create a pre-defined composite
@@ -164,6 +164,25 @@ class PotentialFrame(AbstractPotentialBase):
     >>> framedpot6 = gp.PotentialFrame(potential=pot, operator=op6)
     >>> framedpot6.potential_energy(w2)
     Quantity['specific energy'](Array(-1.95035509, dtype=float64), unit='kpc2 / Myr2')
+
+    We've seen that the potential can be time-dependent, but so far the
+    operators have been Galilean. Let's fix the time-dependent mass of the
+    potential but make the frame operator time-dependent in a more interesting
+    way. We will also exaggerate the triaxiality of the potential to make the
+    effect of the rotation more obvious:
+
+    >>> pot2 = gp.TriaxialHernquistPotential(m=Quantity(1e12, "Msun"),
+    ...     c=Quantity(1, "kpc"), q1=0.1, q2=0.1, units="galactic")
+
+    >>> op7 = gco.ConstantRotationOperator(Omega_z=Quantity(90, "deg/Gyr"))
+    >>> framedpot7 = gp.PotentialFrame(potential=pot2, operator=op7)
+
+    The potential energy at a given position will change with time:
+
+    >>> framedpot7.potential_energy(w1).value  # t=0 Gyr
+    Array(-2.24925108, dtype=float64)
+    >>> framedpot7.potential_energy(w2).value  # t=1 Gyr
+    Array(-2.23568166, dtype=float64)
     """
 
     potential: AbstractPotentialBase

--- a/src/galax/potential/_potential/frame.py
+++ b/src/galax/potential/_potential/frame.py
@@ -174,7 +174,7 @@ class PotentialFrame(AbstractPotentialBase):
     >>> pot2 = gp.TriaxialHernquistPotential(m=Quantity(1e12, "Msun"),
     ...     c=Quantity(1, "kpc"), q1=0.1, q2=0.1, units="galactic")
 
-    >>> op7 = gco.ConstantRotationOperator(Omega_z=Quantity(90, "deg/Gyr"))
+    >>> op7 = gco.ConstantRotationZOperator(Omega_z=Quantity(90, "deg/Gyr"))
     >>> framedpot7 = gp.PotentialFrame(potential=pot2, operator=op7)
 
     The potential energy at a given position will change with time:

--- a/tests/unit/potential/test_frame.py
+++ b/tests/unit/potential/test_frame.py
@@ -1,0 +1,57 @@
+"""Tests for `galax.potential._potential.frame` package."""
+
+from dataclasses import replace
+
+import jax.numpy as jnp
+from quax import quaxify
+
+import array_api_jax_compat as xp
+from jax_quantity import Quantity
+
+import galax.coordinates.operators as gco
+import galax.potential as gp
+
+array_equal = quaxify(jnp.array_equal)
+
+
+def test_bar_means_of_rotation() -> None:
+    """Test the equivalence of hard-coded vs operator means of rotation."""
+    base_pot = gp.BarPotential(
+        m=Quantity(1e9, "Msun"),
+        a=Quantity(5, "kpc"),
+        b=Quantity(0.1, "kpc"),
+        c=Quantity(0.1, "kpc"),
+        Omega=Quantity(0, "Hz"),
+        units="galactic",
+    )
+
+    Omega_z_freq = Quantity(220, "1/Myr")
+    Omega_z_angv = xp.multiply(Omega_z_freq, Quantity(1, "rad"))
+
+    # Hard-coded means of rotation
+    hardpot = replace(base_pot, Omega=Omega_z_freq)
+
+    # Operator means of rotation
+    op = gco.ConstantRotationOperator(Omega_z=Omega_z_angv)
+    framedpot = gp.PotentialFrame(base_pot, op)
+
+    # They should be equivalent at t=0
+    q = Quantity([5, 0, 0], "kpc")
+    t = Quantity(0, "Myr")
+    assert framedpot.potential_energy(q, t) == hardpot.potential_energy(q, t)
+    assert array_equal(framedpot.acceleration(q, t), hardpot.acceleration(q, t))
+
+    # They should be equivalent at t=110 Myr (1/2 period)
+    t = Quantity(110, "Myr")
+    assert framedpot.potential_energy(q, t) == hardpot.potential_energy(q, t)
+    assert array_equal(framedpot.acceleration(q, t), hardpot.acceleration(q, t))
+
+    # They should be equivalent at t=220 Myr (1 period)
+    t = Quantity(220, "Myr")
+    assert framedpot.potential_energy(q, t) == hardpot.potential_energy(q, t)
+    assert array_equal(framedpot.acceleration(q, t), hardpot.acceleration(q, t))
+
+    # They should be equivalent at t=55 Myr (1/4 period)
+    t = Quantity(55, "Myr")
+    assert framedpot.potential_energy(q, t) == hardpot.potential_energy(q, t)
+    assert array_equal(framedpot.acceleration(q, t), hardpot.acceleration(q, t))

--- a/tests/unit/potential/test_frame.py
+++ b/tests/unit/potential/test_frame.py
@@ -32,7 +32,7 @@ def test_bar_means_of_rotation() -> None:
     hardpot = replace(base_pot, Omega=Omega_z_freq)
 
     # Operator means of rotation
-    op = gco.ConstantRotationOperator(Omega_z=Omega_z_angv)
+    op = gco.ConstantRotationZOperator(Omega_z=Omega_z_angv)
     framedpot = gp.PotentialFrame(base_pot, op)
 
     # They should be equivalent at t=0


### PR DESCRIPTION
Now any potential can have constant rotation about z axis. Combined with a GalileanRotation operator this allows for rotation about any axes. In the docstring I do this + a time-dependent mass.

This means we can get rid of the Omega parameter in the `galax.potential.BarPotential` and just mention it in the docstring for how to get the bar rotating. Or we can leave it. Either or.

For more general rotations we need to choose whether we want to use intrinsic or extrinsic rotation, what order, etc.
Alternatively, we could forego all this subtlety by using the axis-angle formalism. Thoughts? 

Edit: IMO quaternions are the best way to do this. Very efficient. I'll change this class to `ConstrantRotationZ` that just has `Omega_z` and makes life easy for the common case. We can do general rotations in a followup.
