### PR TITLE
feat: orbit metadata

### DIFF
--- a/src/galax/dynamics/_src/mockstream/core.py
+++ b/src/galax/dynamics/_src/mockstream/core.py
@@ -12,6 +12,7 @@ from jaxtyping import Array, Shaped
 import coordinax as cx
 import quaxed.numpy as jnp
 from unxt import Quantity
+from xmmutablemap import ImmutableMap
 
 import galax.typing as gt
 from galax.coordinates import (
@@ -53,6 +54,15 @@ class MockStreamArm(AbstractPhaseSpacePosition):
 
     release_time: gt.QVecTime = eqx.field(converter=Quantity["time"].constructor)
     """Release time of the stream particles [Myr]."""
+
+    meta: ImmutableMap[Any] = eqx.field(
+        default_factory=dict,
+        converter=ImmutableMap,
+        static=True,
+        repr=False,
+        compare=False,
+    )
+    """Metadata about the mock-stream."""
 
     # ==========================================================================
     # Array properties

--- a/src/galax/dynamics/_src/mockstream/core.py
+++ b/src/galax/dynamics/_src/mockstream/core.py
@@ -62,7 +62,7 @@ class MockStreamArm(AbstractPhaseSpacePosition):
         repr=False,
         compare=False,
     )
-    """Metadata about the mock-stream."""
+    """Metadata about the mock-stream arm."""
 
     # ==========================================================================
     # Array properties
@@ -96,6 +96,15 @@ class MockStreamArm(AbstractPhaseSpacePosition):
 @final
 class MockStream(AbstractCompositePhaseSpacePosition):
     _time_sorter: Shaped[Array, "alltimes"]
+
+    meta: ImmutableMap[Any] = eqx.field(
+        default_factory=dict,
+        converter=ImmutableMap,
+        static=True,
+        repr=False,
+        compare=False,
+    )
+    """Metadata about the mock stream."""
 
     def __init__(
         self,

--- a/src/galax/dynamics/_src/mockstream/mockstream_generator.py
+++ b/src/galax/dynamics/_src/mockstream/mockstream_generator.py
@@ -102,7 +102,11 @@ class MockStreamGenerator(eqx.Module):  # type: ignore[misc]
             def integ_ics(ics: gt.Vec6) -> gt.VecN:
                 # TODO: only return the final state
                 return evaluate_orbit(
-                    self.potential, ics, tstep, integrator=self.stream_integrator
+                    self.potential,
+                    ics,
+                    tstep,
+                    integrator=self.stream_integrator,
+                    include_meta=False,
                 ).w(units=self.units)[-1]
 
             # vmap integration over leading and trailing arm
@@ -137,10 +141,18 @@ class MockStreamGenerator(eqx.Module):  # type: ignore[misc]
         ) -> tuple[gt.Vec6, gt.Vec6]:
             tstep = xp.asarray([ts[i], t_f])
             w_lead = evaluate_orbit(
-                self.potential, w0_l_i, tstep, integrator=self.stream_integrator
+                self.potential,
+                w0_l_i,
+                tstep,
+                integrator=self.stream_integrator,
+                include_meta=False,
             ).w(units=self.potential.units)[-1]
             w_trail = evaluate_orbit(
-                self.potential, w0_t_i, tstep, integrator=self.stream_integrator
+                self.potential,
+                w0_t_i,
+                tstep,
+                integrator=self.stream_integrator,
+                include_meta=False,
             ).w(units=self.potential.units)[-1]
             return w_lead, w_trail
 
@@ -206,6 +218,8 @@ class MockStreamGenerator(eqx.Module):  # type: ignore[misc]
         # Parse vmapped
         use_vmap = get_backend().platform == "gpu" if vmapped is None else vmapped
 
+        original_rng = rng
+
         # Ensure w0 is a PhaseSpacePosition
         w0: gc.PhaseSpacePosition
         if isinstance(prog_w0, gc.PhaseSpacePosition):
@@ -253,4 +267,4 @@ class MockStreamGenerator(eqx.Module):  # type: ignore[misc]
             release_time=mock0["trail"].release_time,
         )
 
-        return MockStream(comps), prog_o[-1]
+        return MockStream(comps, meta={}), prog_o[-1]

--- a/src/galax/dynamics/_src/orbit.py
+++ b/src/galax/dynamics/_src/orbit.py
@@ -12,6 +12,7 @@ import jax.numpy as jnp
 
 import coordinax as cx
 from unxt import Quantity
+from xmmutablemap import ImmutableMap
 
 import galax.coordinates as gc
 import galax.typing as gt
@@ -98,6 +99,15 @@ class Orbit(gc.AbstractPhaseSpacePosition):
 
     interpolant: PhaseSpacePositionInterpolant | None = None
     """The interpolation function."""
+
+    meta: ImmutableMap[Any] = eqx.field(
+        default_factory=dict,
+        converter=ImmutableMap,
+        static=True,
+        repr=False,
+        compare=False,
+    )
+    """Metadata about the orbit."""
 
     def __post_init__(self) -> None:
         """Post-initialization."""

--- a/src/galax/potential/_src/base.py
+++ b/src/galax/potential/_src/base.py
@@ -330,6 +330,7 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
         *,
         integrator: "Integrator | None" = None,
         interpolated: Literal[True, False] = False,
+        include_meta: Literal[True, False] = False,
     ) -> "Orbit":
         """Compute an orbit in a potential.
 
@@ -357,7 +358,7 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
                 A :class:`~galax.coordinates.PhaseSpacePosition` will be
                 constructed, interpreting the array as the  'q', 'p' (each
                 Array[float, (*batch, 3)]) arguments, with 't' set to ``t[0]``.
-        t: Quantity[float, (time,)]
+        t : Quantity[float, (time,)]
             Array of times at which to compute the orbit. The first element
             should be the initial time and the last element should be the final
             time and the array should be monotonically moving from the first to
@@ -375,10 +376,16 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
             Integrator to use.  If `None`, the default integrator
             :class:`~galax.integrator.Integrator` is used.
 
-        interpolated: bool, optional keyword-only
-                If `True`, return an interpolated orbit.  If `False`, return the orbit
-                at the requested times.  Default is `False`.
+        interpolated : bool, optional keyword-only
+            If `True`, return an interpolated orbit.  If `False`, return the
+            orbit at the requested times.  Default is `False`.
 
+        include_meta : bool, optional keyword-only
+            Metadata is attached as an :class:`~immutable_map_jax.ImmutableMap`.
+            If `True`, the metadata is populated with:
+
+            - `'integrator'`: The integrator used.
+            - `'has_t0'`: Whether `w0` has time information.
 
         Returns
         -------
@@ -396,7 +403,12 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
         return cast(
             "Orbit",
             evaluate_orbit(
-                self, w0, t, integrator=integrator, interpolated=interpolated
+                self,
+                w0,
+                t,
+                integrator=integrator,
+                interpolated=interpolated,
+                include_meta=include_meta,
             ),
         )
 


### PR DESCRIPTION
Add some read-only metadata to `Orbit` and `MockStream`. 
I'm not 100% sure what metadata we want, just that something seems useful.
