### PR TITLE
feat: Triaxial (density) NFW potentials

### DIFF
--- a/src/galax/potential/__init__.pyi
+++ b/src/galax/potential/__init__.pyi
@@ -24,14 +24,16 @@ __all__ = [
     "IsochronePotential",
     "KeplerPotential",
     "KuzminPotential",
-    "LeeSutoTriaxialNFWPotential",
     "LogarithmicPotential",
     "MiyamotoNagaiPotential",
-    "NFWPotential",
     "NullPotential",
     "PlummerPotential",
     "PowerLawCutoffPotential",
     "TriaxialHernquistPotential",
+    # nfw
+    "NFWPotential",
+    "LeeSutoTriaxialNFWPotential",
+    "TriaxialNFWPotential",
     "Vogelsberger08TriaxialNFWPotential",
     # special
     "BovyMWPotential2014",
@@ -42,20 +44,23 @@ __all__ = [
 
 from ._potential import io
 from ._potential.base import AbstractPotentialBase
-from ._potential.builtin import (
+from ._potential.builtin.builtin import (
     BarPotential,
     HernquistPotential,
     IsochronePotential,
     KeplerPotential,
     KuzminPotential,
-    LeeSutoTriaxialNFWPotential,
     LogarithmicPotential,
     MiyamotoNagaiPotential,
-    NFWPotential,
     NullPotential,
     PlummerPotential,
     PowerLawCutoffPotential,
     TriaxialHernquistPotential,
+)
+from ._potential.builtin.nfw import (
+    LeeSutoTriaxialNFWPotential,
+    NFWPotential,
+    TriaxialNFWPotential,
     Vogelsberger08TriaxialNFWPotential,
 )
 from ._potential.composite import AbstractCompositePotential, CompositePotential

--- a/src/galax/potential/_potential/builtin/builtin.py
+++ b/src/galax/potential/_potential/builtin/builtin.py
@@ -53,6 +53,7 @@ class BarPotential(AbstractPotential):
     b: AbstractParameter = ParameterField(dimensions="length")  # type: ignore[assignment]
     c: AbstractParameter = ParameterField(dimensions="length")  # type: ignore[assignment]
     Omega: AbstractParameter = ParameterField(dimensions="frequency")  # type: ignore[assignment]
+
     _: KW_ONLY
     units: AbstractUnitSystem = eqx.field(converter=unitsystem, static=True)
     constants: ImmutableDict[Quantity] = eqx.field(
@@ -208,6 +209,12 @@ class KuzminPotential(AbstractPotential):
     a: AbstractParameter = ParameterField(dimensions="length")  # type: ignore[assignment]
     """Scale length."""
 
+    _: KW_ONLY
+    units: AbstractUnitSystem = eqx.field(converter=unitsystem, static=True)
+    constants: ImmutableDict[Quantity] = eqx.field(
+        default=default_constants, converter=ImmutableDict
+    )
+
     @partial(jax.jit)
     def _potential_energy(
         self: "KuzminPotential", q: gt.QVec3, t: gt.RealQScalar, /
@@ -230,6 +237,12 @@ class LogarithmicPotential(AbstractPotential):
 
     v_c: AbstractParameter = ParameterField(dimensions="speed")  # type: ignore[assignment]
     r_h: AbstractParameter = ParameterField(dimensions="length")  # type: ignore[assignment]
+
+    _: KW_ONLY
+    units: AbstractUnitSystem = eqx.field(converter=unitsystem, static=True)
+    constants: ImmutableDict[Quantity] = eqx.field(
+        default=default_constants, converter=ImmutableDict
+    )
 
     @partial(jax.jit)
     def _potential_energy(
@@ -302,7 +315,6 @@ class NullPotential(AbstractPotential):
     units: AbstractUnitSystem = eqx.field(
         default="galactic", converter=unitsystem, static=True
     )
-
     constants: ImmutableDict[Quantity] = eqx.field(
         default=default_constants, converter=ImmutableDict
     )
@@ -328,6 +340,12 @@ class PlummerPotential(AbstractPotential):
 
     m_tot: AbstractParameter = ParameterField(dimensions="mass")  # type: ignore[assignment]
     b: AbstractParameter = ParameterField(dimensions="length")  # type: ignore[assignment]
+
+    _: KW_ONLY
+    units: AbstractUnitSystem = eqx.field(converter=unitsystem, static=True)
+    constants: ImmutableDict[Quantity] = eqx.field(
+        default=default_constants, converter=ImmutableDict
+    )
 
     @partial(jax.jit)
     def _potential_energy(
@@ -371,6 +389,12 @@ class PowerLawCutoffPotential(AbstractPotential):
 
     r_c: AbstractParameter = ParameterField(dimensions="length")  # type: ignore[assignment]
     """Cutoff radius."""
+
+    _: KW_ONLY
+    units: AbstractUnitSystem = eqx.field(converter=unitsystem, static=True)
+    constants: ImmutableDict[Quantity] = eqx.field(
+        default=default_constants, converter=ImmutableDict
+    )
 
     @partial(jax.jit)
     def _potential_energy(
@@ -457,12 +481,9 @@ class TriaxialHernquistPotential(AbstractPotential):
 
     _: KW_ONLY
     units: AbstractUnitSystem = eqx.field(converter=unitsystem, static=True)
-    """The unit system to use for the potential."""
-
     constants: ImmutableDict[Quantity] = eqx.field(
         converter=ImmutableDict, default=default_constants
     )
-    """The constants used by the potential."""
 
     @partial(jax.jit)
     def _potential_energy(  # TODO: inputs w/ units

--- a/tests/unit/potential/builtin/test_triaxialnfw.py
+++ b/tests/unit/potential/builtin/test_triaxialnfw.py
@@ -1,0 +1,100 @@
+from typing import Any
+
+import astropy.units as u
+import pytest
+
+import quaxed.numpy as qnp
+from unxt import AbstractUnitSystem, Quantity
+
+import galax.potential as gp
+import galax.typing as gt
+from ..test_core import TestAbstractPotential as AbstractPotential_Test
+from .test_common import (
+    ParameterMMixin,
+    ParameterScaleRadiusMixin,
+    ParameterShapeQ1Mixin,
+    ParameterShapeQ2Mixin,
+)
+from galax.potential import AbstractPotentialBase, TriaxialNFWPotential
+
+
+class TestTriaxialNFWPotential(
+    AbstractPotential_Test,
+    # Parameters
+    ParameterMMixin,
+    ParameterScaleRadiusMixin,
+    ParameterShapeQ1Mixin,
+    ParameterShapeQ2Mixin,
+):
+    """Test the `galax.potential.TriaxialNFWPotential` class."""
+
+    @pytest.fixture(scope="class")
+    def pot_cls(self) -> type[gp.TriaxialNFWPotential]:
+        return gp.TriaxialNFWPotential
+
+    @pytest.fixture(scope="class")
+    def fields_(
+        self,
+        field_m: u.Quantity,
+        field_r_s: u.Quantity,
+        field_q1: u.Quantity,
+        field_q2: u.Quantity,
+        field_units: AbstractUnitSystem,
+    ) -> dict[str, Any]:
+        return {
+            "m": field_m,
+            "r_s": field_r_s,
+            "q1": field_q1,
+            "q2": field_q2,
+            "units": field_units,
+        }
+
+    # ==========================================================================
+
+    def test_potential_energy(self, pot: TriaxialNFWPotential, x: gt.Vec3) -> None:
+        expect = Quantity(-1.06475915, unit="kpc2 / Myr2")
+        assert qnp.isclose(
+            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+        )
+
+    def test_gradient(self, pot: TriaxialNFWPotential, x: gt.Vec3) -> None:
+        expect = Quantity([0.03189139, 0.0604938, 0.13157674], "kpc / Myr2")
+        assert qnp.allclose(
+            pot.gradient(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+        )
+
+    def test_density(self, pot: TriaxialNFWPotential, x: gt.Vec3) -> None:
+        expect = Quantity(2.32106514e08, "solMass / kpc3")
+        assert qnp.isclose(
+            pot.density(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+        )
+
+    def test_hessian(self, pot: TriaxialNFWPotential, x: gt.Vec3) -> None:
+        expect = Quantity(
+            [
+                [0.02774251, -0.00788965, -0.0165603],
+                [-0.00788965, 0.01521376, -0.03105306],
+                [-0.0165603, -0.03105306, -0.02983532],
+            ],
+            "1/Myr2",
+        )
+        assert qnp.allclose(
+            pot.hessian(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+        )
+
+    # ---------------------------------
+    # Convenience methods
+
+    def test_tidal_tensor(self, pot: AbstractPotentialBase, x: gt.Vec3) -> None:
+        """Test the `AbstractPotentialBase.tidal_tensor` method."""
+        expect = Quantity(
+            [
+                [0.02336886, -0.00788965, -0.0165603],
+                [-0.00788965, 0.01084011, -0.03105306],
+                [-0.0165603, -0.03105306, -0.03420897],
+            ],
+            "1/Myr2",
+        )
+        assert qnp.allclose(
+            pot.tidal_tensor(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+        )


### PR DESCRIPTION
Triaxial-in-the-density NFW potential, of the same type as https://docs.galpy.org/en/latest/reference/potentialtriaxialnfw.html.
The formalism is from 

```
@BOOK{1969efe..book.....C,
       author = {{Chandrasekhar}, Subrahmanyan},
        title = "{Ellipsoidal figures of equilibrium}",
         year = 1969,
       adsurl = {https://ui.adsabs.harvard.edu/abs/1969efe..book.....C},
      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
}
@ARTICLE{1996ApJ...460..136M,
       author = {{Merritt}, David and {Fridman}, Tema},
        title = "{Triaxial Galaxies with Cusps}",
      journal = {\apj},
     keywords = {CELESTIAL MECHANICS, STELLAR DYNAMICS, GALAXIES: KINEMATICS AND DYNAMICS, METHODS: NUMERICAL, Astrophysics},
         year = 1996,
        month = mar,
       volume = {460},
        pages = {136},
          doi = {10.1086/176957},
archivePrefix = {arXiv},
       eprint = {astro-ph/9511021},
 primaryClass = {astro-ph},
       adsurl = {https://ui.adsabs.harvard.edu/abs/1996ApJ...460..136M},
      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
}
```
