### PR TITLE
refactor: rename potential_energy to potential

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -66,7 +66,7 @@ we could compute the potential energy or the acceleration at a Cartesian
 position near the Sun::
 
     >>> xyz = [-8., 0, 0] * u.kpc
-    >>> mw.potential_energy(xyz, t=0).to_units("kpc2 / Myr2")
+    >>> mw.potential(xyz, t=0).to_units("kpc2 / Myr2")
     Quantity['specific energy'](Array(-0.16440296, dtype=float64), unit='kpc2 / Myr2')
     >>> mw.acceleration(xyz, t=0).to_units("kpc/Myr2")
     Quantity['acceleration'](Array([ 0.00702262, -0.        , -0.        ], dtype=float64), unit='kpc / Myr2')
@@ -77,7 +77,7 @@ with associated physical units. :class:`~astropy.units.Quantity` objects can be
 re-represented in any equivalent units, so, for example, we could display the
 energy or acceleration in other units::
 
-    >>> mw.potential_energy(xyz, t=0).to_units("kpc2/Myr2")
+    >>> mw.potential(xyz, t=0).to_units("kpc2/Myr2")
     Quantity['specific energy'](Array(-0.16440296, dtype=float64), unit='kpc2 / Myr2')
     >>> mw.acceleration(xyz, t=0).to_units("kpc/Myr2")
     Quantity['acceleration'](Array([ 0.00702262, -0.        , -0.        ], dtype=float64), unit='kpc / Myr2')

--- a/src/galax/coordinates/_psp/base.py
+++ b/src/galax/coordinates/_psp/base.py
@@ -491,7 +491,7 @@ class AbstractBasePhaseSpacePosition(eqx.Module, strict=True):  # type: ignore[c
         >>> w.potential_energy(pot)
         Quantity['specific energy'](Array(..., dtype=float64), unit='kpc2 / Myr2')
         """
-        return potential.potential_energy(self.q, t=self.t)
+        return potential.potential(self.q, t=self.t)
 
     @partial(jax.jit)
     def total_energy(self, potential: "AbstractPotentialBase") -> gt.BatchFloatQScalar:

--- a/src/galax/dynamics/_dynamics/base.py
+++ b/src/galax/dynamics/_dynamics/base.py
@@ -116,8 +116,8 @@ class AbstractOrbit(gc.AbstractPhaseSpacePosition):
             The specific potential energy.
         """
         if potential is None:
-            return self.potential.potential_energy(self.q, t=self.t)
-        return potential.potential_energy(self.q, t=self.t)
+            return self.potential.potential(self.q, t=self.t)
+        return potential.potential(self.q, t=self.t)
 
     @partial(jax.jit)
     def total_energy(

--- a/src/galax/potential/__init__.pyi
+++ b/src/galax/potential/__init__.pyi
@@ -43,7 +43,7 @@ __all__ = [
     # frame
     "PotentialFrame",
     # funcs
-    "potential_energy",
+    "potential",
     "gradient",
     "laplacian",
     "density",
@@ -102,7 +102,7 @@ from ._potential.funcs import (
     gradient,
     hessian,
     laplacian,
-    potential_energy,
+    potential,
     tidal_tensor,
 )
 from ._potential.param import (

--- a/src/galax/potential/_potential/base.py
+++ b/src/galax/potential/_potential/base.py
@@ -122,7 +122,7 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
     # @partial(jax.jit)
     # @vectorize_method(signature="(3),()->()")
     @abc.abstractmethod
-    def _potential_energy(
+    def _potential(
         self, q: gt.QVec3, t: gt.RealQScalar, /
     ) -> Shaped[Quantity["specific energy"], ""]:
         """Compute the potential energy at the given position(s).
@@ -130,7 +130,7 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
         This method MUST be implemented by subclasses.
 
         It is recommended to both JIT and vectorize this function.
-        See ``AbstractPotentialBase.potential_energy`` for an example.
+        See ``AbstractPotentialBase.potential`` for an example.
 
         Parameters
         ----------
@@ -148,16 +148,16 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
         """
         raise NotImplementedError
 
-    def potential_energy(
+    def potential(
         self: "AbstractPotentialBase", *args: Any, **kwargs: Any
     ) -> Quantity["specific energy"]:  # TODO: shape hint
         """Compute the potential energy at the given position(s).
 
-        See :func:`~galax.potential.potential_energy` for details.
+        See :func:`~galax.potential.potential` for details.
         """
-        from .funcs import potential_energy
+        from .funcs import potential
 
-        return potential_energy(self, *args, **kwargs)
+        return potential(self, *args, **kwargs)
 
     @partial(jax.jit)
     def __call__(
@@ -179,9 +179,9 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
 
         See Also
         --------
-        :meth:`galax.potential.AbstractPotentialBase.potential_energy`
+        :meth:`galax.potential.AbstractPotentialBase.potential`
         """
-        return self.potential_energy(q, t)
+        return self.potential(q, t)
 
     # ---------------------------------------
     # Gradient
@@ -191,7 +191,7 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
     def _gradient(self, q: gt.BatchQVec3, /, t: gt.RealQScalar) -> gt.BatchQVec3:
         """See ``gradient``."""
         grad_op = unxt.experimental.grad(
-            self._potential_energy, units=(self.units["length"], self.units["time"])
+            self._potential, units=(self.units["length"], self.units["time"])
         )
         return grad_op(q, t)
 
@@ -259,7 +259,7 @@ class AbstractPotentialBase(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
     def _hessian(self, q: gt.QVec3, /, t: gt.RealQScalar) -> QMatrix33:
         """See ``hessian``."""
         hess_op = unxt.experimental.hessian(
-            self._potential_energy, units=(self.units["length"], self.units["time"])
+            self._potential, units=(self.units["length"], self.units["time"])
         )
         return hess_op(q, t)
 

--- a/src/galax/potential/_potential/builtin/bars.py
+++ b/src/galax/potential/_potential/builtin/bars.py
@@ -52,7 +52,7 @@ class BarPotential(AbstractPotential):
     @quaxify  # type: ignore[misc]
     @partial(jax.jit)
     @vectorize_method(signature="(3),()->()")
-    def _potential_energy(self, q: gt.QVec3, t: gt.RealQScalar, /) -> gt.FloatQScalar:
+    def _potential(self, q: gt.QVec3, t: gt.RealQScalar, /) -> gt.FloatQScalar:
         ## First take the simulation frame coordinates and rotate them by Omega*t
         ang = -self.Omega(t) * t
         rotation_matrix = xp.asarray(
@@ -103,7 +103,7 @@ class LongMuraliBarPotential(AbstractPotential):
     alpha: AbstractParameter = ParameterField(dimensions="angle")  # type: ignore[assignment]
 
     @partial(jax.jit)
-    def _potential_energy(
+    def _potential(
         self, q: gt.BatchQVec3, t: gt.BatchableRealQScalar, /
     ) -> gt.BatchFloatQScalar:
         m_tot = self.m_tot(t)

--- a/src/galax/potential/_potential/builtin/builtin.py
+++ b/src/galax/potential/_potential/builtin/builtin.py
@@ -69,7 +69,7 @@ class BurkertPotential(AbstractPotential):
     )
 
     @partial(jax.jit)
-    def _potential_energy(
+    def _potential(
         self, q: gt.BatchQVec3, t: gt.BatchableRealQScalar, /
     ) -> gt.BatchFloatQScalar:
         m, r_s = self.m(t), self.r_s(t)
@@ -173,7 +173,7 @@ class HernquistPotential(AbstractPotential):
     )
 
     @partial(jax.jit)
-    def _potential_energy(
+    def _potential(
         self, q: gt.BatchQVec3, t: gt.BatchableRealQScalar, /
     ) -> gt.BatchFloatQScalar:
         r = xp.linalg.vector_norm(q, axis=-1)
@@ -219,7 +219,7 @@ class IsochronePotential(AbstractPotential):
     )
 
     @partial(jax.jit)
-    def _potential_energy(  # TODO: inputs w/ units
+    def _potential(  # TODO: inputs w/ units
         self, q: gt.BatchQVec3, t: gt.BatchableRealQScalar, /
     ) -> gt.BatchFloatQScalar:
         r = xp.linalg.vector_norm(q, axis=-1)
@@ -238,7 +238,7 @@ class JaffePotential(AbstractPotential):
     r_s: AbstractParameter = ParameterField(dimensions="length")  # type: ignore[assignment]
 
     @partial(jax.jit)
-    def _potential_energy(
+    def _potential(
         self, q: gt.BatchQVec3, t: gt.BatchableRealQScalar, /
     ) -> gt.BatchFloatQScalar:
         r = xp.linalg.vector_norm(q, axis=-1)
@@ -268,7 +268,7 @@ class KeplerPotential(AbstractPotential):
     )
 
     @partial(jax.jit)
-    def _potential_energy(  # TODO: inputs w/ units
+    def _potential(  # TODO: inputs w/ units
         self, q: gt.BatchQVec3, t: gt.BatchableRealQScalar, /
     ) -> gt.BatchFloatQScalar:
         r = xp.linalg.vector_norm(q, axis=-1)
@@ -319,7 +319,7 @@ class KuzminPotential(AbstractPotential):
     )
 
     @partial(jax.jit)
-    def _potential_energy(
+    def _potential(
         self: "KuzminPotential", q: gt.QVec3, t: gt.RealQScalar, /
     ) -> gt.FloatQScalar:
         return (
@@ -348,7 +348,7 @@ class LogarithmicPotential(AbstractPotential):
     )
 
     @partial(jax.jit)
-    def _potential_energy(
+    def _potential(
         self, q: gt.BatchQVec3, t: gt.BatchableRealQScalar, /
     ) -> gt.BatchFloatQScalar:
         r2 = xp.linalg.vector_norm(q, axis=-1).to_value(self.units["length"]) ** 2
@@ -383,7 +383,7 @@ class MiyamotoNagaiPotential(AbstractPotential):
     )
 
     @partial(jax.jit)
-    def _potential_energy(
+    def _potential(
         self: "MiyamotoNagaiPotential", q: gt.QVec3, t: gt.RealQScalar, /
     ) -> gt.FloatQScalar:
         R2 = q[..., 0] ** 2 + q[..., 1] ** 2
@@ -409,7 +409,7 @@ class NullPotential(AbstractPotential):
 
     >>> q = Quantity([1, 0, 0], "kpc")
     >>> t = Quantity(0, "Gyr")
-    >>> pot.potential_energy(q, t)
+    >>> pot.potential(q, t)
     Quantity['specific energy'](Array(0, dtype=int64), unit='kpc2 / Myr2')
 
     """
@@ -423,7 +423,7 @@ class NullPotential(AbstractPotential):
     )
 
     @partial(jax.jit)
-    def _potential_energy(  # TODO: inputs w/ units
+    def _potential(  # TODO: inputs w/ units
         self,
         q: gt.BatchQVec3,
         t: gt.BatchableRealQScalar,  # noqa: ARG002
@@ -481,7 +481,7 @@ class PlummerPotential(AbstractPotential):
     )
 
     @partial(jax.jit)
-    def _potential_energy(
+    def _potential(
         self, q: gt.BatchQVec3, t: gt.BatchableRealQScalar, /
     ) -> gt.BatchFloatQScalar:
         r2 = xp.linalg.vector_norm(q, axis=-1) ** 2
@@ -530,7 +530,7 @@ class PowerLawCutoffPotential(AbstractPotential):
     )
 
     @partial(jax.jit)
-    def _potential_energy(
+    def _potential(
         self, q: gt.BatchQVec3, t: gt.BatchableRealQScalar, /
     ) -> gt.BatchFloatQScalar:
         m, a, r_c = self.m_tot(t), 0.5 * self.alpha(t), self.r_c(t)
@@ -572,7 +572,7 @@ class SatohPotential(AbstractPotential):
     b: AbstractParameter = ParameterField(dimensions="length")  # type: ignore[assignment]
 
     @partial(jax.jit)
-    def _potential_energy(
+    def _potential(
         self, q: gt.BatchQVec3, t: gt.BatchableRealQScalar, /
     ) -> gt.BatchFloatQScalar:
         a, b = self.a(t), self.b(t)
@@ -617,7 +617,7 @@ class StoneOstriker15Potential(AbstractPotential):
     #     _ = eqx.error_if(self.r_c, self.r_c.value >= self.r_h.value, "Core radius must be less than halo radius")   # noqa: E501, ERA001
 
     @partial(jax.jit)
-    def _potential_energy(
+    def _potential(
         self, q: gt.BatchQVec3, t: gt.BatchableRealQScalar, /
     ) -> gt.BatchFloatQScalar:
         r_h = self.r_h(t)
@@ -677,7 +677,7 @@ class TriaxialHernquistPotential(AbstractPotential):
 
     >>> q = Quantity([1, 0, 0], "kpc")
     >>> t = Quantity(0, "Gyr")
-    >>> pot.potential_energy(q, t)
+    >>> pot.potential(q, t)
     Quantity['specific energy'](Array(-0.49983357, dtype=float64), unit='kpc2 / Myr2')
     """
 
@@ -707,7 +707,7 @@ class TriaxialHernquistPotential(AbstractPotential):
     )
 
     @partial(jax.jit)
-    def _potential_energy(  # TODO: inputs w/ units
+    def _potential(  # TODO: inputs w/ units
         self, q: gt.BatchQVec3, t: gt.BatchableRealQScalar, /
     ) -> gt.BatchFloatQScalar:
         r_s, q1, q2 = self.r_s(t), self.q1(t), self.q2(t)

--- a/src/galax/potential/_potential/builtin/logarithmic.py
+++ b/src/galax/potential/_potential/builtin/logarithmic.py
@@ -36,7 +36,7 @@ class LogarithmicPotential(AbstractPotential):
     )
 
     @partial(jax.jit)
-    def _potential_energy(
+    def _potential(
         self, q: gt.BatchQVec3, t: gt.BatchableRealQScalar, /
     ) -> gt.BatchFloatQScalar:
         r2 = xp.linalg.vector_norm(q, axis=-1).to_value(self.units["length"]) ** 2
@@ -70,7 +70,7 @@ class LMJ09LogarithmicPotential(AbstractPotential):
     )
 
     @partial(jax.jit)
-    def _potential_energy(
+    def _potential(
         self, q: gt.BatchQVec3, t: gt.BatchableRealQScalar, /
     ) -> gt.BatchFloatQScalar:
         # Load parameters

--- a/src/galax/potential/_potential/builtin/nfw.py
+++ b/src/galax/potential/_potential/builtin/nfw.py
@@ -56,7 +56,7 @@ class NFWPotential(AbstractPotential):
     )
 
     @partial(jax.jit)
-    def _potential_energy(  # TODO: inputs w/ units
+    def _potential(  # TODO: inputs w/ units
         self, q: gt.BatchQVec3, t: gt.BatchableRealQScalar, /
     ) -> gt.BatchFloatQScalar:
         r"""Potential energy.
@@ -115,15 +115,15 @@ class LeeSutoTriaxialNFWPotential(AbstractPotential):
 
     >>> q = Quantity([1, 0, 0], "kpc")
     >>> t = Quantity(0, "Gyr")
-    >>> pot.potential_energy(q, t).decompose(pot.units)
+    >>> pot.potential(q, t).decompose(pot.units)
     Quantity['specific energy'](Array(-0.14620419, dtype=float64), unit='kpc2 / Myr2')
 
     >>> q = Quantity([0, 1, 0], "kpc")
-    >>> pot.potential_energy(q, t).decompose(pot.units)
+    >>> pot.potential(q, t).decompose(pot.units)
     Quantity['specific energy'](Array(-0.14593972, dtype=float64), unit='kpc2 / Myr2')
 
     >>> q = Quantity([0, 0, 1], "kpc")
-    >>> pot.potential_energy(q, t).decompose(pot.units)
+    >>> pot.potential(q, t).decompose(pot.units)
     Quantity['specific energy'](Array(-0.14570309, dtype=float64), unit='kpc2 / Myr2')
     """
 
@@ -170,7 +170,7 @@ class LeeSutoTriaxialNFWPotential(AbstractPotential):
         )
 
     @partial(jax.jit)
-    def _potential_energy(  # TODO: inputs w/ units
+    def _potential(  # TODO: inputs w/ units
         self, q: gt.BatchQVec3, t: gt.BatchableRealQScalar, /
     ) -> gt.BatchFloatQScalar:
         # https://github.com/adrn/gala/blob/2067009de41518a71c674d0252bc74a7b2d78a36/gala/potential/potential/builtin/builtin_potentials.c#L1472
@@ -326,7 +326,7 @@ class TriaxialNFWPotential(AbstractPotential):
         )
 
     @partial(jax.jit)
-    def _potential_energy(
+    def _potential(
         self,
         q: gt.BatchQVec3,
         t: gt.BatchableRealQScalar,
@@ -478,7 +478,7 @@ class Vogelsberger08TriaxialNFWPotential(AbstractPotential):
         return (r_a + r) * r_e / (r_a + r_e)
 
     @partial(jax.jit)
-    def _potential_energy(
+    def _potential(
         self: "Vogelsberger08TriaxialNFWPotential", q: gt.QVec3, t: gt.RealQScalar, /
     ) -> gt.FloatQScalar:
         r = self._r_tilde(q, t)

--- a/src/galax/potential/_potential/composite.py
+++ b/src/galax/potential/_potential/composite.py
@@ -59,12 +59,12 @@ class AbstractCompositePotential(
     # === Potential ===
 
     @partial(jax.jit)
-    def _potential_energy(  # TODO: inputs w/ units
+    def _potential(  # TODO: inputs w/ units
         self, q: gt.BatchQVec3, t: gt.BatchableRealQScalar, /
     ) -> gt.BatchFloatQScalar:
         return xp.sum(
             xp.asarray(
-                [p._potential_energy(q, t) for p in self.values()]  # noqa: SLF001
+                [p._potential(q, t) for p in self.values()]  # noqa: SLF001
             ),
             axis=0,
         )

--- a/src/galax/potential/_potential/core.py
+++ b/src/galax/potential/_potential/core.py
@@ -32,7 +32,7 @@ class AbstractPotential(AbstractPotentialBase, strict=True):
 
     # TODO: inputs w/ units
     @abc.abstractmethod
-    def _potential_energy(self, q: gt.QVec3, t: gt.RealScalar, /) -> gt.FloatQScalar:
+    def _potential(self, q: gt.QVec3, t: gt.RealScalar, /) -> gt.FloatQScalar:
         raise NotImplementedError
 
     ###########################################################################

--- a/src/galax/potential/_potential/frame.py
+++ b/src/galax/potential/_potential/frame.py
@@ -64,10 +64,10 @@ class PotentialFrame(AbstractPotentialBase):
     >>> op1
     GalileanSpatialTranslationOperator( translation=Cartesian3DVector( ... ) )
 
-    >>> framedpot1 = gp.PotentialFrame(potential=pot, operator=op1)
+    >>> framedpot1 = gp.PotentialFrame(original_potential=pot, operator=op1)
     >>> framedpot1
     PotentialFrame(
-      potential=TriaxialHernquistPotential( ... ),
+      original_potential=TriaxialHernquistPotential( ... ),
       operator=OperatorSequence(
         operators=( GalileanSpatialTranslationOperator( ... ), )
       )
@@ -91,7 +91,7 @@ class PotentialFrame(AbstractPotentialBase):
     >>> op2.translation.t.to_units("Myr")
     Quantity['time'](Array(3.26156366, dtype=float64), unit='Myr')
 
-    >>> framedpot2 = gp.PotentialFrame(potential=pot, operator=op2)
+    >>> framedpot2 = gp.PotentialFrame(original_potential=pot, operator=op2)
 
     We can see that the potential energy is the same as before, since we have
     been evaluating the potential at ``w1.t=t=0``:
@@ -113,7 +113,7 @@ class PotentialFrame(AbstractPotentialBase):
     >>> op3
     GalileanBoostOperator( velocity=CartesianDifferential3D( ... ) )
 
-    >>> framedpot3 = gp.PotentialFrame(potential=pot, operator=op3)
+    >>> framedpot3 = gp.PotentialFrame(original_potential=pot, operator=op3)
     >>> framedpot3.potential(w2)
     Quantity['specific energy'](Array(-1.37421204, dtype=float64), unit='kpc2 / Myr2')
 
@@ -128,7 +128,7 @@ class PotentialFrame(AbstractPotentialBase):
     >>> op4
     GalileanRotationOperator(rotation=f64[3,3])
 
-    >>> framedpot4 = gp.PotentialFrame(potential=pot, operator=op4)
+    >>> framedpot4 = gp.PotentialFrame(original_potential=pot, operator=op4)
     >>> framedpot4.potential(w1)
     Quantity['specific energy'](Array(-1.49950072, dtype=float64), unit='kpc2 / Myr2')
 
@@ -152,7 +152,7 @@ class PotentialFrame(AbstractPotentialBase):
       velocity=GalileanBoostOperator( ... )
     )
 
-    >>> framedpot5 = gp.PotentialFrame(potential=pot, operator=op5)
+    >>> framedpot5 = gp.PotentialFrame(original_potential=pot, operator=op5)
     >>> framedpot5.potential(w2)
     Quantity['specific energy'](Array(-1.16598068, dtype=float64), unit='kpc2 / Myr2')
 
@@ -160,7 +160,7 @@ class PotentialFrame(AbstractPotentialBase):
     will make a sequence that mimics the previous example:
 
     >>> op6 = op4 | op2 | op3
-    >>> framedpot6 = gp.PotentialFrame(potential=pot, operator=op6)
+    >>> framedpot6 = gp.PotentialFrame(original_potential=pot, operator=op6)
     >>> framedpot6.potential(w2)
     Quantity['specific energy'](Array(-1.16598068, dtype=float64), unit='kpc2 / Myr2')
 
@@ -174,7 +174,7 @@ class PotentialFrame(AbstractPotentialBase):
     ...     r_s=Quantity(1, "kpc"), q1=0.1, q2=0.1, units="galactic")
 
     >>> op7 = gc.operators.ConstantRotationZOperator(Omega_z=Quantity(90, "deg/Gyr"))
-    >>> framedpot7 = gp.PotentialFrame(potential=pot2, operator=op7)
+    >>> framedpot7 = gp.PotentialFrame(original_potential=pot2, operator=op7)
 
     The potential energy at a given position will change with time:
 
@@ -184,7 +184,7 @@ class PotentialFrame(AbstractPotentialBase):
     Array(-2.23568166, dtype=float64)
     """  # noqa: E501
 
-    potential: AbstractPotentialBase
+    original_potential: AbstractPotentialBase
 
     operator: OperatorSequence = eqx.field(default=(), converter=OperatorSequence)
     """Transformation to reference frame of the potential.
@@ -196,12 +196,12 @@ class PotentialFrame(AbstractPotentialBase):
     @property
     def units(self) -> AbstractUnitSystem:
         """The unit system of the potential."""
-        return cast(AbstractUnitSystem, self.potential.units)
+        return cast(AbstractUnitSystem, self.original_potential.units)
 
     @property
     def constants(self) -> ImmutableDict[Quantity]:
         """The constants of the potential."""
-        return cast("ImmutableDict[Quantity]", self.potential.constants)
+        return cast("ImmutableDict[Quantity]", self.original_potential.constants)
 
     def _potential(
         self, q: gt.BatchQVec3, t: gt.BatchableRealQScalar, /
@@ -228,7 +228,7 @@ class PotentialFrame(AbstractPotentialBase):
         # Transform the position, time.
         qp, tp = inv(q, t)
         # Evaluate the potential energy at the transformed position, time.
-        return self.potential._potential(qp, tp)  # noqa: SLF001
+        return self.original_potential._potential(qp, tp)  # noqa: SLF001
 
     # ruff: noqa: ERA001
     # def _gradient(

--- a/src/galax/potential/_potential/frame.py
+++ b/src/galax/potential/_potential/frame.py
@@ -47,15 +47,15 @@ class PotentialFrame(AbstractPotentialBase):
 
     The triaxiality can be seen in the potential energy of the three positions:
 
-    >>> pot.potential_energy(w1)
+    >>> pot.potential(w1)
     Quantity['specific energy'](Array(-2.24925108, dtype=float64), unit='kpc2 / Myr2')
 
     >>> q = Quantity([0, 1, 0], "kpc")
-    >>> pot.potential_energy(q, t)
+    >>> pot.potential(q, t)
     Quantity['specific energy'](Array(-2.24925108, dtype=float64), unit='kpc2 / Myr2')
 
     >>> q = Quantity([0, 0, 1], "kpc")
-    >>> pot.potential_energy(q, t)
+    >>> pot.potential(q, t)
     Quantity['specific energy'](Array(-1.49950072, dtype=float64), unit='kpc2 / Myr2')
 
     Let's apply a spatial translation to the potential:
@@ -76,13 +76,13 @@ class PotentialFrame(AbstractPotentialBase):
     Now the potential energy is different because the potential has been
     translated by 3 kpc in the x-direction:
 
-    >>> framedpot1.potential_energy(w1)
+    >>> framedpot1.potential(w1)
     Quantity['specific energy'](Array(-1.49950072, dtype=float64), unit='kpc2 / Myr2')
 
     This is the same as evaluating the untranslated potential at [-2, 0, 0] kpc:
 
     >>> q = Quantity([-2, 0, 0], "kpc")
-    >>> pot.potential_energy(q, Quantity(0, "Gyr"))
+    >>> pot.potential(q, Quantity(0, "Gyr"))
     Quantity['specific energy'](Array(-1.49950072, dtype=float64), unit='kpc2 / Myr2')
 
     We can also apply a time translation to the potential:
@@ -96,7 +96,7 @@ class PotentialFrame(AbstractPotentialBase):
     We can see that the potential energy is the same as before, since we have
     been evaluating the potential at ``w1.t=t=0``:
 
-    >>> framedpot2.potential_energy(w1)
+    >>> framedpot2.potential(w1)
     Quantity['specific energy'](Array(-2.24851747, dtype=float64), unit='kpc2 / Myr2')
 
     But if we evaluate the potential at a different time, the potential energy
@@ -104,7 +104,7 @@ class PotentialFrame(AbstractPotentialBase):
 
     >>> from dataclasses import replace
     >>> w2 = replace(w1, t=Quantity(10, "Myr"))
-    >>> framedpot2.potential_energy(w2)
+    >>> framedpot2.potential(w2)
     Quantity['specific energy'](Array(-2.25076672, dtype=float64), unit='kpc2 / Myr2')
 
     Now let's boost the potential by 200 km/s in the y-direction:
@@ -114,7 +114,7 @@ class PotentialFrame(AbstractPotentialBase):
     GalileanBoostOperator( velocity=CartesianDifferential3D( ... ) )
 
     >>> framedpot3 = gp.PotentialFrame(potential=pot, operator=op3)
-    >>> framedpot3.potential_energy(w2)
+    >>> framedpot3.potential(w2)
     Quantity['specific energy'](Array(-1.37421204, dtype=float64), unit='kpc2 / Myr2')
 
     Alternatively we can rotate the potential by 90 degrees about the y-axis:
@@ -129,11 +129,11 @@ class PotentialFrame(AbstractPotentialBase):
     GalileanRotationOperator(rotation=f64[3,3])
 
     >>> framedpot4 = gp.PotentialFrame(potential=pot, operator=op4)
-    >>> framedpot4.potential_energy(w1)
+    >>> framedpot4.potential(w1)
     Quantity['specific energy'](Array(-1.49950072, dtype=float64), unit='kpc2 / Myr2')
 
     >>> q = Quantity([0, 0, 1], "kpc")
-    >>> framedpot4.potential_energy(q, t)
+    >>> framedpot4.potential(q, t)
     Quantity['specific energy'](Array(-2.24925108, dtype=float64), unit='kpc2 / Myr2')
 
     If you look all the way back to the first examples, you will see that the
@@ -153,7 +153,7 @@ class PotentialFrame(AbstractPotentialBase):
     )
 
     >>> framedpot5 = gp.PotentialFrame(potential=pot, operator=op5)
-    >>> framedpot5.potential_energy(w2)
+    >>> framedpot5.potential(w2)
     Quantity['specific energy'](Array(-1.16598068, dtype=float64), unit='kpc2 / Myr2')
 
     The second way is to create a custom sequence of operators. In this case we
@@ -161,7 +161,7 @@ class PotentialFrame(AbstractPotentialBase):
 
     >>> op6 = op4 | op2 | op3
     >>> framedpot6 = gp.PotentialFrame(potential=pot, operator=op6)
-    >>> framedpot6.potential_energy(w2)
+    >>> framedpot6.potential(w2)
     Quantity['specific energy'](Array(-1.16598068, dtype=float64), unit='kpc2 / Myr2')
 
     We've seen that the potential can be time-dependent, but so far the
@@ -178,9 +178,9 @@ class PotentialFrame(AbstractPotentialBase):
 
     The potential energy at a given position will change with time:
 
-    >>> framedpot7.potential_energy(w1).value  # t=0 Gyr
+    >>> framedpot7.potential(w1).value  # t=0 Gyr
     Array(-2.24925108, dtype=float64)
-    >>> framedpot7.potential_energy(w2).value  # t=1 Gyr
+    >>> framedpot7.potential(w2).value  # t=1 Gyr
     Array(-2.23568166, dtype=float64)
     """  # noqa: E501
 
@@ -203,7 +203,7 @@ class PotentialFrame(AbstractPotentialBase):
         """The constants of the potential."""
         return cast("ImmutableDict[Quantity]", self.potential.constants)
 
-    def _potential_energy(
+    def _potential(
         self, q: gt.BatchQVec3, t: gt.BatchableRealQScalar, /
     ) -> gt.BatchFloatQScalar:
         """Compute the potential energy at the given position(s).
@@ -228,7 +228,7 @@ class PotentialFrame(AbstractPotentialBase):
         # Transform the position, time.
         qp, tp = inv(q, t)
         # Evaluate the potential energy at the transformed position, time.
-        return self.potential._potential_energy(qp, tp)  # noqa: SLF001
+        return self.potential._potential(qp, tp)  # noqa: SLF001
 
     # ruff: noqa: ERA001
     # def _gradient(

--- a/src/galax/potential/_potential/funcs.py
+++ b/src/galax/potential/_potential/funcs.py
@@ -1,7 +1,7 @@
 """galax: Galactic Dynamix in Jax."""
 
 __all__ = [
-    "potential_energy",
+    "potential",
     "gradient",
     "laplacian",
     "density",
@@ -56,7 +56,7 @@ TimeOptions: TypeAlias = (
 
 
 @dispatch  # type: ignore[misc]
-def potential_energy(
+def potential(
     potential: AbstractPotentialBase,
     pspt: gc.AbstractPhaseSpacePosition | cx.FourVector,
     /,
@@ -92,7 +92,7 @@ def potential_energy(
     ...                           p=Quantity([4, 5, 6], "km/s"),
     ...                           t=Quantity(0, "Gyr"))
 
-    >>> pot.potential_energy(w)
+    >>> pot.potential(w)
     Quantity['specific energy'](Array(-1.20227527, dtype=float64), unit='kpc2 / Myr2')
 
     We can also compute the potential energy at multiple positions and times:
@@ -100,7 +100,7 @@ def potential_energy(
     >>> w = gc.PhaseSpacePosition(q=Quantity([[1, 2, 3], [4, 5, 6]], "kpc"),
     ...                           p=Quantity([[4, 5, 6], [7, 8, 9]], "km/s"),
     ...                           t=Quantity([0, 1], "Gyr"))
-    >>> pot.potential_energy(w)
+    >>> pot.potential(w)
     Quantity['specific energy'](Array([-1.20227527, -0.5126519 ], dtype=float64), unit='kpc2 / Myr2')
 
     Instead of passing a
@@ -109,18 +109,18 @@ def potential_energy(
 
     >>> from coordinax import FourVector
     >>> w = FourVector(q=Quantity([1, 2, 3], "kpc"), t=Quantity(0, "Gyr"))
-    >>> pot.potential_energy(w)
+    >>> pot.potential(w)
     Quantity['specific energy'](Array(-1.20227527, dtype=float64), unit='kpc2 / Myr2')
     """  # noqa: E501
     q = _convert_from_3dvec(pspt.q, units=potential.units)
-    return potential._potential_energy(q, pspt.t)  # noqa: SLF001
+    return potential._potential(q, pspt.t)  # noqa: SLF001
 
 
-_potential_energy = potential_energy  # Needed to bypass namespace restrictions
+_potential = potential  # Needed to bypass namespace restrictions
 
 
 @dispatch
-def potential_energy(
+def potential(
     potential: AbstractPotentialBase, q: PositionalLike, /, t: TimeOptions
 ) -> Quantity["specific energy"]:  # TODO: shape hint
     """Compute the potential energy at the given position(s).
@@ -149,13 +149,13 @@ def potential_energy(
 
     >>> q = cx.Cartesian3DVector.constructor(Quantity([1, 2, 3], "kpc"))
     >>> t = Quantity(0, "Gyr")
-    >>> pot.potential_energy(q, t)
+    >>> pot.potential(q, t)
     Quantity['specific energy'](Array(-1.20227527, dtype=float64), unit='kpc2 / Myr2')
 
     We can also compute the potential energy at multiple positions:
 
     >>> q = cx.Cartesian3DVector.constructor(Quantity([[1, 2, 3], [4, 5, 6]], "kpc"))
-    >>> pot.potential_energy(q, t)
+    >>> pot.potential(q, t)
     Quantity['specific energy'](Array([-1.20227527, -0.5126519 ], dtype=float64), unit='kpc2 / Myr2')
 
     Instead of passing a :class:`~vector.Abstract3DVector` (in this case a
@@ -164,7 +164,7 @@ def potential_energy(
     position:
 
     >>> q = Quantity([1., 2, 3], "kpc")
-    >>> pot.potential_energy(q, t)
+    >>> pot.potential(q, t)
     Quantity['specific energy'](Array(-1.20227527, dtype=float64), unit='kpc2 / Myr2')
 
     Again, this can be batched.  If the input position object has no units
@@ -173,16 +173,16 @@ def potential_energy(
 
     >>> import jax.numpy as jnp
     >>> q = jnp.asarray([[1, 2, 3], [4, 5, 6]])
-    >>> pot.potential_energy(q, t)
+    >>> pot.potential(q, t)
     Quantity['specific energy'](Array([-1.20227527, -0.5126519 ], dtype=float64), unit='kpc2 / Myr2')
     """  # noqa: E501
     q = parse_to_quantity(q, unit=potential.units["length"])
     t = Quantity.constructor(t, potential.units["time"])
-    return potential._potential_energy(q, t)  # noqa: SLF001
+    return potential._potential(q, t)  # noqa: SLF001
 
 
 @dispatch
-def potential_energy(
+def potential(
     potential: AbstractPotentialBase, q: PositionalLike, /, *, t: TimeOptions
 ) -> Quantity["specific energy"]:  # TODO: shape hint
     """Compute the potential energy when `t` is keyword-only.
@@ -201,16 +201,16 @@ def potential_energy(
 
     >>> q = cx.Cartesian3DVector.constructor(Quantity([1, 2, 3], "kpc"))
     >>> t = Quantity(0, "Gyr")
-    >>> pot.potential_energy(q, t=t)
+    >>> pot.potential(q, t=t)
     Quantity['specific energy'](Array(-1.20227527, dtype=float64), unit='kpc2 / Myr2')
 
     See the other examples in the positional-only case.
     """
-    return _potential_energy(potential, q, t)
+    return _potential(potential, q, t)
 
 
 @dispatch
-def potential_energy(
+def potential(
     potential: AbstractPotentialBase,
     q: APYRepresentation | APYQuantity | np.ndarray,
     /,
@@ -218,7 +218,7 @@ def potential_energy(
 ) -> Quantity["specific energy"]:  # TODO: shape hint
     """Compute the potential energy at the given position(s).
 
-    :meth:`~galax.potential.AbstractPotentialBase.potential_energy` also
+    :meth:`~galax.potential.AbstractPotentialBase.potential` also
     supports Astropy objects, like
     :class:`astropy.coordinates.BaseRepresentation` and
     :class:`astropy.units.Quantity`, which are interpreted like their jax'ed
@@ -239,13 +239,13 @@ def potential_energy(
 
     >>> q = c.CartesianRepresentation([1, 2, 3], unit=u.kpc)
     >>> t = u.Quantity(0, "Gyr")
-    >>> pot.potential_energy(q, t)
+    >>> pot.potential(q, t)
     Quantity['specific energy'](Array(-1.20227527, dtype=float64), unit='kpc2 / Myr2')
 
     We can also compute the potential energy at multiple positions:
 
     >>> q = c.CartesianRepresentation(x=[1, 2], y=[4, 5], z=[7, 8], unit=u.kpc)
-    >>> pot.potential_energy(q, t)
+    >>> pot.potential(q, t)
     Quantity['specific energy'](Array([-0.55372734, -0.46647294], dtype=float64), unit='kpc2 / Myr2')
 
     Instead of passing a
@@ -254,7 +254,7 @@ def potential_energy(
     interpreted as a Cartesian position:
 
     >>> q = u.Quantity([1, 2, 3], "kpc")
-    >>> pot.potential_energy(q, t)
+    >>> pot.potential(q, t)
     Quantity['specific energy'](Array(-1.20227527, dtype=float64), unit='kpc2 / Myr2')
 
     Again, this can be batched.  Also, If the input position object has no
@@ -262,16 +262,16 @@ def potential_energy(
     unit system as the potential.
 
     >>> q = np.array([[1, 2, 3], [4, 5, 6]])
-    >>> pot.potential_energy(q, t)
+    >>> pot.potential(q, t)
     Quantity['specific energy'](Array([-1.20227527, -0.5126519 ], dtype=float64), unit='kpc2 / Myr2')
     """  # noqa: E501
     q = parse_to_quantity(q, unit=potential.units["length"])
     t = Quantity.constructor(t, potential.units["time"])
-    return potential._potential_energy(q, t)  # noqa: SLF001
+    return potential._potential(q, t)  # noqa: SLF001
 
 
 @dispatch
-def potential_energy(
+def potential(
     potential: AbstractPotentialBase,
     q: APYRepresentation | APYQuantity | np.ndarray,
     /,
@@ -294,12 +294,12 @@ def potential_energy(
 
     >>> q = c.CartesianRepresentation([1, 2, 3], unit=u.kpc)
     >>> t = u.Quantity(0, "Gyr")
-    >>> pot.potential_energy(q, t=t)
+    >>> pot.potential(q, t=t)
     Quantity['specific energy'](Array(-1.20227527, dtype=float64), unit='kpc2 / Myr2')
 
     See the other examples in the positional-only case.
     """
-    return _potential_energy(potential, q, t)
+    return _potential(potential, q, t)
 
 
 # =============================================================================

--- a/src/galax/potential/_potential/param/field.py
+++ b/src/galax/potential/_potential/param/field.py
@@ -91,7 +91,7 @@ class ParameterField:
 
     >>> class KeplerPotential(gp.AbstractPotential):
     ...     mass: gp.ParameterField = gp.ParameterField(dimensions="mass")
-    ...     def _potential_energy(self, q, t):
+    ...     def _potential(self, q, t):
     ...         return -self.constants["G"] * self.mass(t) / xp.linalg.norm(q, axis=-1)
 
     The `mass` parameter is a `ParameterField` that has dimensions of mass.

--- a/tests/unit/coordinates/psp/test_base_psp.py
+++ b/tests/unit/coordinates/psp/test_base_psp.py
@@ -200,15 +200,13 @@ class AbstractPhaseSpacePosition_Test(Generic[T], metaclass=ABCMeta):
         # TODO: more tests
 
     @pytest.mark.parametrize("pot", potentials)
-    def test_potential_energy(self, w: T, pot: AbstractPotentialBase) -> None:
-        """Test method ``potential_energy``."""
+    def test_potential(self, w: T, pot: AbstractPotentialBase) -> None:
+        """Test method ``potential``."""
         pe = w.potential_energy(pot)
         assert pe.shape == w.shape  # confirm relation to shape and components
         assert xp.all(pe <= Quantity(0, "km2/s2"))
         # definitional
-        assert qnp.allclose(
-            pe, pot.potential_energy(w.q, t=0), atol=Quantity(1e-10, pe.unit)
-        )
+        assert qnp.allclose(pe, pot.potential(w.q, t=0), atol=Quantity(1e-10, pe.unit))
 
     @pytest.mark.parametrize("potential", potentials)
     def test_total_energy(self, w: T, potential: AbstractPotentialBase) -> None:
@@ -218,7 +216,7 @@ class AbstractPhaseSpacePosition_Test(Generic[T], metaclass=ABCMeta):
         # definitional
         assert qnp.allclose(
             pe,
-            w.kinetic_energy() + potential.potential_energy(w.q, t=0),
+            w.kinetic_energy() + potential.potential(w.q, t=0),
             atol=Quantity(1e-10, pe.unit),
         )
 

--- a/tests/unit/potential/builtin/bars/test_bar.py
+++ b/tests/unit/potential/builtin/bars/test_bar.py
@@ -58,10 +58,10 @@ class TestBarPotential(
 
     # ==========================================================================
 
-    def test_potential_energy(self, pot: BarPotential, x: gt.QVec3) -> None:
+    def test_potential(self, pot: BarPotential, x: gt.QVec3) -> None:
         expect = Quantity(-0.94601574, pot.units["specific energy"])
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: BarPotential, x: gt.QVec3) -> None:

--- a/tests/unit/potential/builtin/bars/test_longmuralibar.py
+++ b/tests/unit/potential/builtin/bars/test_longmuralibar.py
@@ -78,10 +78,10 @@ class TestLongMuraliBarPotential(
 
     # ==========================================================================
 
-    def test_potential_energy(self, pot: LongMuraliBarPotential, x: gt.QVec3) -> None:
+    def test_potential(self, pot: LongMuraliBarPotential, x: gt.QVec3) -> None:
         expect = Quantity(-0.9494695, unit="kpc2 / Myr2")
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: LongMuraliBarPotential, x: gt.QVec3) -> None:

--- a/tests/unit/potential/builtin/logarithmic/test_lmj09logarithmic.py
+++ b/tests/unit/potential/builtin/logarithmic/test_lmj09logarithmic.py
@@ -95,12 +95,10 @@ class TestLMJ09LogarithmicPotential(
 
     # ==========================================================================
 
-    def test_potential_energy(
-        self, pot: LMJ09LogarithmicPotential, x: gt.QVec3
-    ) -> None:
+    def test_potential(self, pot: LMJ09LogarithmicPotential, x: gt.QVec3) -> None:
         expect = Quantity(0.11819267, unit="kpc2 / Myr2")
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: LMJ09LogarithmicPotential, x: gt.QVec3) -> None:
@@ -152,7 +150,7 @@ class TestLMJ09LogarithmicPotential(
     @pytest.mark.parametrize(
         ("method0", "method1", "atol"),
         [
-            ("potential_energy", "energy", 1e-8),
+            ("potential", "energy", 1e-8),
             ("gradient", "gradient", 1e-8),
             # ("density", "density", 1e-8),  # TODO: get gala and galax to agree
             # ("hessian", "hessian", 1e-8),  # TODO: get gala and galax to agree

--- a/tests/unit/potential/builtin/logarithmic/test_logarithmic.py
+++ b/tests/unit/potential/builtin/logarithmic/test_logarithmic.py
@@ -36,10 +36,10 @@ class TestLogarithmicPotential(
 
     # ==========================================================================
 
-    def test_potential_energy(self, pot: LogarithmicPotential, x: gt.QVec3) -> None:
+    def test_potential(self, pot: LogarithmicPotential, x: gt.QVec3) -> None:
         expect = Quantity(0.11027593, unit="kpc2 / Myr2")
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: LogarithmicPotential, x: gt.QVec3) -> None:

--- a/tests/unit/potential/builtin/misc/test_burkert.py
+++ b/tests/unit/potential/builtin/misc/test_burkert.py
@@ -40,10 +40,10 @@ class TestBurkertPotential(
 
     # ==========================================================================
 
-    def test_potential_energy(self, pot: BurkertPotential, x: gt.Vec3) -> None:
+    def test_potential(self, pot: BurkertPotential, x: gt.Vec3) -> None:
         expect = Quantity(-15.76623941, "kpc2 / Myr2")
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: BurkertPotential, x: gt.Vec3) -> None:
@@ -95,7 +95,7 @@ class TestBurkertPotential(
     @pytest.mark.parametrize(
         ("method0", "method1", "atol"),
         [
-            ("potential_energy", "energy", 1e-8),
+            ("potential", "energy", 1e-8),
             ("gradient", "gradient", 1e-8),
             ("density", "density", 1e-8),
             # ("hessian", "hessian", 1e-8),  # TODO: get gala and galax to agree

--- a/tests/unit/potential/builtin/misc/test_hernquist.py
+++ b/tests/unit/potential/builtin/misc/test_hernquist.py
@@ -27,10 +27,10 @@ class TestHernquistPotential(
 
     # ==========================================================================
 
-    def test_potential_energy(self, pot: HernquistPotential, x: gt.QVec3) -> None:
+    def test_potential(self, pot: HernquistPotential, x: gt.QVec3) -> None:
         expect = Quantity(-0.94871936, pot.units["specific energy"])
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: HernquistPotential, x: gt.QVec3) -> None:

--- a/tests/unit/potential/builtin/misc/test_isochrone.py
+++ b/tests/unit/potential/builtin/misc/test_isochrone.py
@@ -28,10 +28,10 @@ class TestIsochronePotential(
 
     # ==========================================================================
 
-    def test_potential_energy(self, pot: IsochronePotential, x: gt.QVec3) -> None:
+    def test_potential(self, pot: IsochronePotential, x: gt.QVec3) -> None:
         expect = Quantity(-0.9231515, pot.units["specific energy"])
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: IsochronePotential, x: gt.QVec3) -> None:

--- a/tests/unit/potential/builtin/misc/test_jaffe.py
+++ b/tests/unit/potential/builtin/misc/test_jaffe.py
@@ -36,10 +36,10 @@ class TestJaffePotential(
 
     # ==========================================================================
 
-    def test_potential_energy(self, pot: JaffePotential, x: gt.QVec3) -> None:
+    def test_potential(self, pot: JaffePotential, x: gt.QVec3) -> None:
         expect = Quantity(-1.06550653, unit="kpc2 / Myr2")
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: JaffePotential, x: gt.QVec3) -> None:

--- a/tests/unit/potential/builtin/misc/test_kepler.py
+++ b/tests/unit/potential/builtin/misc/test_kepler.py
@@ -27,10 +27,10 @@ class TestKeplerPotential(
 
     # ==========================================================================
 
-    def test_potential_energy(self, pot: KeplerPotential, x: QVec3) -> None:
+    def test_potential(self, pot: KeplerPotential, x: QVec3) -> None:
         expect = Quantity(-1.20227527, pot.units["specific energy"])
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: KeplerPotential, x: QVec3) -> None:

--- a/tests/unit/potential/builtin/misc/test_kuzmin.py
+++ b/tests/unit/potential/builtin/misc/test_kuzmin.py
@@ -37,10 +37,10 @@ class TestKuzminPotential(
 
     # ==========================================================================
 
-    def test_potential_energy(self, pot: KuzminPotential, x: gt.QVec3) -> None:
+    def test_potential(self, pot: KuzminPotential, x: gt.QVec3) -> None:
         expect = Quantity(-0.98165365, unit="kpc2 / Myr2")
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: KuzminPotential, x: gt.QVec3) -> None:
@@ -92,7 +92,7 @@ class TestKuzminPotential(
     @pytest.mark.parametrize(
         ("method0", "method1", "atol"),
         [
-            ("potential_energy", "energy", 1e-8),
+            ("potential", "energy", 1e-8),
             ("gradient", "gradient", 1e-8),
             ("density", "density", 5e-7),  # TODO: why is this different?
             # ("hessian", "hessian", 1e-8),  # TODO: why is gala's 0?

--- a/tests/unit/potential/builtin/misc/test_leesutotriaxialnfw.py
+++ b/tests/unit/potential/builtin/misc/test_leesutotriaxialnfw.py
@@ -123,12 +123,10 @@ class TestLeeSutoTriaxialNFWPotential(
 
     # ==========================================================================
 
-    def test_potential_energy(
-        self, pot: gp.LeeSutoTriaxialNFWPotential, x: gt.QVec3
-    ) -> None:
+    def test_potential(self, pot: gp.LeeSutoTriaxialNFWPotential, x: gt.QVec3) -> None:
         expect = Quantity(-9.68797618, pot.units["specific energy"])
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: gp.LeeSutoTriaxialNFWPotential, x: gt.QVec3) -> None:
@@ -180,7 +178,7 @@ class TestLeeSutoTriaxialNFWPotential(
     @pytest.mark.parametrize(
         ("method0", "method1", "atol"),
         [
-            ("potential_energy", "energy", 1e-8),
+            ("potential", "energy", 1e-8),
             ("gradient", "gradient", 1e-8),
             ("density", "density", 1e-8),
             # ("hessian", "hessian", 1e-8),  # No hessian method in gala!

--- a/tests/unit/potential/builtin/misc/test_miyamotonagai.py
+++ b/tests/unit/potential/builtin/misc/test_miyamotonagai.py
@@ -38,10 +38,10 @@ class TestMiyamotoNagaiPotential(
 
     # ==========================================================================
 
-    def test_potential_energy(self, pot: MiyamotoNagaiPotential, x: Vec3) -> None:
+    def test_potential(self, pot: MiyamotoNagaiPotential, x: Vec3) -> None:
         expect = Quantity(-0.95208676, pot.units["specific energy"])
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: MiyamotoNagaiPotential, x: Vec3) -> None:

--- a/tests/unit/potential/builtin/misc/test_null.py
+++ b/tests/unit/potential/builtin/misc/test_null.py
@@ -57,11 +57,11 @@ class TestNullPotential(AbstractPotential_Test):
 
     # ==========================================================================
 
-    def test_potential_energy(self, pot: gp.NullPotential, x: gt.QVec3) -> None:
-        """Test :meth:`NullPotential.potential_energy`."""
+    def test_potential(self, pot: gp.NullPotential, x: gt.QVec3) -> None:
+        """Test :meth:`NullPotential.potential`."""
         expect = Quantity(0.0, pot.units["specific energy"])
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: gp.NullPotential, x: gt.QVec3) -> None:

--- a/tests/unit/potential/builtin/misc/test_plummer.py
+++ b/tests/unit/potential/builtin/misc/test_plummer.py
@@ -36,10 +36,10 @@ class TestPlummerPotential(
 
     # ==========================================================================
 
-    def test_potential_energy(self, pot: PlummerPotential, x: gt.QVec3) -> None:
+    def test_potential(self, pot: PlummerPotential, x: gt.QVec3) -> None:
         expect = Quantity(-1.16150826, unit="kpc2 / Myr2")
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: PlummerPotential, x: gt.QVec3) -> None:

--- a/tests/unit/potential/builtin/misc/test_powerlawcutoff.py
+++ b/tests/unit/potential/builtin/misc/test_powerlawcutoff.py
@@ -92,10 +92,10 @@ class TestPowerLawCutoffPotential(
 
     # ==========================================================================
 
-    def test_potential_energy(self, pot: PowerLawCutoffPotential, x: gt.QVec3) -> None:
+    def test_potential(self, pot: PowerLawCutoffPotential, x: gt.QVec3) -> None:
         expect = Quantity(6.26573365, unit="kpc2 / Myr2")
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: PowerLawCutoffPotential, x: gt.QVec3) -> None:

--- a/tests/unit/potential/builtin/misc/test_satoh.py
+++ b/tests/unit/potential/builtin/misc/test_satoh.py
@@ -43,10 +43,10 @@ class TestSatohPotential(
 
     # ==========================================================================
 
-    def test_potential_energy(self, pot: SatohPotential, x: gt.QVec3) -> None:
+    def test_potential(self, pot: SatohPotential, x: gt.QVec3) -> None:
         expect = Quantity(-0.97415472, unit="kpc2 / Myr2")
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: SatohPotential, x: gt.QVec3) -> None:

--- a/tests/unit/potential/builtin/misc/test_stone.py
+++ b/tests/unit/potential/builtin/misc/test_stone.py
@@ -89,10 +89,10 @@ class TestStoneOstriker15Potential(
 
     # ==========================================================================
 
-    def test_potential_energy(self, pot: StoneOstriker15Potential, x: gt.QVec3) -> None:
+    def test_potential(self, pot: StoneOstriker15Potential, x: gt.QVec3) -> None:
         expect = Quantity(-0.51579523, unit="kpc2 / Myr2")
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: StoneOstriker15Potential, x: gt.QVec3) -> None:

--- a/tests/unit/potential/builtin/misc/test_triaxialhernquist.py
+++ b/tests/unit/potential/builtin/misc/test_triaxialhernquist.py
@@ -46,12 +46,10 @@ class TestTriaxialHernquistPotential(
 
     # ==========================================================================
 
-    def test_potential_energy(
-        self, pot: TriaxialHernquistPotential, x: gt.QVec3
-    ) -> None:
+    def test_potential(self, pot: TriaxialHernquistPotential, x: gt.QVec3) -> None:
         expect = Quantity(-0.61215074, pot.units["specific energy"])
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: TriaxialHernquistPotential, x: gt.QVec3) -> None:

--- a/tests/unit/potential/builtin/nfw/test_nfw.py
+++ b/tests/unit/potential/builtin/nfw/test_nfw.py
@@ -39,10 +39,10 @@ class TestNFWPotential(
 
     # ==========================================================================
 
-    def test_potential_energy(self, pot: gp.NFWPotential, x: gt.QVec3) -> None:
+    def test_potential(self, pot: gp.NFWPotential, x: gt.QVec3) -> None:
         expect = Quantity(-1.87120528, pot.units["specific energy"])
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: gp.NFWPotential, x: gt.QVec3) -> None:

--- a/tests/unit/potential/builtin/nfw/test_triaxialnfw.py
+++ b/tests/unit/potential/builtin/nfw/test_triaxialnfw.py
@@ -55,10 +55,10 @@ class TestTriaxialNFWPotential(
 
     # ==========================================================================
 
-    def test_potential_energy(self, pot: TriaxialNFWPotential, x: gt.QVec3) -> None:
+    def test_potential(self, pot: TriaxialNFWPotential, x: gt.QVec3) -> None:
         expect = Quantity(-1.06475915, unit="kpc2 / Myr2")
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: TriaxialNFWPotential, x: gt.QVec3) -> None:

--- a/tests/unit/potential/builtin/nfw/test_vogelsberger08nfw.py
+++ b/tests/unit/potential/builtin/nfw/test_vogelsberger08nfw.py
@@ -78,12 +78,12 @@ class TestVogelsberger08TriaxialNFWPotential(
 
     # ==========================================================================
 
-    def test_potential_energy(
+    def test_potential(
         self, pot: Vogelsberger08TriaxialNFWPotential, x: gt.QVec3
     ) -> None:
         expect = Quantity(-1.91410199, unit="kpc2 / Myr2")
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(

--- a/tests/unit/potential/builtin/special/test_bovymwpotential2014.py
+++ b/tests/unit/potential/builtin/special/test_bovymwpotential2014.py
@@ -52,10 +52,10 @@ class TestBovyMWPotential2014(AbstractCompositePotential_Test):
 
     # ==========================================================================
 
-    def test_potential_energy(self, pot: BovyMWPotential2014, x: gt.QVec3) -> None:
+    def test_potential(self, pot: BovyMWPotential2014, x: gt.QVec3) -> None:
         expect = Quantity(-0.09550731, unit="kpc2 / Myr2")
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: BovyMWPotential2014, x: gt.QVec3) -> None:

--- a/tests/unit/potential/builtin/special/test_lm10.py
+++ b/tests/unit/potential/builtin/special/test_lm10.py
@@ -50,10 +50,10 @@ class TestLM10Potential(AbstractCompositePotential_Test):
 
     # ==========================================================================
 
-    def test_potential_energy(self, pot: LM10Potential, x: gt.QVec3) -> None:
+    def test_potential(self, pot: LM10Potential, x: gt.QVec3) -> None:
         expect = Quantity(-0.00242568, unit="kpc2 / Myr2")
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: LM10Potential, x: gt.QVec3) -> None:
@@ -105,7 +105,7 @@ class TestLM10Potential(AbstractCompositePotential_Test):
     @pytest.mark.parametrize(
         ("method0", "method1", "atol"),
         [
-            ("potential_energy", "energy", 1e-8),
+            ("potential", "energy", 1e-8),
             ("gradient", "gradient", 1e-8),
             # ("density", "density", 1e-8),  # TODO: get gala and galax to agree
             # ("hessian", "hessian", 1e-8),  # TODO: get gala and galax to agree

--- a/tests/unit/potential/builtin/special/test_milkywaypotential.py
+++ b/tests/unit/potential/builtin/special/test_milkywaypotential.py
@@ -59,11 +59,11 @@ class TestMilkyWayPotential(AbstractCompositePotential_Test):
 
     # ==========================================================================
 
-    def test_potential_energy(self, pot: MilkyWayPotential, x: gt.QVec3) -> None:
-        """Test the :meth:`MilkyWayPotential.potential_energy` method."""
+    def test_potential(self, pot: MilkyWayPotential, x: gt.QVec3) -> None:
+        """Test the :meth:`MilkyWayPotential.potential` method."""
         expect = Quantity(-0.19386052, pot.units["specific energy"])
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: MilkyWayPotential, x: gt.QVec3) -> None:

--- a/tests/unit/potential/io/test_gala.py
+++ b/tests/unit/potential/io/test_gala.py
@@ -105,5 +105,5 @@ def test_offset_hernquist() -> None:
         [1.0, 2, 3] * u.kpc
     )
 
-    assert isinstance(gxpot.potential, gp.HernquistPotential)
+    assert isinstance(gxpot.original_potential, gp.HernquistPotential)
     assert gxpot.units._core_units == galactic._core_units

--- a/tests/unit/potential/io/test_gala.py
+++ b/tests/unit/potential/io/test_gala.py
@@ -23,7 +23,7 @@ else:
 parametrize_test_method_gala = pytest.mark.parametrize(
     ("method0", "method1", "atol"),
     [
-        ("potential_energy", "energy", 1e-8),
+        ("potential", "energy", 1e-8),
         ("gradient", "gradient", 1e-8),
         ("density", "density", 1e-8),
         ("hessian", "hessian", 1e-8),

--- a/tests/unit/potential/test_base.py
+++ b/tests/unit/potential/test_base.py
@@ -113,20 +113,20 @@ class AbstractPotentialBase_Test(GalaIOMixin, metaclass=ABCMeta):
     # ---------------------------------
 
     @abstractmethod
-    def test_potential_energy(self, pot: AbstractPotentialBase, x: gt.QVec3) -> None:
-        """Test the `potential_energy` method."""
+    def test_potential(self, pot: AbstractPotentialBase, x: gt.QVec3) -> None:
+        """Test the `potential` method."""
         ...
 
-    def test_potential_energy_batch(
+    def test_potential_batch(
         self, pot: AbstractPotentialBase, batchx: gt.BatchQVec3
     ) -> None:
-        """Test the `AbstractPotentialBase.potential_energy` method."""
+        """Test the `AbstractPotentialBase.potential` method."""
         # Test that the method works on batches.
-        assert pot.potential_energy(batchx, t=0).shape == batchx.shape[:-1]
+        assert pot.potential(batchx, t=0).shape == batchx.shape[:-1]
         # Test that the batched method is equivalent to the scalar method
         assert qnp.allclose(
-            pot.potential_energy(batchx, t=0)[0],
-            pot.potential_energy(batchx[0], t=0),
+            pot.potential(batchx, t=0)[0],
+            pot.potential(batchx[0], t=0),
             atol=Quantity(1e-15, pot.units["specific energy"]),
         )
 
@@ -134,7 +134,7 @@ class AbstractPotentialBase_Test(GalaIOMixin, metaclass=ABCMeta):
 
     def test_call(self, pot: AbstractPotentialBase, x: gt.QVec3) -> None:
         """Test the `AbstractPotentialBase.__call__` method."""
-        assert xp.equal(pot(x, t=0), pot.potential_energy(x, t=0))
+        assert xp.equal(pot(x, t=0), pot.potential(x, t=0))
 
     @abstractmethod
     def test_gradient(self, pot: AbstractPotentialBase, x: gt.QVec3) -> None:
@@ -215,7 +215,7 @@ class TestAbstractPotentialBase(AbstractPotentialBase_Test):
             )
 
             @partial(jax.jit)
-            def _potential_energy(  # TODO: inputs w/ units
+            def _potential(  # TODO: inputs w/ units
                 self, q: gt.BatchQVec3, t: gt.BatchableRealQScalar, /
             ) -> gt.BatchFloatQScalar:
                 return (
@@ -242,10 +242,10 @@ class TestAbstractPotentialBase(AbstractPotentialBase_Test):
 
     # ---------------------------------
 
-    def test_potential_energy(self, pot: AbstractPotentialBase, x: gt.QVec3) -> None:
-        """Test the `AbstractPotentialBase.potential_energy` method."""
+    def test_potential(self, pot: AbstractPotentialBase, x: gt.QVec3) -> None:
+        """Test the `AbstractPotentialBase.potential` method."""
         assert qnp.allclose(
-            pot.potential_energy(x, t=0),
+            pot.potential(x, t=0),
             Quantity(1.20227527, "kpc2/Myr2"),
             atol=Quantity(1e-8, "kpc2/Myr2"),
         )

--- a/tests/unit/potential/test_composite.py
+++ b/tests/unit/potential/test_composite.py
@@ -315,10 +315,10 @@ class TestCompositePotential(AbstractCompositePotential_Test):
 
     # ==========================================================================
 
-    def test_potential_energy(self, pot: CompositePotential, x: Vec3) -> None:
+    def test_potential(self, pot: CompositePotential, x: Vec3) -> None:
         expect = Quantity(xp.asarray(-0.6753781), "kpc2 / Myr2")
         assert qnp.isclose(
-            pot.potential_energy(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
+            pot.potential(x, t=0), expect, atol=Quantity(1e-8, expect.unit)
         )
 
     def test_gradient(self, pot: CompositePotential, x: Vec3) -> None:

--- a/tests/unit/potential/test_core.py
+++ b/tests/unit/potential/test_core.py
@@ -52,7 +52,7 @@ class TestAbstractPotential(AbstractPotential_Test):
             )
 
             @partial(jax.jit)
-            def _potential_energy(  # TODO: inputs w/ units
+            def _potential(  # TODO: inputs w/ units
                 self, q: gt.BatchQVec3, t: gt.BatchableRealQScalar, /
             ) -> gt.BatchFloatQScalar:
                 return (
@@ -79,10 +79,10 @@ class TestAbstractPotential(AbstractPotential_Test):
 
     # ---------------------------------
 
-    def test_potential_energy(self, pot: gp.AbstractPotentialBase, x: gt.QVec3) -> None:
-        """Test the `AbstractPotentialBase.potential_energy` method."""
+    def test_potential(self, pot: gp.AbstractPotentialBase, x: gt.QVec3) -> None:
+        """Test the `AbstractPotentialBase.potential` method."""
         assert qnp.allclose(
-            pot.potential_energy(x, t=0),
+            pot.potential(x, t=0),
             Quantity(1.20227527, "kpc2/Myr2"),
             atol=Quantity(1e-8, "kpc2/Myr2"),
         )

--- a/tests/unit/potential/test_frame.py
+++ b/tests/unit/potential/test_frame.py
@@ -40,20 +40,20 @@ def test_bar_means_of_rotation() -> None:
     assert isinstance(newt, Quantity)
 
     # They should be equivalent at t=0
-    assert framedpot.potential_energy(q, t) == hardpot.potential_energy(q, t)
+    assert framedpot.potential(q, t) == hardpot.potential(q, t)
     assert qnp.array_equal(framedpot.acceleration(q, t), hardpot.acceleration(q, t))
 
     # They should be equivalent at t=110 Myr (1/2 period)
     t = Quantity(110, "Myr")
-    assert framedpot.potential_energy(q, t) == hardpot.potential_energy(q, t)
+    assert framedpot.potential(q, t) == hardpot.potential(q, t)
     assert qnp.array_equal(framedpot.acceleration(q, t), hardpot.acceleration(q, t))
 
     # They should be equivalent at t=220 Myr (1 period)
     t = Quantity(220, "Myr")
-    assert framedpot.potential_energy(q, t) == hardpot.potential_energy(q, t)
+    assert framedpot.potential(q, t) == hardpot.potential(q, t)
     assert qnp.array_equal(framedpot.acceleration(q, t), hardpot.acceleration(q, t))
 
     # They should be equivalent at t=55 Myr (1/4 period)
     t = Quantity(55, "Myr")
-    assert framedpot.potential_energy(q, t) == hardpot.potential_energy(q, t)
+    assert framedpot.potential(q, t) == hardpot.potential(q, t)
     assert qnp.array_equal(framedpot.acceleration(q, t), hardpot.acceleration(q, t))


### PR DESCRIPTION
Shouldn't have ever named it `potential_energy`. It's the `potential`.