### PR TITLE
feat: runtime tyecheck off by default

### DIFF
--- a/src/galax/setup_package.py
+++ b/src/galax/setup_package.py
@@ -8,6 +8,6 @@ config.update("jax_enable_x64", True)  # noqa: FBT003
 
 RUNTIME_TYPECHECKER = (
     "beartype.beartype"
-    if (os.environ.get("GALAX_ENABLE_RUNTIME_TYPECHECKS", "1") == "1")
+    if (os.environ.get("GALAX_ENABLE_RUNTIME_TYPECHECKS", "0") == "1")
     else None
 )


### PR DESCRIPTION
Faster.
It can be enabled by setting the environment variable.