### PR TITLE
refactor: cleanup funcs

### DIFF
--- a/src/galax/potential/_potential/base.py
+++ b/src/galax/potential/_potential/base.py
@@ -11,7 +11,7 @@ import jax
 import jax.numpy as jnp
 from astropy.constants import G as _CONST_G  # pylint: disable=no-name-in-module
 from astropy.units import Quantity as APYQuantity
-from jaxtyping import Array, Float, Shaped
+from jaxtyping import Float, Shaped
 
 import coordinax as cx
 import quaxed.array_api as xp
@@ -33,20 +33,6 @@ if TYPE_CHECKING:
 
 
 HessianVec: TypeAlias = Shaped[Quantity["1/s^2"], "*#shape 3 3"]  # TODO: shape -> batch
-
-# Position and time input options
-PositionalLike: TypeAlias = (
-    cx.AbstractPosition3D | gt.LengthBatchableVec3 | Shaped[Array, "*#batch 3"]
-)
-TimeOptions: TypeAlias = (
-    gt.BatchRealQScalar
-    | gt.FloatQScalar
-    | gt.IntQScalar
-    | gt.BatchableRealScalarLike
-    | gt.FloatScalar
-    | gt.IntScalar
-    | APYQuantity
-)
 
 CONST_G = Quantity(_CONST_G.value, _CONST_G.unit)
 

--- a/src/galax/potential/_potential/funcs.py
+++ b/src/galax/potential/_potential/funcs.py
@@ -239,6 +239,12 @@ def potential(
 
     In the following example we will show compatibility with Astropy objects.
 
+    .. invisible-code-block: python
+
+        from galax.utils._optional_deps import HAS_ASTROPY
+
+    .. skip: start if(not HAS_ASTROPY, reason="requires Astropy")
+
     >>> import astropy.coordinates as c
     >>> import astropy.units as u
 
@@ -247,6 +253,7 @@ def potential(
     >>> pot.potential(q, t=t)
     Quantity['specific energy'](Array(-1.20227527, dtype=float64), unit='kpc2 / Myr2')
 
+    .. skip: end
     """
     return potential(pot, q, t)
 
@@ -392,11 +399,14 @@ def gradient(
     counterparts :class:`~coordinax.AbstractPosition3D` and
     :class:`~unxt.Quantity`.
 
+    .. invisible-code-block: python
+
+        from galax.utils._optional_deps import HAS_ASTROPY
+
+    .. skip: start if(not HAS_ASTROPY, reason="requires Astropy")
+
     >>> import astropy.units as u
     >>> import astropy.coordinates as c
-    >>> import galax.potential as gp
-
-    >>> pot = gp.KeplerPotential(m_tot=u.Quantity(1e12, "Msun"), units="galactic")
 
     We can compute the potential energy at a position (and time, if any
     parameters are time-dependent):
@@ -436,6 +446,7 @@ def gradient(
         [[0.086 0.172 0.258]
          [0.027 0.033 0.04 ]]>
 
+    .. skip: end
     """
     q = parse_to_quantity(q, unit=pot.units["length"])
     t = Quantity.constructor(t, pot.units["time"])
@@ -501,12 +512,6 @@ def gradient(
     <CartesianAcceleration3D (d2_x[kpc / Myr2], d2_y[kpc / Myr2], d2_z[kpc / Myr2])
         [[0.086 0.172 0.258]
          [0.027 0.033 0.04 ]]>
-
-    - - -
-
-    :fun:`~galax.potential.gradient` also supports Astropy objects.
-
-
 
     """
     return gradient(pot, q, t)
@@ -641,6 +646,12 @@ def laplacian(pot: AbstractPotentialBase, q: Any, t: Any, /) -> Quantity["1/s^2"
     counterparts :class:`~coordinax.AbstractPosition3D` and
     :class:`~unxt.Quantity`.
 
+    .. invisible-code-block: python
+
+        from galax.utils._optional_deps import HAS_ASTROPY
+
+    .. skip: start if(not HAS_ASTROPY, reason="requires Astropy")
+
     >>> import astropy.units as u
     >>> import astropy.coordinates as c
 
@@ -675,6 +686,7 @@ def laplacian(pot: AbstractPotentialBase, q: Any, t: Any, /) -> Quantity["1/s^2"
     >>> pot.laplacian(q, t)
     Quantity[...](Array([2.77555756e-17, 0.00000000e+00], dtype=float64), unit='1 / Myr2')
 
+    .. skip: end
     """  # noqa: E501
     q = parse_to_quantity(q, unit=pot.units["length"])
     t = Quantity.constructor(t, pot.units["time"])
@@ -861,6 +873,12 @@ def density(pot: AbstractPotentialBase, q: Any, t: Any, /) -> Quantity["mass den
     counterparts :class:`~coordinax.AbstractPosition3D` and
     :class:`~unxt.Quantity`.
 
+    .. invisible-code-block: python
+
+        from galax.utils._optional_deps import HAS_ASTROPY
+
+    .. skip: start if(not HAS_ASTROPY, reason="requires Astropy")
+
     >>> import numpy as np
     >>> import astropy.coordinates as c
     >>> import astropy.units as u
@@ -894,6 +912,8 @@ def density(pot: AbstractPotentialBase, q: Any, t: Any, /) -> Quantity["mass den
     >>> q = np.array([[1, 2, 3], [4, 5, 6]])
     >>> pot.density(q, t)
     Quantity['mass density'](Array([0., 0.], dtype=float64), unit='solMass / kpc3')
+
+    .. skip: end
     """
     q = parse_to_quantity(q, unit=pot.units["length"])
     t = Quantity.constructor(t, pot.units["time"])
@@ -927,7 +947,12 @@ def density(
 
     :func:`~galax.potential.density` also supports Astropy objects.
 
-    >>> import numpy as np
+    .. invisible-code-block: python
+
+        from galax.utils._optional_deps import HAS_ASTROPY
+
+    .. skip: start if(not HAS_ASTROPY, reason="requires Astropy")
+
     >>> import astropy.coordinates as c
     >>> import astropy.units as u
 
@@ -936,6 +961,7 @@ def density(
     >>> pot.density(q, t=t)
     Quantity['mass density'](Array(0., dtype=float64), unit='solMass / kpc3')
 
+    .. skip: end
     """
     return density(pot, q, t)
 
@@ -1093,6 +1119,12 @@ def hessian(pot: AbstractPotentialBase, q: Any, t: Any, /) -> HessianVec:
     counterparts :class:`~coordinax.AbstractPosition3D` and
     :class:`~unxt.Quantity`.
 
+    .. invisible-code-block: python
+
+        from galax.utils._optional_deps import HAS_ASTROPY
+
+    .. skip: start if(not HAS_ASTROPY, reason="requires Astropy")
+
     >>> import numpy as np
     >>> import astropy.coordinates as c
     >>> import astropy.units as u
@@ -1144,6 +1176,8 @@ def hessian(pot: AbstractPotentialBase, q: Any, t: Any, /) -> HessianVec:
                           [-0.00518791,  0.00017293, -0.00778186],
                           [-0.00622549, -0.00778186, -0.00268042]]], dtype=float64),
                     unit='1 / Myr2')
+
+    .. skip: end
     """
     q = parse_to_quantity(q, unit=pot.units["length"])
     t = Quantity.constructor(t, pot.units["time"])
@@ -1436,6 +1470,12 @@ def tidal_tensor(
     counterparts :class:`~coordinax.AbstractPosition3D` and
     :class:`~unxt.Quantity`.
 
+    .. invisible-code-block: python
+
+        from galax.utils._optional_deps import HAS_ASTROPY
+
+    .. skip: start if(not HAS_ASTROPY, reason="requires Astropy")
+
     >>> import numpy as np
     >>> import astropy.coordinates as c
     >>> import astropy.units as u
@@ -1476,6 +1516,9 @@ def tidal_tensor(
                     unit='1 / Myr2')
 
     Again, this can be batched.
+
+    .. skip: end
+
     """
     J = hessian(pot, *args, **kwargs)  # (*batch, 3, 3)
     batch_shape, arr_shape = batched_shape(J, expect_ndim=2)  # (*batch), (3, 3)

--- a/src/galax/potential/_potential/funcs.py
+++ b/src/galax/potential/_potential/funcs.py
@@ -14,10 +14,7 @@ from functools import partial
 from typing import Any, TypeAlias
 
 import jax
-import numpy as np
-from astropy.coordinates import BaseRepresentation as APYRepresentation
-from astropy.units import Quantity as APYQuantity
-from jaxtyping import Array, Float, Shaped
+from jaxtyping import Shaped
 from plum import convert, dispatch
 
 import coordinax as cx
@@ -34,39 +31,22 @@ from galax.utils._shape import batched_shape, expand_arr_dims, expand_batch_dims
 
 HessianVec: TypeAlias = Shaped[Quantity["1/s^2"], "*#shape 3 3"]  # TODO: shape -> batch
 
-# Position and time input options
-PositionalLike: TypeAlias = (
-    cx.AbstractPosition3D
-    | gt.LengthBatchableVec3
-    | Shaped[Quantity["length"], "*#batch 3"]
-    | Shaped[Array, "*#batch 3"]
-)
-TimeOptions: TypeAlias = (
-    gt.BatchRealQScalar
-    | gt.FloatQScalar
-    | gt.IntQScalar
-    | gt.BatchableRealScalarLike
-    | gt.FloatScalar
-    | gt.IntScalar
-    | int  # .e.g. 0
-    | APYQuantity
-)
-
 # =============================================================================
 # Potential Energy
 
 
-@dispatch  # type: ignore[misc]
+@dispatch
 def potential(
-    potential: AbstractPotentialBase,
+    pot: AbstractPotentialBase,
     pspt: gc.AbstractPhaseSpacePosition | cx.FourVector,
     /,
-) -> Quantity["specific energy"]:  # TODO: shape hint
+) -> Quantity["specific energy"]:
     """Compute the potential energy at the given position(s).
 
     Parameters
     ----------
-    pspt : :class:`~galax.coordinates.AbstractPhaseSpacePosition`
+    pot : :class:`~galax.potential.AbstractPotentialBase`, positional-only
+    pspt : :class:`~galax.coordinates.AbstractPhaseSpacePosition`, positional-only
         The phase-space + time position to compute the value of the
         potential.
 
@@ -113,29 +93,27 @@ def potential(
     >>> pot.potential(w)
     Quantity['specific energy'](Array(-1.20227527, dtype=float64), unit='kpc2 / Myr2')
     """  # noqa: E501
-    q = _convert_from_3dvec(pspt.q, units=potential.units)
-    return potential._potential(q, pspt.t)  # noqa: SLF001
-
-
-_potential = potential  # Needed to bypass namespace restrictions
+    q = _convert_from_3dvec(pspt.q, units=pot.units)
+    return pot._potential(q, pspt.t)  # noqa: SLF001
 
 
 @dispatch
 def potential(
-    potential: AbstractPotentialBase, q: PositionalLike, /, t: TimeOptions
-) -> Quantity["specific energy"]:  # TODO: shape hint
+    pot: AbstractPotentialBase, q: Any, t: Any, /
+) -> Quantity["specific energy"]:
     """Compute the potential energy at the given position(s).
 
     Parameters
     ----------
-    q : PositionalLike
-        The position to compute the value of the potential.  If unitless
-        (i.e. is an `~jax.Array`), it is assumed to be in the unit system of
-        the potential.
-    t : TimeOptions
-        The time at which to compute the value of the potential.  If
-        unitless (i.e. is an `~jax.Array`), it is assumed to be in the unit
-        system of the potential.
+    pot : :class:`~galax.potential.AbstractPotentialBase`, positional-only
+        The potential to compute the value of.
+    q : Any, positional-only
+        The position to compute the value of the potential. See
+        `parse_to_quantity` for more details.
+
+    t : Any, positional-only
+        The time at which to compute the value of the potential. See
+        :meth:`unxt.Quantity.constructor` for more details.
 
     Examples
     --------
@@ -159,79 +137,40 @@ def potential(
     >>> pot.potential(q, t)
     Quantity['specific energy'](Array([-1.20227527, -0.5126519 ], dtype=float64), unit='kpc2 / Myr2')
 
-    Instead of passing a :class:`~vector.AbstractPosition3D` (in this case a
-    :class:`~vector.CartesianPosition3D`), we can instead pass a
-    :class:`unxt.Quantity`, which is interpreted as a Cartesian
-    position:
+    Instead of passing a :class:`~coordinax.AbstractPosition3D` (in this case a
+    :class:`~coordinax.CartesianPosition3D`), we can instead pass a
+    :class:`unxt.Quantity`, which is interpreted as a Cartesian position:
 
     >>> q = Quantity([1., 2, 3], "kpc")
     >>> pot.potential(q, t)
     Quantity['specific energy'](Array(-1.20227527, dtype=float64), unit='kpc2 / Myr2')
 
-    Again, this can be batched.  If the input position object has no units
-    (i.e. is an `~jax.Array`), it is assumed to be in the same unit system
-    as the potential.
+    Again, this can be batched.  If the input position object has no units (i.e.
+    is an `~jax.Array`), it is assumed to be in the same unit system as the
+    potential.
 
     >>> import jax.numpy as jnp
     >>> q = jnp.asarray([[1, 2, 3], [4, 5, 6]])
     >>> pot.potential(q, t)
     Quantity['specific energy'](Array([-1.20227527, -0.5126519 ], dtype=float64), unit='kpc2 / Myr2')
-    """  # noqa: E501
-    q = parse_to_quantity(q, unit=potential.units["length"])
-    t = Quantity.constructor(t, potential.units["time"])
-    return potential._potential(q, t)  # noqa: SLF001
 
+    - - -
 
-@dispatch
-def potential(
-    potential: AbstractPotentialBase, q: PositionalLike, /, *, t: TimeOptions
-) -> Quantity["specific energy"]:  # TODO: shape hint
-    """Compute the potential energy when `t` is keyword-only.
-
-    Examples
-    --------
-    All these examples are covered by the case where `t` is positional.
-    :mod:`plum` dispatches on positional arguments only, so it necessary
-    to redispatch here.
-
-    >>> from unxt import Quantity
-    >>> import coordinax as cx
-    >>> import galax.potential as gp
-
-    >>> pot = gp.KeplerPotential(m_tot=Quantity(1e12, "Msun"), units="galactic")
-
-    >>> q = cx.CartesianPosition3D.constructor(Quantity([1, 2, 3], "kpc"))
-    >>> t = Quantity(0, "Gyr")
-    >>> pot.potential(q, t=t)
-    Quantity['specific energy'](Array(-1.20227527, dtype=float64), unit='kpc2 / Myr2')
-
-    See the other examples in the positional-only case.
-    """
-    return _potential(potential, q, t)
-
-
-@dispatch
-def potential(
-    potential: AbstractPotentialBase,
-    q: APYRepresentation | APYQuantity | np.ndarray,
-    /,
-    t: TimeOptions,
-) -> Quantity["specific energy"]:  # TODO: shape hint
-    """Compute the potential energy at the given position(s).
-
-    :meth:`~galax.potential.AbstractPotentialBase.potential` also
-    supports Astropy objects, like
+    :fun:`~galax.potential.potential` also supports Astropy objects, like
     :class:`astropy.coordinates.BaseRepresentation` and
     :class:`astropy.units.Quantity`, which are interpreted like their jax'ed
-    counterparts :class:`~vector.AbstractPosition3D` and
+    counterparts :class:`~coordinax.AbstractPosition3D` and
     :class:`~unxt.Quantity`.
 
-    Examples
-    --------
+    .. invisible-code-block: python
+
+        from galax.utils._optional_deps import HAS_ASTROPY
+
+    .. skip: start if(not HAS_ASTROPY, reason="requires Astropy")
+
     >>> import numpy as np
     >>> import astropy.coordinates as c
     >>> import astropy.units as u
-    >>> import galax.potential as gp
 
     >>> pot = gp.KeplerPotential(m_tot=1e12, units="galactic")
 
@@ -249,75 +188,87 @@ def potential(
     >>> pot.potential(q, t)
     Quantity['specific energy'](Array([-0.55372734, -0.46647294], dtype=float64), unit='kpc2 / Myr2')
 
-    Instead of passing a
-    :class:`astropy.coordinates.CartesianRepresentation`,
-    we can instead pass a :class:`astropy.units.Quantity`, which is
-    interpreted as a Cartesian position:
+    Instead of passing a :class:`astropy.coordinates.CartesianRepresentation`,
+    we can instead pass a :class:`astropy.units.Quantity`, which is interpreted
+    as a Cartesian position:
 
     >>> q = u.Quantity([1, 2, 3], "kpc")
     >>> pot.potential(q, t)
     Quantity['specific energy'](Array(-1.20227527, dtype=float64), unit='kpc2 / Myr2')
 
-    Again, this can be batched.  Also, If the input position object has no
-    units (i.e. is an `~numpy.ndarray`), it is assumed to be in the same
-    unit system as the potential.
+    Again, this can be batched.  Also, If the input position object has no units
+    (i.e. is an `~numpy.ndarray`), it is assumed to be in the same unit system
+    as the potential.
 
     >>> q = np.array([[1, 2, 3], [4, 5, 6]])
     >>> pot.potential(q, t)
     Quantity['specific energy'](Array([-1.20227527, -0.5126519 ], dtype=float64), unit='kpc2 / Myr2')
+
+    .. skip: end
+
     """  # noqa: E501
-    q = parse_to_quantity(q, unit=potential.units["length"])
-    t = Quantity.constructor(t, potential.units["time"])
-    return potential._potential(q, t)  # noqa: SLF001
+    q = parse_to_quantity(q, unit=pot.units["length"])
+    t = Quantity.constructor(t, pot.units["time"])
+    return pot._potential(q, t)  # noqa: SLF001
 
 
 @dispatch
 def potential(
-    potential: AbstractPotentialBase,
-    q: APYRepresentation | APYQuantity | np.ndarray,
-    /,
-    *,
-    t: TimeOptions,
-) -> Float[Quantity["specific energy"], "*batch"]:
+    pot: AbstractPotentialBase, q: Any, /, *, t: Any
+) -> Quantity["specific energy"]:
     """Compute the potential energy when `t` is keyword-only.
 
     Examples
     --------
-    >>> import numpy as np
-    >>> import astropy.coordinates as c
-    >>> import astropy.units as u
+    All these examples are covered by the case where `t` is positional.
+    :mod:`plum` dispatches on positional arguments only, so it necessary to
+    redispatch here. See the other examples in the positional-only case.
+
+    >>> from unxt import Quantity
+    >>> import coordinax as cx
     >>> import galax.potential as gp
 
-    >>> pot = gp.KeplerPotential(m_tot=u.Quantity(1e12, "Msun"), units="galactic")
+    >>> pot = gp.KeplerPotential(m_tot=Quantity(1e12, "Msun"), units="galactic")
 
-    We can compute the potential energy at a position (and time, if any
-    parameters are time-dependent):
+    >>> q = cx.CartesianPosition3D.constructor(Quantity([1, 2, 3], "kpc"))
+    >>> t = Quantity(0, "Gyr")
+    >>> pot.potential(q, t=t)
+    Quantity['specific energy'](Array(-1.20227527, dtype=float64), unit='kpc2 / Myr2')
+
+    - - -
+
+    In the following example we will show compatibility with Astropy objects.
+
+    >>> import astropy.coordinates as c
+    >>> import astropy.units as u
 
     >>> q = c.CartesianRepresentation([1, 2, 3], unit=u.kpc)
     >>> t = u.Quantity(0, "Gyr")
     >>> pot.potential(q, t=t)
     Quantity['specific energy'](Array(-1.20227527, dtype=float64), unit='kpc2 / Myr2')
 
-    See the other examples in the positional-only case.
     """
-    return _potential(potential, q, t)
+    return potential(pot, q, t)
 
 
 # =============================================================================
 # Gradient
 
 
-@dispatch  # type: ignore[misc]
+@dispatch
 def gradient(
-    potential: AbstractPotentialBase,
+    pot: AbstractPotentialBase,
     pspt: gc.AbstractPhaseSpacePosition | cx.FourVector,
     /,
-) -> cx.CartesianAcceleration3D:  # TODO: shape hint
+) -> cx.CartesianAcceleration3D:
     """Compute the gradient of the potential at the given position(s).
 
     Parameters
     ----------
-    pspt : :class:`~galax.coordinates.AbstractPhaseSpacePosition`
+    pot : :class:`~galax.potential.AbstractPotentialBase`, positional-only
+        The potential to compute the gradient of.
+    pspt : :class:`~galax.coordinates.AbstractPhaseSpacePosition`,
+    positional-only
         The phase-space + time position to compute the gradient.
 
     Returns
@@ -357,8 +308,7 @@ def gradient(
         [[0.086 0.172 0.258]
          [0.027 0.033 0.04 ]]>
 
-    Instead of passing a
-    :class:`~galax.coordinates.AbstractPhaseSpacePosition`,
+    Instead of passing a :class:`~galax.coordinates.AbstractPhaseSpacePosition`,
     we can instead pass a :class:`~vector.FourVector`:
 
     >>> from coordinax import FourVector
@@ -367,29 +317,27 @@ def gradient(
     <CartesianAcceleration3D (d2_x[kpc / Myr2], d2_y[kpc / Myr2], d2_z[kpc / Myr2])
         [0.086 0.172 0.258]>
     """
-    q = _convert_from_3dvec(pspt.q, units=potential.units)
-    return cx.CartesianAcceleration3D.constructor(potential._gradient(q, pspt.t))  # noqa: SLF001
-
-
-_gradient = gradient  # Needed to bypass namespace restrictions
+    q = _convert_from_3dvec(pspt.q, units=pot.units)
+    return cx.CartesianAcceleration3D.constructor(pot._gradient(q, pspt.t))  # noqa: SLF001
 
 
 @dispatch
 def gradient(
-    potential: AbstractPotentialBase, q: PositionalLike, /, t: TimeOptions
-) -> cx.CartesianAcceleration3D:  # TODO: shape hint
+    pot: AbstractPotentialBase, q: Any, t: Any, /
+) -> cx.CartesianAcceleration3D:
     """Compute the gradient of the potential at the given position(s).
 
     Parameters
     ----------
-    q : :class:`vector.AbstractPosition3D` | (Quantity|Array)[float, (*batch, 3)]
-        The position to compute the gradient of the potential.  If unitless
-        (i.e. is an `~jax.Array`), it is assumed to be in the unit system of
-        the potential.
-    t : Array[float | int, *batch] | float | int
-        The time at which to compute the gradient of the potential.  If
-        unitless (i.e. is an `~jax.Array`), it is assumed to be in the unit
-        system of the potential.
+    pot : :class:`~galax.potential.AbstractPotentialBase`, positional-only
+        The potential to compute the gradient of.
+    q : Any, positional-only
+        The position to compute the gradient of the potential. See
+        `parse_to_quantity` for more details.
+
+    t : Any, positional-only
+        The time at which to compute the gradient of the potential. See
+        :meth:`unxt.Quantity.constructor` for more details.
 
     Examples
     --------
@@ -416,19 +364,18 @@ def gradient(
         [[0.086 0.172 0.258]
          [0.027 0.033 0.04 ]]>
 
-    Instead of passing a :class:`~vector.AbstractPosition3D` (in this case a
-    :class:`~vector.CartesianPosition3D`), we can instead pass a
-    :class:`unxt.Quantity`, which is interpreted as a Cartesian
-    position:
+    Instead of passing a :class:`~coordinax.AbstractPosition3D` (in this case a
+    :class:`~coordinax.CartesianPosition3D`), we can instead pass a
+    :class:`unxt.Quantity`, which is interpreted as a Cartesian position:
 
     >>> q = Quantity([1., 2, 3], "kpc")
     >>> print(pot.gradient(q, t))
     <CartesianAcceleration3D (d2_x[kpc / Myr2], d2_y[kpc / Myr2], d2_z[kpc / Myr2])
         [0.086 0.172 0.258]>
 
-    Again, this can be batched.  If the input position object has no units
-    (i.e. is an `~jax.Array`), it is assumed to be in the same unit system
-    as the potential.
+    Again, this can be batched.  If the input position object has no units (i.e.
+    is an `~jax.Array`), it is assumed to be in the same unit system as the
+    potential.
 
     >>> import jax.numpy as jnp
     >>> q = jnp.asarray([[1., 2, 3], [4, 5, 6]])
@@ -436,28 +383,79 @@ def gradient(
     <CartesianAcceleration3D (d2_x[kpc / Myr2], d2_y[kpc / Myr2], d2_z[kpc / Myr2])
         [[0.086 0.172 0.258]
          [0.027 0.033 0.04 ]]>
+
+    - - -
+
+    :func:`~galax.potential.gradient` also supports Astropy objects, like
+    :class:`astropy.coordinates.BaseRepresentation` and
+    :class:`astropy.units.Quantity`, which are interpreted like their jax'ed
+    counterparts :class:`~coordinax.AbstractPosition3D` and
+    :class:`~unxt.Quantity`.
+
+    >>> import astropy.units as u
+    >>> import astropy.coordinates as c
+    >>> import galax.potential as gp
+
+    >>> pot = gp.KeplerPotential(m_tot=u.Quantity(1e12, "Msun"), units="galactic")
+
+    We can compute the potential energy at a position (and time, if any
+    parameters are time-dependent):
+
+    >>> q = c.CartesianRepresentation(u.Quantity([1, 2, 3], "kpc"))
+    >>> t = u.Quantity(0, "Gyr")
+    >>> print(pot.gradient(q, t))
+    <CartesianAcceleration3D (d2_x[kpc / Myr2], d2_y[kpc / Myr2], d2_z[kpc / Myr2])
+        [0.086 0.172 0.258]>
+
+    We can also compute the potential energy at multiple positions:
+
+    >>> q = c.CartesianRepresentation(u.Quantity([[1, 4], [2, 5], [3, 6]], "kpc"))
+    >>> print(pot.gradient(q, t))
+    <CartesianAcceleration3D (d2_x[kpc / Myr2], d2_y[kpc / Myr2], d2_z[kpc / Myr2])
+        [[0.086 0.172 0.258]
+         [0.027 0.033 0.04 ]]>
+
+    Instead of passing a :class:`~astropy.coordinates.Representation` (in this
+    case a :class:`~astropy.coordinates.CartesianRepresentation`), we can
+    instead pass a :class:`astropy.units.Quantity`, which is interpreted as a
+    Cartesian position:
+
+    >>> q = u.Quantity([1., 2, 3], "kpc")
+    >>> print(pot.gradient(q, t))
+    <CartesianAcceleration3D (d2_x[kpc / Myr2], d2_y[kpc / Myr2], d2_z[kpc / Myr2])
+        [0.086 0.172 0.258]>
+
+    Again, this can be batched.  If the input position object has no units (i.e.
+    is an :class:`~numpy.ndarray`), it is assumed to be in the same unit system
+    as the potential.
+
+    >>> import numpy as np
+    >>> q = jnp.asarray([[1, 2, 3], [4, 5, 6]])
+    >>> print(pot.gradient(q, t))
+    <CartesianAcceleration3D (d2_x[kpc / Myr2], d2_y[kpc / Myr2], d2_z[kpc / Myr2])
+        [[0.086 0.172 0.258]
+         [0.027 0.033 0.04 ]]>
+
     """
-    q = parse_to_quantity(q, unit=potential.units["length"])
-    t = Quantity.constructor(t, potential.units["time"])
-    return cx.CartesianAcceleration3D.constructor(potential._gradient(q, t))  # noqa: SLF001
+    q = parse_to_quantity(q, unit=pot.units["length"])
+    t = Quantity.constructor(t, pot.units["time"])
+    return cx.CartesianAcceleration3D.constructor(pot._gradient(q, t))  # noqa: SLF001
 
 
 @dispatch
 def gradient(
-    potential: AbstractPotentialBase, q: PositionalLike, /, *, t: TimeOptions
-) -> cx.CartesianAcceleration3D:  # TODO: shape hint
+    pot: AbstractPotentialBase, q: Any, /, *, t: Any
+) -> cx.CartesianAcceleration3D:
     """Compute the gradient at the given position(s).
 
     Parameters
     ----------
-    q : PositionalLike
-        The position to compute the gradient of the potential.  If unitless
-        (i.e. is an `~jax.Array`), it is assumed to be in the unit system of
-        the potential.
-    t : TimeOptions
-        The time at which to compute the gradient of the potential.  If
-        unitless (i.e. is an `~jax.Array`), it is assumed to be in the unit
-        system of the potential.
+    pot : :class:`~galax.potential.AbstractPotentialBase`, positional-only
+        The potential to compute the gradient of.
+    q : Any, positional-only
+        The position to compute the gradient of the potential.
+    t : Any, keyword-only
+        The time at which to compute the gradient of the potential.
 
     Examples
     --------
@@ -467,8 +465,8 @@ def gradient(
 
     >>> pot = gp.KeplerPotential(m_tot=Quantity(1e12, "Msun"), units="galactic")
 
-    We can compute the gradient at a position (and time, if any
-    parameters are time-dependent):
+    We can compute the gradient at a position (and time, if any parameters are
+    time-dependent):
 
     >>> q = cx.CartesianPosition3D.constructor(Quantity([1, 2, 3], "kpc"))
     >>> t = Quantity(0, "Gyr")
@@ -484,19 +482,18 @@ def gradient(
         [[0.086 0.172 0.258]
          [0.027 0.033 0.04 ]]>
 
-    Instead of passing a :class:`~vector.AbstractPosition3D` (in this case a
-    :class:`~vector.CartesianPosition3D`), we can instead pass a
-    :class:`unxt.Quantity`, which is interpreted as a Cartesian
-    position:
+    Instead of passing a :class:`~coordinax.AbstractPosition3D` (in this case a
+    :class:`~coordinax.CartesianPosition3D`), we can instead pass a
+    :class:`unxt.Quantity`, which is interpreted as a Cartesian position:
 
     >>> q = Quantity([1., 2, 3], "kpc")
     >>> print(pot.gradient(q, t))
     <CartesianAcceleration3D (d2_x[kpc / Myr2], d2_y[kpc / Myr2], d2_z[kpc / Myr2])
         [0.086 0.172 0.258]>
 
-    Again, this can be batched.  If the input position object has no units
-    (i.e. is an `~jax.Array`), it is assumed to be in the same unit system
-    as the potential.
+    Again, this can be batched.  If the input position object has no units (i.e.
+    is an `~jax.Array`), it is assumed to be in the same unit system as the
+    potential.
 
     >>> import jax.numpy as jnp
     >>> q = jnp.asarray([[1, 2, 3], [4, 5, 6]])
@@ -504,136 +501,35 @@ def gradient(
     <CartesianAcceleration3D (d2_x[kpc / Myr2], d2_y[kpc / Myr2], d2_z[kpc / Myr2])
         [[0.086 0.172 0.258]
          [0.027 0.033 0.04 ]]>
+
+    - - -
+
+    :fun:`~galax.potential.gradient` also supports Astropy objects.
+
+
+
     """
-    return _gradient(potential, q, t)
-
-
-@dispatch
-def gradient(
-    potential: AbstractPotentialBase,
-    q: APYRepresentation | APYQuantity,
-    /,
-    t: TimeOptions,
-) -> cx.CartesianAcceleration3D:  # TODO: shape hint
-    """Compute the gradient at the given position(s).
-
-    :meth:`~galax.potential.AbstractPotentialBase.gradient` also
-    supports Astropy objects, like
-    :class:`astropy.coordinates.BaseRepresentation` and
-    :class:`astropy.units.Quantity`, which are interpreted like their jax'ed
-    counterparts :class:`~vector.AbstractPosition3D` and
-    :class:`~unxt.Quantity`.
-
-    Parameters
-    ----------
-    q : PositionalLike
-        The position to compute the value of the potential.  If unitless
-        (i.e. is an `~jax.Array`), it is assumed to be in the unit system of
-        the potential.
-    t : TimeOptions
-        The time at which to compute the value of the potential.  If
-        unitless (i.e. is an `~jax.Array`), it is assumed to be in the unit
-        system of the potential.
-
-    Examples
-    --------
-    >>> from unxt import Quantity
-    >>> import coordinax as cx
-    >>> import galax.potential as gp
-
-    >>> pot = gp.KeplerPotential(m_tot=Quantity(1e12, "Msun"), units="galactic")
-
-    We can compute the potential energy at a position (and time, if any
-    parameters are time-dependent):
-
-    >>> q = cx.CartesianPosition3D.constructor(Quantity([1, 2, 3], "kpc"))
-    >>> t = Quantity(0, "Gyr")
-    >>> print(pot.gradient(q, t))
-    <CartesianAcceleration3D (d2_x[kpc / Myr2], d2_y[kpc / Myr2], d2_z[kpc / Myr2])
-        [0.086 0.172 0.258]>
-
-    We can also compute the potential energy at multiple positions:
-
-    >>> q = cx.CartesianPosition3D.constructor(Quantity([[1, 2, 3], [4, 5, 6]], "kpc"))
-    >>> print(pot.gradient(q, t))
-    <CartesianAcceleration3D (d2_x[kpc / Myr2], d2_y[kpc / Myr2], d2_z[kpc / Myr2])
-        [[0.086 0.172 0.258]
-         [0.027 0.033 0.04 ]]>
-
-    Instead of passing a :class:`~vector.AbstractPosition3D` (in this case a
-    :class:`~vector.CartesianPosition3D`), we can instead pass a
-    :class:`unxt.Quantity`, which is interpreted as a Cartesian
-    position:
-
-    >>> q = Quantity([1., 2, 3], "kpc")
-    >>> print(pot.gradient(q, t))
-    <CartesianAcceleration3D (d2_x[kpc / Myr2], d2_y[kpc / Myr2], d2_z[kpc / Myr2])
-        [0.086 0.172 0.258]>
-
-    Again, this can be batched.  If the input position object has no units
-    (i.e. is an `~jax.Array`), it is assumed to be in the same unit system
-    as the potential.
-
-    >>> import jax.numpy as jnp
-    >>> q = jnp.asarray([[1, 2, 3], [4, 5, 6]])
-    >>> print(pot.gradient(q, t))
-    <CartesianAcceleration3D (d2_x[kpc / Myr2], d2_y[kpc / Myr2], d2_z[kpc / Myr2])
-        [[0.086 0.172 0.258]
-         [0.027 0.033 0.04 ]]>
-    """
-    q = parse_to_quantity(q, unit=potential.units["length"])
-    t = Quantity.constructor(t, potential.units["time"])  # TODO: value
-    return cx.CartesianAcceleration3D.constructor(potential._gradient(q, t))  # noqa: SLF001
-
-
-@dispatch
-def gradient(
-    potential: AbstractPotentialBase,
-    q: APYRepresentation | APYQuantity,
-    /,
-    *,
-    t: TimeOptions,
-) -> cx.CartesianAcceleration3D:  # TODO: shape hint
-    """Compute the gradient when `t` is keyword-only.
-
-    Examples
-    --------
-    All these examples are covered by the case where `t` is positional.
-    :mod:`plum` dispatches on positional arguments only, so it necessary
-    to redispatch here.
-
-    >>> from unxt import Quantity
-    >>> import coordinax as cx
-    >>> import galax.potential as gp
-
-    >>> pot = gp.KeplerPotential(m_tot=Quantity(1e12, "Msun"), units="galactic")
-
-    >>> q = cx.CartesianPosition3D.constructor(Quantity([1, 2, 3], "kpc"))
-    >>> t = Quantity(0, "Gyr")
-    >>> print(pot.gradient(q, t=t))
-    <CartesianAcceleration3D (d2_x[kpc / Myr2], d2_y[kpc / Myr2], d2_z[kpc / Myr2])
-        [0.086 0.172 0.258]>
-
-    See the other examples in the positional-only case.
-    """
-    return _gradient(potential, q, t)
+    return gradient(pot, q, t)
 
 
 # =============================================================================
 # Laplacian
 
 
-@dispatch  # type: ignore[misc]
+@dispatch
 def laplacian(
-    potential: AbstractPotentialBase,
+    pot: AbstractPotentialBase,
     pspt: gc.AbstractPhaseSpacePosition | cx.FourVector,
     /,
-) -> Quantity["1/s^2"]:  # TODO: shape hint
+) -> Quantity["1/s^2"]:
     """Compute the laplacian of the potential at the given position(s).
 
     Parameters
     ----------
-    pspt : :class:`~galax.coordinates.AbstractPhaseSpacePosition`
+    pot : :class:`~galax.potential.AbstractPotentialBase`, positional-only
+        The potential to compute the laplacian of.
+    pspt : :class:`~galax.coordinates.AbstractPhaseSpacePosition`,
+    positional-only
         The phase-space + time position to compute the laplacian.
 
     Returns
@@ -670,8 +566,7 @@ def laplacian(
     >>> pot.laplacian(w)
     Quantity[...](Array([2.77555756e-17, 0.00000000e+00], dtype=float64), unit='1 / Myr2')
 
-    Instead of passing a
-    :class:`~galax.coordinates.AbstractPhaseSpacePosition`,
+    Instead of passing a :class:`~galax.coordinates.AbstractPhaseSpacePosition`,
     we can instead pass a :class:`~vector.FourVector`:
 
     >>> from coordinax import FourVector
@@ -679,26 +574,22 @@ def laplacian(
     >>> pot.laplacian(w)
     Quantity[...](Array(2.77555756e-17, dtype=float64), unit='1 / Myr2')
     """  # noqa: E501
-    q = _convert_from_3dvec(pspt.q, units=potential.units)
-    return potential._laplacian(q, pspt.t)  # noqa: SLF001
-
-
-_laplacian = laplacian  # Needed to bypass namespace restrictions
+    q = _convert_from_3dvec(pspt.q, units=pot.units)
+    return pot._laplacian(q, pspt.t)  # noqa: SLF001
 
 
 @dispatch
-def laplacian(
-    potential: AbstractPotentialBase, q: PositionalLike, /, t: TimeOptions
-) -> Quantity["1/s^2"]:  # TODO: shape hint
+def laplacian(pot: AbstractPotentialBase, q: Any, t: Any, /) -> Quantity["1/s^2"]:
     """Compute the laplacian of the potential at the given position(s).
 
     Parameters
     ----------
-    q : :class:`vector.AbstractPosition3D` | (Quantity|Array)[float, (*batch, 3)]
-        The position to compute the laplacian of the potential.  If unitless
-        (i.e. is an `~jax.Array`), it is assumed to be in the unit system of
-        the potential.
-    t : Array[float | int, *batch] | float | int
+    pot : :class:`~galax.potential.AbstractPotentialBase`, positional-only
+        The potential to compute the laplacian of.
+    q : Any, positional-only
+        The position to compute the laplacian of the potential. See
+        `parse_to_quantity` for more details.
+    t : Any, positional-only
         The time at which to compute the laplacian of the potential.  If
         unitless (i.e. is an `~jax.Array`), it is assumed to be in the unit
         system of the potential.
@@ -725,45 +616,83 @@ def laplacian(
     >>> pot.laplacian(q, t)
     Quantity[...](Array([2.77555756e-17, 0.00000000e+00], dtype=float64), unit='1 / Myr2')
 
-    Instead of passing a :class:`~vector.AbstractPosition3D` (in this case a
-    :class:`~vector.CartesianPosition3D`), we can instead pass a
-    :class:`unxt.Quantity`, which is interpreted as a Cartesian
-    position:
+    Instead of passing a :class:`~coordinax.AbstractPosition3D` (in this case a
+    :class:`~coordinax.CartesianPosition3D`), we can instead pass a
+    :class:`unxt.Quantity`, which is interpreted as a Cartesian position:
 
     >>> q = Quantity([1., 2, 3], "kpc")
     >>> pot.laplacian(q, t)
     Quantity[...](Array(2.77555756e-17, dtype=float64), unit='1 / Myr2')
 
-    Again, this can be batched.  If the input position object has no units
-    (i.e. is an `~jax.Array`), it is assumed to be in the same unit system
-    as the potential.
+    Again, this can be batched.  If the input position object has no units (i.e.
+    is an `~jax.Array`), it is assumed to be in the same unit system as the
+    potential.
 
     >>> import jax.numpy as jnp
     >>> q = jnp.asarray([[1, 2, 3], [4, 5, 6]])
     >>> pot.laplacian(q, t)
     Quantity[...](Array([2.77555756e-17, 0.00000000e+00], dtype=float64), unit='1 / Myr2')
+
+    - - -
+
+    :func:`~galax.potential.laplacian` also supports Astropy objects, like
+    :class:`astropy.coordinates.BaseRepresentation` and
+    :class:`astropy.units.Quantity`, which are interpreted like their jax'ed
+    counterparts :class:`~coordinax.AbstractPosition3D` and
+    :class:`~unxt.Quantity`.
+
+    >>> import astropy.units as u
+    >>> import astropy.coordinates as c
+
+    We can compute the potential energy at a position (and time, if any
+    parameters are time-dependent):
+
+    >>> q = c.CartesianRepresentation(u.Quantity([1, 2, 3], "kpc"))
+    >>> t = Quantity(0, "Gyr")
+    >>> pot.laplacian(q, t)
+    Quantity[...](Array(2.77555756e-17, dtype=float64), unit='1 / Myr2')
+
+    We can also compute the potential energy at multiple positions:
+
+    >>> q = c.CartesianRepresentation(u.Quantity([[1, 4], [2, 5], [3, 6]], "kpc"))
+    >>> pot.laplacian(q, t)
+    Quantity[...](Array([2.77555756e-17, 0.00000000e+00], dtype=float64), unit='1 / Myr2')
+
+    Instead of passing a :class:`~coordinax.AbstractPosition3D` (in this case a
+    :class:`~coordinax.CartesianPosition3D`), we can instead pass a
+    :class:`unxt.Quantity`, which is interpreted as a Cartesian position:
+
+    >>> q = u.Quantity([1., 2, 3], "kpc")
+    >>> pot.laplacian(q, t)
+    Quantity[...](Array(2.77555756e-17, dtype=float64), unit='1 / Myr2')
+
+    Again, this can be batched.  If the input position object has no units (i.e.
+    is a :class:`~numpy.ndarray`), it is assumed to be in the same unit system
+    as the potential.
+
+    >>> import numpy as np
+    >>> q = jnp.asarray([[1, 2, 3], [4, 5, 6]])
+    >>> pot.laplacian(q, t)
+    Quantity[...](Array([2.77555756e-17, 0.00000000e+00], dtype=float64), unit='1 / Myr2')
+
     """  # noqa: E501
-    q = parse_to_quantity(q, unit=potential.units["length"])
-    t = Quantity.constructor(t, potential.units["time"])
-    return potential._laplacian(q, t)  # noqa: SLF001
+    q = parse_to_quantity(q, unit=pot.units["length"])
+    t = Quantity.constructor(t, pot.units["time"])
+    return pot._laplacian(q, t)  # noqa: SLF001
 
 
 @dispatch
-def laplacian(
-    potential: AbstractPotentialBase, q: PositionalLike, /, *, t: TimeOptions
-) -> Quantity["1/s^2"]:  # TODO: shape hint
+def laplacian(pot: AbstractPotentialBase, q: Any, /, *, t: Any) -> Quantity["1/s^2"]:
     """Compute the laplacian at the given position(s).
 
     Parameters
     ----------
-    q : PositionalLike
-        The position to compute the laplacian of the potential.  If unitless
-        (i.e. is an `~jax.Array`), it is assumed to be in the unit system of
-        the potential.
-    t : TimeOptions
-        The time at which to compute the laplacian of the potential.  If
-        unitless (i.e. is an `~jax.Array`), it is assumed to be in the unit
-        system of the potential.
+    pot : :class:`~galax.potential.AbstractPotentialBase`, positional-only
+        The potential to compute the laplacian of.
+    q : Any, positional-only
+        The position to compute the laplacian of the potential.
+    t : Any, keyword-only
+        The time at which to compute the laplacian of the potential.
 
     Examples
     --------
@@ -773,8 +702,8 @@ def laplacian(
 
     >>> pot = gp.KeplerPotential(m_tot=Quantity(1e12, "Msun"), units="galactic")
 
-    We can compute the laplacian at a position (and time, if any
-    parameters are time-dependent):
+    We can compute the laplacian at a position (and time, if any parameters are
+    time-dependent):
 
     >>> q = cx.CartesianPosition3D.constructor(Quantity([1, 2, 3], "kpc"))
     >>> t = Quantity(0, "Gyr")
@@ -787,145 +716,42 @@ def laplacian(
     >>> pot.laplacian(q, t)
     Quantity[...](Array([2.77555756e-17, 0.00000000e+00], dtype=float64), unit='1 / Myr2')
 
-    Instead of passing a :class:`~vector.AbstractPosition3D` (in this case a
-    :class:`~vector.CartesianPosition3D`), we can instead pass a
-    :class:`unxt.Quantity`, which is interpreted as a Cartesian
-    position:
+    Instead of passing a :class:`~coordinax.AbstractPosition3D` (in this case a
+    :class:`~coordinax.CartesianPosition3D`), we can instead pass a
+    :class:`unxt.Quantity`, which is interpreted as a Cartesian position:
 
     >>> q = Quantity([1., 2, 3], "kpc")
     >>> pot.laplacian(q, t)
     Quantity[...](Array(2.77555756e-17, dtype=float64), unit='1 / Myr2')
 
-    Again, this can be batched.  If the input position object has no units
-    (i.e. is an `~jax.Array`), it is assumed to be in the same unit system
-    as the potential.
+    Again, this can be batched.  If the input position object has no units (i.e.
+    is an `~jax.Array`), it is assumed to be in the same unit system as the
+    potential.
 
     >>> import jax.numpy as jnp
     >>> q = jnp.asarray([[1, 2, 3], [4, 5, 6]])
     >>> pot.laplacian(q, t)
     Quantity[...](Array([2.77555756e-17, 0.00000000e+00], dtype=float64), unit='1 / Myr2')
     """  # noqa: E501
-    return _laplacian(potential, q, t)
-
-
-@dispatch
-def laplacian(
-    potential: AbstractPotentialBase,
-    q: APYRepresentation | APYQuantity,
-    /,
-    t: TimeOptions,
-) -> Quantity["1/s^2"]:  # TODO: shape hint
-    """Compute the laplacian at the given position(s).
-
-    :meth:`~galax.potential.AbstractPotentialBase.laplacian` also
-    supports Astropy objects, like
-    :class:`astropy.coordinates.BaseRepresentation` and
-    :class:`astropy.units.Quantity`, which are interpreted like their jax'ed
-    counterparts :class:`~vector.AbstractPosition3D` and
-    :class:`~unxt.Quantity`.
-
-    Parameters
-    ----------
-    q : PositionalLike
-        The position to compute the value of the potential.  If unitless
-        (i.e. is an `~jax.Array`), it is assumed to be in the unit system of
-        the potential.
-    t : TimeOptions
-        The time at which to compute the value of the potential.  If
-        unitless (i.e. is an `~jax.Array`), it is assumed to be in the unit
-        system of the potential.
-
-    Examples
-    --------
-    >>> from unxt import Quantity
-    >>> import coordinax as cx
-    >>> import galax.potential as gp
-
-    >>> pot = gp.KeplerPotential(m_tot=Quantity(1e12, "Msun"), units="galactic")
-
-    We can compute the potential energy at a position (and time, if any
-    parameters are time-dependent):
-
-    >>> q = cx.CartesianPosition3D.constructor(Quantity([1, 2, 3], "kpc"))
-    >>> t = Quantity(0, "Gyr")
-    >>> pot.laplacian(q, t)
-    Quantity[...](Array(2.77555756e-17, dtype=float64), unit='1 / Myr2')
-
-    We can also compute the potential energy at multiple positions:
-
-    >>> q = cx.CartesianPosition3D.constructor(Quantity([[1, 2, 3], [4, 5, 6]], "kpc"))
-    >>> pot.laplacian(q, t)
-    Quantity[...](Array([2.77555756e-17, 0.00000000e+00], dtype=float64), unit='1 / Myr2')
-
-    Instead of passing a :class:`~vector.AbstractPosition3D` (in this case a
-    :class:`~vector.CartesianPosition3D`), we can instead pass a
-    :class:`unxt.Quantity`, which is interpreted as a Cartesian
-    position:
-
-    >>> q = Quantity([1., 2, 3], "kpc")
-    >>> pot.laplacian(q, t)
-    Quantity[...](Array(2.77555756e-17, dtype=float64), unit='1 / Myr2')
-
-    Again, this can be batched.  If the input position object has no units
-    (i.e. is an `~jax.Array`), it is assumed to be in the same unit system
-    as the potential.
-
-    >>> import jax.numpy as jnp
-    >>> q = jnp.asarray([[1, 2, 3], [4, 5, 6]])
-    >>> pot.laplacian(q, t)
-    Quantity[...](Array([2.77555756e-17, 0.00000000e+00], dtype=float64), unit='1 / Myr2')
-    """  # noqa: E501
-    q = parse_to_quantity(q, unit=potential.units["length"])
-    t = Quantity.constructor(t, potential.units["time"])
-    return potential._laplacian(q, t)  # noqa: SLF001
-
-
-@dispatch
-def laplacian(
-    potential: AbstractPotentialBase,
-    q: APYRepresentation | APYQuantity,
-    /,
-    *,
-    t: TimeOptions,
-) -> Quantity["1/s^2"]:  # TODO: shape hint
-    """Compute the laplacian when `t` is keyword-only.
-
-    Examples
-    --------
-    All these examples are covered by the case where `t` is positional.
-    :mod:`plum` dispatches on positional arguments only, so it necessary
-    to redispatch here.
-
-    >>> from unxt import Quantity
-    >>> import coordinax as cx
-    >>> import galax.potential as gp
-
-    >>> pot = gp.KeplerPotential(m_tot=Quantity(1e12, "Msun"), units="galactic")
-
-    >>> q = cx.CartesianPosition3D.constructor(Quantity([1, 2, 3], "kpc"))
-    >>> t = Quantity(0, "Gyr")
-    >>> pot.laplacian(q, t=t)
-    Quantity[...](Array(2.77555756e-17, dtype=float64), unit='1 / Myr2')
-
-    See the other examples in the positional-only case.
-    """
-    return _laplacian(potential, q, t)
+    return laplacian(pot, q, t)
 
 
 # =============================================================================
 # Density
 
 
-@dispatch  # type: ignore[misc]
+@dispatch
 def density(
-    potential: AbstractPotentialBase,
+    pot: AbstractPotentialBase,
     pspt: gc.AbstractPhaseSpacePosition | cx.FourVector,
     /,
-) -> Quantity["mass density"]:  # TODO: shape hint
+) -> Quantity["mass density"]:
     """Compute the density at the given position(s).
 
     Parameters
     ----------
+    pot : :class:`~galax.potential.AbstractPotentialBase`, positional-only
+        The potential to compute the density of.
     pspt : :class:`~galax.coordinates.AbstractPhaseSpacePosition`
         The phase-space + time position to compute the density.
 
@@ -963,8 +789,7 @@ def density(
     >>> pot.density(w)
     Quantity['mass density'](Array([0., 0.], dtype=float64), unit='solMass / kpc3')
 
-    Instead of passing a
-    :class:`~galax.coordinates.AbstractPhaseSpacePosition`,
+    Instead of passing a :class:`~galax.coordinates.AbstractPhaseSpacePosition`,
     we can instead pass a :class:`~vector.FourVector`:
 
     >>> from coordinax import FourVector
@@ -972,29 +797,22 @@ def density(
     >>> pot.density(w)
     Quantity['mass density'](Array(0., dtype=float64), unit='solMass / kpc3')
     """
-    q = _convert_from_3dvec(pspt.q, units=potential.units)
-    return potential._density(q, pspt.t)  # noqa: SLF001
-
-
-_density = density  # Needed to bypass namespace restrictions
+    q = _convert_from_3dvec(pspt.q, units=pot.units)
+    return pot._density(q, pspt.t)  # noqa: SLF001
 
 
 @dispatch
-def density(
-    potential: AbstractPotentialBase, q: PositionalLike, /, t: TimeOptions
-) -> Quantity["mass density"]:  # TODO: shape hint
+def density(pot: AbstractPotentialBase, q: Any, t: Any, /) -> Quantity["mass density"]:
     """Compute the density at the given position(s).
 
     Parameters
     ----------
-    q : PositionalLike
-        The position to compute the density of the potential.  If unitless
-        (i.e. is an `~jax.Array`), it is assumed to be in the unit system of
-        the potential.
-    t : TimeOptions
-        The time at which to compute the density of the potential.  If
-        unitless (i.e. is an `~jax.Array`), it is assumed to be in the unit
-        system of the potential.
+    q : Any, positional-only
+        The position to compute the density of the potential.
+        See `parse_to_quantity` for more details.
+    t : Any, positional-only
+        The time at which to compute the density of the potential.
+        See :meth:`unxt.Quantity.constructor` for more details.
 
     Examples
     --------
@@ -1004,8 +822,8 @@ def density(
 
     >>> pot = gp.KeplerPotential(m_tot=Quantity(1e12, "Msun"), units="galactic")
 
-    We can compute the density at a position (and time, if any
-    parameters are time-dependent):
+    We can compute the density at a position (and time, if any parameters are
+    time-dependent):
 
     >>> q = cx.CartesianPosition3D.constructor(Quantity([1, 2, 3], "kpc"))
     >>> t = Quantity(0, "Gyr")
@@ -1018,84 +836,37 @@ def density(
     >>> pot.density(q, t)
     Quantity['mass density'](Array([0., 0.], dtype=float64), unit='solMass / kpc3')
 
-    Instead of passing a :class:`~vector.AbstractPosition3D` (in this case a
-    :class:`~vector.CartesianPosition3D`), we can instead pass a
-    :class:`unxt.Quantity`, which is interpreted as a Cartesian
-    position:
+    Instead of passing a :class:`~coordinax.AbstractPosition3D` (in this case a
+    :class:`~coordinax.CartesianPosition3D`), we can instead pass a
+    :class:`unxt.Quantity`, which is interpreted as a Cartesian position:
 
     >>> q = Quantity([1., 2, 3], "kpc")
     >>> pot.density(q, t)
     Quantity['mass density'](Array(0., dtype=float64), unit='solMass / kpc3')
 
-    Again, this can be batched.  If the input position object has no units
-    (i.e. is an `~jax.Array`), it is assumed to be in the same unit system
-    as the potential.
+    Again, this can be batched.  If the input position object has no units (i.e.
+    is an `~jax.Array`), it is assumed to be in the same unit system as the
+    potential.
 
     >>> import jax.numpy as jnp
     >>> q = jnp.asarray([[1, 2, 3], [4, 5, 6]])
     >>> pot.density(q, t)
     Quantity['mass density'](Array([0., 0.], dtype=float64), unit='solMass / kpc3')
-    """
-    q = parse_to_quantity(q, unit=potential.units["length"])
-    t = Quantity.constructor(t, potential.units["time"])
-    return potential._density(q, t)  # noqa: SLF001
 
+    - - -
 
-@dispatch
-def density(
-    potential: AbstractPotentialBase, q: PositionalLike, /, *, t: TimeOptions
-) -> Quantity["mass density"]:
-    """Compute the density when `t` is keyword-only.
-
-    Examples
-    --------
-    All these examples are covered by the case where `t` is positional.
-    :mod:`plum` dispatches on positional arguments only, so it necessary
-    to redispatch here.
-
-    >>> from unxt import Quantity
-    >>> import coordinax as cx
-    >>> import galax.potential as gp
-
-    >>> pot = gp.KeplerPotential(m_tot=Quantity(1e12, "Msun"), units="galactic")
-
-    >>> q = cx.CartesianPosition3D.constructor(Quantity([1, 2, 3], "kpc"))
-    >>> t = Quantity(0, "Gyr")
-    >>> pot.density(q, t=t)
-    Quantity['mass density'](Array(0., dtype=float64), unit='solMass / kpc3')
-
-    See the other examples in the positional-only case.
-    """
-    return _density(potential, q, t)
-
-
-@dispatch
-def density(
-    potential: AbstractPotentialBase,
-    q: APYRepresentation | APYQuantity | np.ndarray,
-    /,
-    t: TimeOptions,
-) -> Quantity["mass density"]:  # TODO: shape hint
-    """Compute the density at the given position(s).
-
-    :meth:`~galax.potential.AbstractPotentialBase.density` also
-    supports Astropy objects, like
-    :class:`astropy.coordinates.BaseRepresentation` and
+    meth:`~galax.potential.AbstractPotentialBase.density` also supports Astropy
+    objects, like :class:`astropy.coordinates.BaseRepresentation` and
     :class:`astropy.units.Quantity`, which are interpreted like their jax'ed
-    counterparts :class:`~vector.AbstractPosition3D` and
+    counterparts :class:`~coordinax.AbstractPosition3D` and
     :class:`~unxt.Quantity`.
 
-    Examples
-    --------
     >>> import numpy as np
     >>> import astropy.coordinates as c
     >>> import astropy.units as u
-    >>> import galax.potential as gp
 
-    >>> pot = gp.KeplerPotential(m_tot=u.Quantity(1e12, "Msun"), units="galactic")
-
-    We can compute the density at a position (and time, if any
-    parameters are time-dependent):
+    We can compute the density at a position (and time, if any parameters are
+    time-dependent):
 
     >>> q = c.CartesianRepresentation([1, 2, 3], unit=u.kpc)
     >>> t = u.Quantity(0, "Gyr")
@@ -1108,67 +879,74 @@ def density(
     >>> pot.density(q, t)
     Quantity['mass density'](Array([0., 0.], dtype=float64), unit='solMass / kpc3')
 
-    Instead of passing a
-    :class:`astropy.coordinates.CartesianRepresentation`,
-    we can instead pass a :class:`astropy.units.Quantity`, which is
-    interpreted as a Cartesian position:
+    Instead of passing a :class:`astropy.coordinates.CartesianRepresentation`,
+    we can instead pass a :class:`astropy.units.Quantity`, which is interpreted
+    as a Cartesian position:
 
     >>> q = u.Quantity([1, 2, 3], "kpc")
     >>> pot.density(q, t)
     Quantity['mass density'](Array(0., dtype=float64), unit='solMass / kpc3')
 
-    Again, this can be batched.  Also, If the input position object has no
-    units (i.e. is an `~numpy.ndarray`), it is assumed to be in the same
-    unit system as the potential.
+    Again, this can be batched.  Also, If the input position object has no units
+    (i.e. is an `~numpy.ndarray`), it is assumed to be in the same unit system
+    as the potential.
 
     >>> q = np.array([[1, 2, 3], [4, 5, 6]])
     >>> pot.density(q, t)
     Quantity['mass density'](Array([0., 0.], dtype=float64), unit='solMass / kpc3')
     """
-    q = parse_to_quantity(q, unit=potential.units["length"])
-    t = Quantity.constructor(t, potential.units["time"])
-    return potential._density(q, t)  # noqa: SLF001
+    q = parse_to_quantity(q, unit=pot.units["length"])
+    t = Quantity.constructor(t, pot.units["time"])
+    return pot._density(q, t)  # noqa: SLF001
 
 
 @dispatch
 def density(
-    potential: AbstractPotentialBase,
-    q: APYRepresentation | APYQuantity | np.ndarray,
-    /,
-    *,
-    t: TimeOptions,
-) -> Quantity["mass density"]:  # TODO: shape hint
+    pot: AbstractPotentialBase, q: Any, /, *, t: Any
+) -> Quantity["mass density"]:
     """Compute the density when `t` is keyword-only.
 
     Examples
     --------
+    All these examples are covered by the case where `t` is positional.
+    :mod:`plum` dispatches on positional arguments only, so it necessary to
+    redispatch here. See the other examples in the positional-only case.
+
+    >>> from unxt import Quantity
+    >>> import coordinax as cx
+    >>> import galax.potential as gp
+
+    >>> pot = gp.KeplerPotential(m_tot=Quantity(1e12, "Msun"), units="galactic")
+
+    >>> q = cx.CartesianPosition3D.constructor(Quantity([1, 2, 3], "kpc"))
+    >>> t = Quantity(0, "Gyr")
+    >>> pot.density(q, t=t)
+    Quantity['mass density'](Array(0., dtype=float64), unit='solMass / kpc3')
+
+    - - -
+
+    :func:`~galax.potential.density` also supports Astropy objects.
+
     >>> import numpy as np
     >>> import astropy.coordinates as c
     >>> import astropy.units as u
-    >>> import galax.potential as gp
-
-    >>> pot = gp.KeplerPotential(m_tot=u.Quantity(1e12, "Msun"), units="galactic")
-
-    We can compute the density at a position (and time, if any
-    parameters are time-dependent):
 
     >>> q = c.CartesianRepresentation([1, 2, 3], unit=u.kpc)
     >>> t = u.Quantity(0, "Gyr")
     >>> pot.density(q, t=t)
     Quantity['mass density'](Array(0., dtype=float64), unit='solMass / kpc3')
 
-    See the other examples in the positional-only case.
     """
-    return _density(potential, q, t)
+    return density(pot, q, t)
 
 
 # =============================================================================
 # Hessian
 
 
-@dispatch  # type: ignore[misc]
+@dispatch
 def hessian(
-    potential: AbstractPotentialBase,
+    pot: AbstractPotentialBase,
     pspt: gc.AbstractPhaseSpacePosition | cx.FourVector,
     /,
 ) -> gt.BatchQMatrix33:
@@ -1177,8 +955,7 @@ def hessian(
     Parameters
     ----------
     pspt : :class:`~galax.coordinates.AbstractPhaseSpacePosition`
-        The phase-space + time position to compute the hessian of the
-        potential.
+        The phase-space + time position to compute the hessian of the potential.
 
     Returns
     -------
@@ -1223,8 +1000,7 @@ def hessian(
                           [-0.00622549, -0.00778186, -0.00268042]]], dtype=float64),
                     unit='1 / Myr2')
 
-    Instead of passing a
-    :class:`~galax.coordinates.AbstractPhaseSpacePosition`,
+    Instead of passing a :class:`~galax.coordinates.AbstractPhaseSpacePosition`,
     we can instead pass a :class:`~vector.FourVector`:
 
     >>> from coordinax import FourVector
@@ -1235,29 +1011,22 @@ def hessian(
                          [-0.05520652, -0.11041304, -0.07974275]], dtype=float64),
                     unit='1 / Myr2')
     """
-    q = _convert_from_3dvec(pspt.q, units=potential.units)
-    return potential._hessian(q, pspt.t)  # noqa: SLF001
-
-
-_hessian = hessian  # Needed to bypass namespace restrictions
+    q = _convert_from_3dvec(pspt.q, units=pot.units)
+    return pot._hessian(q, pspt.t)  # noqa: SLF001
 
 
 @dispatch
-def hessian(
-    potential: AbstractPotentialBase, q: PositionalLike, /, t: TimeOptions
-) -> HessianVec:
+def hessian(pot: AbstractPotentialBase, q: Any, t: Any, /) -> HessianVec:
     """Compute the hessian of the potential at the given position(s).
 
     Parameters
     ----------
-    q : PositionalLike
-        The position to compute the hessian of the potential.  If unitless
-        (i.e. is an `~jax.Array`), it is assumed to be in the unit system of
-        the potential.
-    t : TimeOptions
-        The time at which to compute the hessian of the potential.  If
-        unitless (i.e. is an `~jax.Array`), it is assumed to be in the unit
-        system of the potential.
+    q : Any, positional-only
+        The position to compute the hessian of the potential. See
+        `parse_to_quantity` for more details.
+    t : Any, positional-only
+        The time at which to compute the hessian of the potential. See
+        :meth:`~unxt.array.Quantity.constructor` for more details.
 
     Examples
     --------
@@ -1267,8 +1036,8 @@ def hessian(
 
     >>> pot = gp.KeplerPotential(m_tot=Quantity(1e12, "Msun"), units="galactic")
 
-    We can compute the hessian at a position (and time, if any
-    parameters are time-dependent):
+    We can compute the hessian at a position (and time, if any parameters are
+    time-dependent):
 
     >>> q = cx.CartesianPosition3D.constructor(Quantity([1, 2, 3], "kpc"))
     >>> t = Quantity(0, "Gyr")
@@ -1290,10 +1059,9 @@ def hessian(
                           [-0.00622549, -0.00778186, -0.00268042]]], dtype=float64),
                     unit='1 / Myr2')
 
-    Instead of passing a :class:`~vector.AbstractPosition3D` (in this case a
-    :class:`~vector.CartesianPosition3D`), we can instead pass a
-    :class:`unxt.Quantity`, which is interpreted as a Cartesian
-    position:
+    Instead of passing a :class:`~coordinax.AbstractPosition3D` (in this case a
+    :class:`~coordinax.CartesianPosition3D`), we can instead pass a
+    :class:`unxt.Quantity`, which is interpreted as a Cartesian position:
 
     >>> q = Quantity([1., 2, 3], "kpc")
     >>> pot.hessian(q, t)
@@ -1302,9 +1070,9 @@ def hessian(
                          [-0.05520652, -0.11041304, -0.07974275]], dtype=float64),
                     unit='1 / Myr2')
 
-    Again, this can be batched.  If the input position object has no units
-    (i.e. is an `~jax.Array`), it is assumed to be in the same unit system
-    as the potential.
+    Again, this can be batched.  If the input position object has no units (i.e.
+    is an `~jax.Array`), it is assumed to be in the same unit system as the
+    potential.
 
     >>> import jax.numpy as jnp
     >>> q = jnp.asarray([[1, 2, 3], [4, 5, 6]])
@@ -1316,70 +1084,21 @@ def hessian(
                           [-0.00518791,  0.00017293, -0.00778186],
                           [-0.00622549, -0.00778186, -0.00268042]]], dtype=float64),
                     unit='1 / Myr2')
-    """
-    q = parse_to_quantity(q, unit=potential.units["length"])
-    t = Quantity.constructor(t, potential.units["time"])
-    return potential._hessian(q, t)  # noqa: SLF001
 
+    - - -
 
-@dispatch
-def hessian(
-    potential: AbstractPotentialBase, q: PositionalLike, /, *, t: TimeOptions
-) -> HessianVec:
-    """Compute the hessian when `t` is keyword-only.
-
-    Examples
-    --------
-    All these examples are covered by the case where `t` is positional.
-    :mod:`plum` dispatches on positional arguments only, so it necessary
-    to redispatch here.
-
-    >>> from unxt import Quantity
-    >>> import coordinax as cx
-    >>> import galax.potential as gp
-
-    >>> pot = gp.KeplerPotential(m_tot=Quantity(1e12, "Msun"), units="galactic")
-
-    >>> q = cx.CartesianPosition3D.constructor(Quantity([1, 2, 3], "kpc"))
-    >>> t = Quantity(0, "Gyr")
-    >>> pot.hessian(q, t=t)
-    Quantity[...](Array([[ 0.06747463, -0.03680435, -0.05520652],
-                         [-0.03680435,  0.01226812, -0.11041304],
-                         [-0.05520652, -0.11041304, -0.07974275]], dtype=float64),
-                    unit='1 / Myr2')
-
-    See the other examples in the positional-only case.
-    """
-    return _hessian(potential, q, t)
-
-
-@dispatch
-def hessian(
-    potential: AbstractPotentialBase,
-    q: APYRepresentation | APYQuantity | np.ndarray,
-    /,
-    t: TimeOptions,
-) -> HessianVec:
-    """Compute the hessian at the given position(s).
-
-    :meth:`~galax.potential.AbstractPotentialBase.hessian` also
-    supports Astropy objects, like
+    :func:`~galax.potential.hessian` also supports Astropy objects, like
     :class:`astropy.coordinates.BaseRepresentation` and
     :class:`astropy.units.Quantity`, which are interpreted like their jax'ed
-    counterparts :class:`~vector.AbstractPosition3D` and
+    counterparts :class:`~coordinax.AbstractPosition3D` and
     :class:`~unxt.Quantity`.
 
-    Examples
-    --------
     >>> import numpy as np
     >>> import astropy.coordinates as c
     >>> import astropy.units as u
-    >>> import galax.potential as gp
 
-    >>> pot = gp.KeplerPotential(m_tot=u.Quantity(1e12, "Msun"), units="galactic")
-
-    We can compute the hessian at a position (and time, if any
-    parameters are time-dependent):
+    We can compute the hessian at a position (and time, if any parameters are
+    time-dependent):
 
     >>> q = c.CartesianRepresentation([1, 2, 3], unit=u.kpc)
     >>> t = u.Quantity(0, "Gyr")
@@ -1401,10 +1120,9 @@ def hessian(
                           [-0.00258882, -0.00647205, -0.00533944]]], dtype=float64),
                     unit='1 / Myr2')
 
-    Instead of passing a
-    :class:`astropy.coordinates.CartesianRepresentation`,
-    we can instead pass a :class:`astropy.units.Quantity`, which is
-    interpreted as a Cartesian position:
+    Instead of passing a :class:`astropy.coordinates.CartesianRepresentation`,
+    we can instead pass a :class:`astropy.units.Quantity`, which is interpreted
+    as a Cartesian position:
 
     >>> q = u.Quantity([1, 2, 3], "kpc")
     >>> pot.hessian(q, t)
@@ -1413,9 +1131,9 @@ def hessian(
                          [-0.05520652, -0.11041304, -0.07974275]], dtype=float64),
                     unit='1 / Myr2')
 
-    Again, this can be batched.  Also, If the input position object has no
-    units (i.e. is an `~numpy.ndarray`), it is assumed to be in the same
-    unit system as the potential.
+    Again, this can be batched.  Also, If the input position object has no units
+    (i.e. is an `~numpy.ndarray`), it is assumed to be in the same unit system
+    as the potential.
 
     >>> q = np.array([[1, 2, 3], [4, 5, 6]])
     >>> pot.hessian(q, t)
@@ -1427,20 +1145,36 @@ def hessian(
                           [-0.00622549, -0.00778186, -0.00268042]]], dtype=float64),
                     unit='1 / Myr2')
     """
-    q = parse_to_quantity(q, unit=potential.units["length"])
-    t = Quantity.constructor(t, potential.units["time"])
-    return potential._hessian(q, t)  # noqa: SLF001
+    q = parse_to_quantity(q, unit=pot.units["length"])
+    t = Quantity.constructor(t, pot.units["time"])
+    return pot._hessian(q, t)  # noqa: SLF001
 
 
 @dispatch
-def hessian(
-    potential: AbstractPotentialBase,
-    q: APYRepresentation | APYQuantity | np.ndarray,
-    /,
-    *,
-    t: TimeOptions,
-) -> HessianVec:
-    return _hessian(potential, q, t)
+def hessian(pot: AbstractPotentialBase, q: Any, /, *, t: Any) -> HessianVec:
+    """Compute the hessian when `t` is keyword-only.
+
+    Examples
+    --------
+    All these examples are covered by the case where `t` is positional.
+    :mod:`plum` dispatches on positional arguments only, so it necessary to
+    redispatch here. See the other examples in the positional-only case.
+
+    >>> from unxt import Quantity
+    >>> import coordinax as cx
+    >>> import galax.potential as gp
+
+    >>> pot = gp.KeplerPotential(m_tot=Quantity(1e12, "Msun"), units="galactic")
+
+    >>> q = cx.CartesianPosition3D.constructor(Quantity([1, 2, 3], "kpc"))
+    >>> t = Quantity(0, "Gyr")
+    >>> pot.hessian(q, t=t)
+    Quantity[...](Array([[ 0.06747463, -0.03680435, -0.05520652],
+                         [-0.03680435,  0.01226812, -0.11041304],
+                         [-0.05520652, -0.11041304, -0.07974275]], dtype=float64),
+                    unit='1 / Myr2')
+    """
+    return hessian(pot, q, t)
 
 
 # =============================================================================
@@ -1449,11 +1183,11 @@ def hessian(
 
 @dispatch  # type: ignore[misc]
 def acceleration(
-    potential: AbstractPotentialBase,
+    pot: AbstractPotentialBase,
     /,
     *args: Any,  # defer to `gradient`
     **kwargs: Any,  # defer to `gradient`
-) -> cx.CartesianAcceleration3D:  # TODO: shape hint
+) -> cx.CartesianAcceleration3D:
     """Compute the acceleration due to the potential at the given position(s).
 
     Parameters
@@ -1527,8 +1261,8 @@ def acceleration(
         [[-0.086 -0.172 -0.258]
          [-0.027 -0.033 -0.04 ]]>
 
-    Instead of passing a :class:`~vector.AbstractPosition3D` (in this case a
-    :class:`~vector.CartesianPosition3D`), we can instead pass a
+    Instead of passing a :class:`~coordinax.AbstractPosition3D` (in this case a
+    :class:`~coordinax.CartesianPosition3D`), we can instead pass a
     :class:`unxt.Quantity`, which is interpreted as a Cartesian position:
 
     >>> q = Quantity([1., 2, 3], "kpc")
@@ -1547,16 +1281,16 @@ def acceleration(
         [[-0.086 -0.172 -0.258]
          [-0.027 -0.033 -0.04 ]]>
     """
-    return -gradient(potential, *args, **kwargs)
+    return -gradient(pot, *args, **kwargs)
 
 
 # =============================================================================
 # Tidal Tensor
 
 
-@dispatch
+@dispatch  # type: ignore[misc]
 def tidal_tensor(
-    potential: AbstractPotentialBase, *args: Any, **kwargs: Any
+    pot: AbstractPotentialBase, *args: Any, **kwargs: Any
 ) -> gt.BatchQMatrix33:
     """Compute the tidal tensor.
 
@@ -1564,8 +1298,8 @@ def tidal_tensor(
 
     .. note::
 
-        This is in cartesian coordinates with a Euclidean metric.
-        Also, this isn't correct for GR.
+        This is in cartesian coordinates with a Euclidean metric. Also, this
+        isn't correct for GR.
 
     Parameters
     ----------
@@ -1617,8 +1351,7 @@ def tidal_tensor(
                           [-0.00622549, -0.00778186, -0.00268042]]], dtype=float64),
                     unit='1 / Myr2')
 
-    Instead of passing a
-    :class:`~galax.coordinates.AbstractPhaseSpacePosition`,
+    Instead of passing a :class:`~galax.coordinates.AbstractPhaseSpacePosition`,
     we can instead pass a :class:`~vector.FourVector`:
 
     >>> from coordinax import FourVector
@@ -1651,10 +1384,9 @@ def tidal_tensor(
                           [-0.00622549, -0.00778186, -0.00268042]]], dtype=float64),
                     unit='1 / Myr2')
 
-    Instead of passing a :class:`~vector.AbstractPosition3D` (in this case a
-    :class:`~vector.CartesianPosition3D`), we can instead pass a
-    :class:`unxt.Quantity`, which is interpreted as a Cartesian
-    position:
+    Instead of passing a :class:`~coordinax.AbstractPosition3D` (in this case a
+    :class:`~coordinax.CartesianPosition3D`), we can instead pass a
+    :class:`unxt.Quantity`, which is interpreted as a Cartesian position:
 
     >>> q = Quantity([1., 2, 3], "kpc")
     >>> pot.tidal_tensor(q, t)
@@ -1663,9 +1395,9 @@ def tidal_tensor(
                          [-0.05520652, -0.11041304, -0.07974275]], dtype=float64),
                     unit='1 / Myr2')
 
-    Again, this can be batched.  If the input position object has no units
-    (i.e. is an `~jax.Array`), it is assumed to be in the same unit system
-    as the potential.
+    Again, this can be batched.  If the input position object has no units (i.e.
+    is an `~jax.Array`), it is assumed to be in the same unit system as the
+    potential.
 
     >>> import jax.numpy as jnp
     >>> q = jnp.asarray([[1, 2, 3], [4, 5, 6]])
@@ -1678,8 +1410,8 @@ def tidal_tensor(
                           [-0.00622549, -0.00778186, -0.00268042]]], dtype=float64),
                     unit='1 / Myr2')
 
-    :mod:`plum` dispatches on positional arguments only, so it necessary
-    to redispatch when `t` is a keyword argument.
+    :mod:`plum` dispatches on positional arguments only, so it necessary to
+    redispatch when `t` is a keyword argument.
 
     >>> from unxt import Quantity
     >>> import coordinax as cx
@@ -1694,41 +1426,19 @@ def tidal_tensor(
                          [-0.03680435,  0.01226812, -0.11041304],
                          [-0.05520652, -0.11041304, -0.07974275]], dtype=float64),
                     unit='1 / Myr2')
-    """
-    J = hessian(potential, *args, **kwargs)  # (*batch, 3, 3)
-    batch_shape, arr_shape = batched_shape(J, expect_ndim=2)  # (*batch), (3, 3)
-    traced = (
-        expand_batch_dims(xp.eye(3), ndim=len(batch_shape))
-        * expand_arr_dims(qnp.trace(J, axis1=-2, axis2=-1), ndim=len(arr_shape))
-        / 3
-    )
-    return J - traced
 
+    - - -
 
-@dispatch
-def tidal_tensor(
-    potential: AbstractPotentialBase,
-    q: APYRepresentation | APYQuantity,
-    t: TimeOptions,
-    /,
-) -> gt.BatchQMatrix33:
-    """Compute the tidal tensor at the given position(s).
-
-    :meth:`~galax.potential.AbstractPotentialBase.tidal_tensor` also
+    :func:`~galax.potential.tidal_tensor` also
     supports Astropy objects, like
     :class:`astropy.coordinates.BaseRepresentation` and
     :class:`astropy.units.Quantity`, which are interpreted like their jax'ed
-    counterparts :class:`~vector.AbstractPosition3D` and
+    counterparts :class:`~coordinax.AbstractPosition3D` and
     :class:`~unxt.Quantity`.
 
-    Examples
-    --------
     >>> import numpy as np
     >>> import astropy.coordinates as c
     >>> import astropy.units as u
-    >>> import galax.potential as gp
-
-    >>> pot = gp.KeplerPotential(m_tot=u.Quantity(1e12, "Msun"), units="galactic")
 
     We can compute the tidal tensor at a position (and time, if any
     parameters are time-dependent):
@@ -1767,20 +1477,14 @@ def tidal_tensor(
 
     Again, this can be batched.
     """
-    q = parse_to_quantity(q, unit=potential.units["length"])
-    t = Quantity.constructor(t, potential.units["time"])
-    return tidal_tensor(potential, q, t)
-
-
-@dispatch
-def tidal_tensor(
-    potential: AbstractPotentialBase,
-    q: APYRepresentation | APYQuantity,
-    /,
-    *,
-    t: TimeOptions,
-) -> gt.BatchQMatrix33:
-    return tidal_tensor(potential, q, t)
+    J = hessian(pot, *args, **kwargs)  # (*batch, 3, 3)
+    batch_shape, arr_shape = batched_shape(J, expect_ndim=2)  # (*batch), (3, 3)
+    traced = (
+        expand_batch_dims(xp.eye(3), ndim=len(batch_shape))
+        * expand_arr_dims(qnp.trace(J, axis1=-2, axis2=-1), ndim=len(arr_shape))
+        / 3
+    )
+    return J - traced
 
 
 # =============================================================================
@@ -1807,7 +1511,7 @@ def _r_hat(x: gt.LengthBatchVec3, /) -> Shaped[Quantity[""], "*batch 3"]:
 # TODO: make public
 @partial(jax.jit, inline=True)
 def dphi_dr(
-    potential: AbstractPotentialBase,
+    pot: AbstractPotentialBase,
     x: gt.LengthBatchVec3,
     t: gt.TimeScalar,
 ) -> Shaped[Quantity["acceleration"], "*batch"]:
@@ -1827,7 +1531,7 @@ def dphi_dr(
     Quantity[float, (3,), 'acceleration']:
         Derivative of potential
     """
-    grad = convert(gradient(potential, x, t), Quantity)
+    grad = convert(gradient(pot, x, t), Quantity)
     return xp.sum(grad * _r_hat(x), axis=-1)
 
 
@@ -1835,7 +1539,7 @@ def dphi_dr(
 @partial(jax.jit)
 @partial(qnp.vectorize, excluded=(0,), signature="(3),()->()")
 def d2phi_dr2(
-    potential: AbstractPotentialBase, x: gt.LengthVec3, t: gt.TimeScalar, /
+    pot: AbstractPotentialBase, x: gt.LengthVec3, t: gt.TimeScalar, /
 ) -> Shaped[Quantity["1/s^2"], ""]:
     """Compute the second derivative of the potential.
 
@@ -1867,4 +1571,4 @@ def d2phi_dr2(
     rhat = _r_hat(x)
     # TODO: this isn't vectorized
     d2phi_dr2_func = grad(dphi_dr, argnums=1, units=(None, x.unit, t.unit))
-    return xp.sum(d2phi_dr2_func(potential, x, t) * rhat)
+    return xp.sum(d2phi_dr2_func(pot, x, t) * rhat)

--- a/src/galax/potential/_potential/utils.py
+++ b/src/galax/potential/_potential/utils.py
@@ -92,5 +92,6 @@ def _convert_from_astropy_quantity(value: APYQuantity, /, **_: Any) -> Array:
 
 
 @parse_to_quantity.register(BaseRepresentation)
-def _convert_from_astropy_baserep(value: BaseRepresentation, /, **_: Any) -> Array:
-    return _convert_from_3dvec(convert(value, cx.CartesianPosition3D))
+def _convert_from_astropy_baserep(rep: BaseRepresentation, /, **_: Any) -> Array:
+    cart = convert(rep, cx.CartesianPosition3D)
+    return _convert_from_3dvec(cart)

--- a/src/galax/utils/_optional_deps.py
+++ b/src/galax/utils/_optional_deps.py
@@ -19,6 +19,10 @@ def get_version(package_name: str) -> Version | Literal[False]:
     return parse(version_str)
 
 
+# This is currently a required dependency
+HAS_ASTROPY: Version | Literal[False] = get_version("astropy")
+
+
 HAS_GALA: Version | Literal[False] = get_version("gala")
 if HAS_GALA:  # pragma: no cover  # gala can be installed incorrectly
     try:


### PR DESCRIPTION
I noticed that a lot of the implementations were the same. Rather than providing specific dispatches for every type, it's much more convenient to defer to the contained conversion functions.