### PR TITLE
feat: direct n-body

### DIFF
--- a/src/galax/dynamics/_dynamics/nbody/__init__.py
+++ b/src/galax/dynamics/_dynamics/nbody/__init__.py
@@ -1,0 +1,3 @@
+"""N-body simulations in ``galax``."""
+
+__all__: list[str] = []

--- a/src/galax/dynamics/_dynamics/nbody/core.py
+++ b/src/galax/dynamics/_dynamics/nbody/core.py
@@ -1,0 +1,162 @@
+"""``galax`` dynamics."""
+# ruff:noqa: F401
+
+__all__: list[str] = []
+
+import warnings
+from collections.abc import Mapping
+from dataclasses import KW_ONLY
+from functools import partial
+from typing import Any, TypeAlias
+
+import diffrax
+import equinox as eqx
+from jaxtyping import Array, Float
+
+from unxt import Quantity
+from xmmutablemap import ImmutableMap
+
+import galax.potential as gp
+from .nbacc import (
+    AbstractNBodyAcceleration,
+    Acceleration,
+    DirectNBodyAcceleration,
+    MassQ,
+    Position,
+    Velocity,
+)
+
+TimeQ: TypeAlias = Float[Quantity["time"], ""]
+
+PositionQ: TypeAlias = Float[Quantity["length"], "N 3"]
+VelocityQ: TypeAlias = Float[Quantity["speed"], "N 3"]
+
+
+null_potential = gp.NullPotential()
+
+
+class TotalVectorField(eqx.Module):  # type: ignore[misc]
+    """Total vector field for the N-body problem.
+
+    This vector field combines an external acceleration field and the N-body
+    gravitational acceleration.
+
+    """
+
+    _: KW_ONLY
+    nbody: AbstractNBodyAcceleration = eqx.field(
+        default_factory=partial(
+            DirectNBodyAcceleration, softening_length=Quantity(0, "m")
+        ),
+        static=True,
+    )
+    """N-body component of the vector field."""
+
+    def __call__(
+        self,
+        t: Float[Array, ""],
+        y: tuple[Position, Velocity],
+        args: tuple[gp.AbstractPotentialBase, MassQ],
+    ) -> tuple[Velocity, Acceleration]:
+        potential, masses = args
+        units = potential.units
+        q, p = y
+        q = Quantity(q, units["length"])
+
+        # External acceleration
+        a_ext = -potential._gradient(  # noqa: SLF001
+            q, Quantity(t, units["time"])
+        )
+
+        # N-body acceleration
+        a_nbody = self.nbody(t, q, masses, (potential.constants["G"],))
+
+        # Total acceleration
+        a = a_ext + a_nbody
+
+        return (p, a.to_units_value(units["acceleration"]))
+
+
+class NBodySimulator(eqx.Module):  # type: ignore[misc]
+    _: KW_ONLY
+    vector_field: TotalVectorField = eqx.field(
+        default_factory=TotalVectorField, static=True
+    )
+    Solver: type[diffrax.AbstractSolver] = eqx.field(
+        default=diffrax.Dopri8, static=True
+    )
+    stepsize_controller: diffrax.AbstractStepSizeController = eqx.field(
+        default=diffrax.PIDController(rtol=1e-7, atol=1e-9), static=True
+    )
+    diffeq_kw: Mapping[str, Any] = eqx.field(
+        default=(("max_steps", None),),
+        static=True,
+        converter=ImmutableMap,
+    )
+    solver_kw: Mapping[str, Any] = eqx.field(
+        default=(), static=True, converter=ImmutableMap
+    )
+
+    def __check_init__(self) -> None:
+        # Check if the stepsize controller has a minimum stepsize
+        if (
+            isinstance(self.stepsize_controller, diffrax.PIDController)
+            and self.stepsize_controller.dtmin is None
+        ):
+            warnings.warn(
+                "adaptive stepsize with no minimum stepsize can be VERY slow.",
+                stacklevel=2,
+            )
+
+    def __call__(
+        self,
+        ic: tuple[PositionQ, VelocityQ],
+        mass: MassQ,
+        t0: TimeQ,
+        t1: TimeQ,
+        /,
+        *,
+        external_potential: gp.AbstractPotentialBase = null_potential,
+        snapshot_times: Float[Quantity["time"], "times"] | None = None,
+        show_progress: bool | diffrax.TqdmProgressMeter = True,
+    ) -> diffrax.Solution:
+        units = external_potential.units
+        # Save times.
+        saveat_snaps = (
+            {
+                "snapshots": diffrax.SubSaveAt(
+                    ts=snapshot_times.to_units_value(units["time"])
+                )
+            }
+            if snapshot_times is not None
+            else {}
+        )
+        saveat = diffrax.SaveAt(subs={"end": diffrax.SubSaveAt(t1=True)} | saveat_snaps)
+
+        # Set up progress meter.
+        if isinstance(show_progress, diffrax.TqdmProgressMeter):
+            progress_meter = show_progress
+        elif show_progress:
+            progress_meter = diffrax.TqdmProgressMeter(refresh_steps=100)
+        else:
+            progress_meter = diffrax.NoProgressMeter()
+
+        y0 = (
+            ic[0].to_units_value(units["length"]),
+            ic[1].to_units_value(units["speed"]),
+        )
+
+        # TODO: enable diffeqsolve to work on Quantity objects.
+        return diffrax.diffeqsolve(
+            diffrax.ODETerm(self.vector_field),
+            self.Solver(**self.solver_kw),
+            t0=t0.to_units_value(units["time"]),
+            t1=t1.to_units_value(units["time"]),
+            dt0=None,
+            y0=y0,
+            saveat=saveat,
+            stepsize_controller=self.stepsize_controller,
+            args=(external_potential, mass),
+            progress_meter=progress_meter,
+            **self.diffeq_kw,
+        )

--- a/src/galax/dynamics/_dynamics/nbody/nbacc.py
+++ b/src/galax/dynamics/_dynamics/nbody/nbacc.py
@@ -1,0 +1,117 @@
+"""``galax`` dynamics."""
+# ruff:noqa: F401
+
+__all__: list[str] = []
+
+from abc import abstractmethod
+from functools import partial
+from typing import TypeAlias
+
+import equinox as eqx
+from jaxtyping import Array, Float
+
+import quaxed.array_api as xp
+from unxt import AbstractUnitSystem, Quantity
+
+Mass: TypeAlias = Float[Array, "N"]
+MassQ: TypeAlias = Float[Quantity["mass"], "N"]
+Position: TypeAlias = Float[Array, "N 3"]
+PositionQ: TypeAlias = Float[Quantity["length"], "N 3"]
+Velocity: TypeAlias = Float[Array, "N 3"]
+Acceleration: TypeAlias = Float[Array, "N 3"]
+AccelerationQ: TypeAlias = Float[Quantity["acceleration"], "N 3"]
+
+
+class AbstractNBodyAcceleration(eqx.Module):  # type: ignore[misc]
+    @abstractmethod
+    def __call__(
+        self,
+        t: Float[Array, ""],
+        y: PositionQ,
+        mass: MassQ,
+        args: tuple[Quantity],
+    ) -> AccelerationQ: ...
+
+
+# =============================================================================
+# Direct N-body gravitational acceleration
+
+
+@partial(eqx.filter_jit, inline=True)
+def pairwise_gravitational_acceleration(
+    q: PositionQ,
+    masses: MassQ,
+    *,
+    G: Quantity,
+    eps: Quantity["area"],
+) -> AccelerationQ:
+    """Compute the direct N-body gravitational acceleration between particles.
+
+    This implementation requires computing the full pairwise distance matrix
+    between all particles, which scales as O(N^2). For large N, this can be
+    slow and memory-intensive.
+
+    Parameters
+    ----------
+    q : array-like, shape (N, 3)
+        The positions of the particles.
+    masses : array-like, shape (N,)
+        The masses of the particles.
+    G : float, optional
+        The gravitational constant. Default is 1.
+    eps : float, optional
+        Softening length to avoid division by zero. Default is 1e-12.
+
+    Returns
+    -------
+    acc : array-like, shape (N, 3)
+        The gravitational accelerations of the particles.
+
+    Examples
+    --------
+    >>> q = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]])
+    >>> masses = np.array([1, 1, 1])
+    >>> pairwise_gravitational_acceleration(q, masses)
+    array([[ 0.        ,  0.        ,  0.        ],
+           [-0.5       ,  0.        ,  0.        ],
+           [ 0.        , -0.5       ,  0.        ]])
+
+    """
+    # Compute the squared L2 norms of the positions
+    d2 = xp.sum(q**2, axis=1)  # shape: N
+
+    # Compute pairwise squared distances using the L2 norms
+    pairwise_d2 = d2[:, None] + d2[None, :] - 2 * q @ q.T
+
+    # Compute the difference vectors ri - rj between all pairs of points
+    diff = q[:, None, :] - q[None, :, :]  # shape: (N, N, 3)
+
+    # Compute the inverse of the cubed distances 1 / |ri - rj|^3
+    inv_dist_cubed = Quantity(
+        xp.pow((pairwise_d2 + eps).to_units_value(d2.unit), -1.5), q.unit**-3
+    )
+
+    # Compute the pairwise gravitational accelerations
+    acc_factors = G * masses * inv_dist_cubed  # Shape: (N, N)
+    acc: AccelerationQ = xp.sum(diff * acc_factors[..., None], axis=0)  # shape: (N, 3)
+
+    return acc
+
+
+class DirectNBodyAcceleration(AbstractNBodyAcceleration):
+    """Vector field for direct N-body gravitational acceleration."""
+
+    softening_length: Float[Quantity["length"], ""]
+
+    @partial(eqx.filter_jit, inline=True)
+    def __call__(
+        self,
+        t: Float[Array, ""],  # noqa: ARG002
+        y: PositionQ,
+        masses: MassQ,
+        args: tuple[Quantity],
+    ) -> AccelerationQ:
+        """Vector field for diffrax."""
+        (G,) = args
+        eps = self.softening_length**2
+        return pairwise_gravitational_acceleration(y, masses, G=G, eps=eps)


### PR DESCRIPTION
Features:
1. Uses diffrax
2. controllably-adaptive step sizes. But note that letting it go "fully" adaptive is can be slow because it's one step size for the whole problem.
3. works with external potentials
4. works with units from user perspective (with under the hood wrangling because diffrax doesn't yet fully support units)
5. modular plug and play n-body acceleration field calculator. Right now direct n-body is implemented. But we can do other stuff.


TODO:
- [ ] Clean up API
    - [ ] converters for fields that enable more concise syntax
    - [ ] top-level alias module
    - [ ] `__all__`s
    - [ ] work with PhaseSpacePositions
- [ ] Write tests
- [ ] documentation


```python
import diffrax
import galax.potential as gp
import jax.random as jr
import matplotlib.pyplot as plt
import quaxed.numpy as jnp
from galax.dynamics._dynamics.nbody.core import (
    NBodySimulator,
    TotalVectorField,
    DirectNBodyAcceleration,
)
from unxt import Quantity

key = jr.key(0)

N = 2
position = Quantity([[-1, 0, 0], [1, 0, 0]], "AU") / 2
velocity = Quantity([[0, -1, 0], [0, 1, 0]], "km/s") * 25
mass = Quantity([1, 1], "Msun")

simulator = NBodySimulator(
    vector_field=TotalVectorField(
        nbody=DirectNBodyAcceleration(softening_length=Quantity(1, "km"))
    ),
    stepsize_controller=diffrax.PIDController(rtol=1e-7, atol=1e-9, dtmin=1e-7),
)

t0 = Quantity(0, "yr")
t1 = Quantity(1.5, "yr")
soln = simulator(
    (position, velocity),
    mass,
    t0,
    t1,
    snapshot_times=jnp.linspace(t0, t1, 1000),
)

plt.scatter(
    soln.ys["snapshots"][0][:, 0, 0],
    soln.ys["snapshots"][0][:, 0, 1],
    c=soln.ts["snapshots"],
)
plt.scatter(
    soln.ys["snapshots"][0][:, 1, 0],
    soln.ys["snapshots"][0][:, 1, 1],
    c=soln.ts["snapshots"],
)
plt.colorbar()
plt.show();
```

![CleanShot 2024-08-24 at 13 36 35@2x](https://github.com/user-attachments/assets/c5da4f04-f50b-4537-b975-4f65a206799a)
