### PR TITLE
feat: re-vectorize

### DIFF
--- a/src/galax/_interop/galax_interop_astropy/dynamics.py
+++ b/src/galax/_interop/galax_interop_astropy/dynamics.py
@@ -51,7 +51,7 @@ def evaluate_orbit(
     get an orbit:
 
     >>> w0 = gc.PhaseSpacePosition(q=Quantity([10., 0., 0.], "kpc"),
-    ...                            p=Quantity([0., 0.1, 0.], "km/s"),
+    ...                            p=Quantity([0., 200, 0.], "km/s"),
     ...                            t=Quantity(-100, "Myr"))
     >>> ts = Quantity(np.linspace(0., 1., 4), "Gyr")
 
@@ -77,7 +77,7 @@ def evaluate_orbit(
     We can also integrate a batch of orbits at once:
 
     >>> w0 = gc.PhaseSpacePosition(q=Quantity([[10., 0, 0], [10., 0, 0]], "kpc"),
-    ...                            p=Quantity([[0, 0.1, 0], [0, 0.2, 0]], "km/s"),
+    ...                            p=Quantity([[0, 200, 0], [0, 220, 0]], "km/s"),
     ...                            t=Quantity([-100, -150], "Myr"))
     >>> orbit = gd.evaluate_orbit(potential, w0, ts)
     >>> orbit
@@ -97,7 +97,7 @@ def evaluate_orbit(
     integrate from a different time than the initial time of the position:
 
     >>> w0 = gc.PhaseSpacePosition(q=Quantity([10., 0., 0.], "kpc"),
-    ...                            p=Quantity([0., 0.1, 0.], "km/s"),
+    ...                            p=Quantity([0., 200, 0.], "km/s"),
     ...                            t=Quantity(0, "Myr"))
     >>> ts = Quantity(np.linspace(0.3, 1.0, 8), "Gyr")
     >>> orbit = gd.evaluate_orbit(potential, w0, ts)

--- a/src/galax/coordinates/_src/__init__.py
+++ b/src/galax/coordinates/_src/__init__.py
@@ -1,0 +1,3 @@
+"""Galax coordinates package."""
+
+__all__: list[str] = []

--- a/src/galax/coordinates/_src/operators/rotating.py
+++ b/src/galax/coordinates/_src/operators/rotating.py
@@ -167,7 +167,7 @@ class ConstantRotationZOperator(cxop.AbstractOperator):  # type: ignore[misc]
         >>> op = ConstantRotationZOperator(Omega_z=Quantity(360, "deg / Gyr"))
         >>> op.inverse
         ConstantRotationZOperator(
-            Omega_z=Quantity[...]( value=weak_i64[], unit=Unit("deg / Gyr") )
+            Omega_z=Quantity[...]( value=...i64[], unit=Unit("deg / Gyr") )
         )
 
         """

--- a/src/galax/coordinates/_src/psps/core.py
+++ b/src/galax/coordinates/_src/psps/core.py
@@ -20,7 +20,7 @@ import galax.typing as gt
 from .base import ComponentShapeTuple
 from .base_composite import AbstractCompositePhaseSpacePosition
 from .base_psp import AbstractPhaseSpacePosition
-from galax.utils._shape import batched_shape, expand_batch_dims, vector_batched_shape
+from galax.utils._shape import batched_shape, vector_batched_shape
 
 
 @final
@@ -110,7 +110,7 @@ class PhaseSpacePosition(AbstractPhaseSpacePosition):
     This is a 3-vector with a batch shape allowing for vector inputs.
     """
 
-    t: gt.BatchableFloatQScalar | gt.FloatQScalar | None = eqx.field(
+    t: gt.TimeBatchableScalar | gt.TimeScalar | None = eqx.field(
         default=None,
         converter=Optional(partial(Quantity["time"].constructor, dtype=float)),
     )
@@ -120,13 +120,6 @@ class PhaseSpacePosition(AbstractPhaseSpacePosition):
     velocities.  If `t` is a scalar it will be broadcast to the same batch shape
     as `q` and `p`.
     """
-
-    def __post_init__(self) -> None:
-        """Post-initialization."""
-        # Need to ensure t shape is correct. Can be Vec0.
-        if (t := self.t) is not None and t.ndim in (0, 1):
-            t = expand_batch_dims(t, ndim=self.q.ndim - t.ndim)
-            object.__setattr__(self, "t", t)
 
     # ==========================================================================
     # Array properties

--- a/src/galax/coordinates/_src/psps/interp.py
+++ b/src/galax/coordinates/_src/psps/interp.py
@@ -24,10 +24,6 @@ class PhaseSpacePositionInterpolant(Protocol):
     units: AbstractUnitSystem
     """The unit system for the interpolation."""
 
-    added_ndim: int
-    """The number of dimensions added to the input time."""
-    # TODO: not require this for Diffrax
-
     def __call__(self, t: gt.QVecTime) -> PhaseSpacePosition:
         """Evaluate the interpolation.
 

--- a/src/galax/typing.py
+++ b/src/galax/typing.py
@@ -104,6 +104,7 @@ BatchQVec3 = Shaped[QVec3, "*batch"]
 
 # Zero or more batches of 6-vectors
 BatchVec6 = Shaped[Vec6, "*batch"]
+BatchableVec6 = Shaped[Vec6, "*#batch"]
 
 # Zero or more batches of 7-vectors
 BatchVec7 = Shaped[Vec7, "*batch"]


### PR DESCRIPTION
Achieve much closer to native diffrax speeds!
Also speeds up the doc tests and simplifies the vectorization structure and the interpolation structure.

Followup:
1. What triggers the random 100s integrations? This appears to be something in diffrax / what is passed to diffrax
2. Calls to `.w(units=...)` are SLOW. Figuring out ways to work with PSPs as PyTrees instead of doing PSP -> array -> PSP through `.w()` would make this faster.
3. Point 2 may be why in `gd.evaluate_orbit` the jitted code ends up slower for > 10^6 saved times. But this should be figured out and fixed.
