### PR TITLE
✨ feat(psp): make PhaseSpacePosition a coordinax.Coordinate object

### DIFF
--- a/src/galax/_interop/galax_interop_astropy/coordinates.py
+++ b/src/galax/_interop/galax_interop_astropy/coordinates.py
@@ -49,7 +49,8 @@ def from_(
     PhaseSpacePosition(
         q=LonLatSphericalPos( lon=..., lat=..., distance=... ),
         p=LonCosLatSphericalVel( d_lon_coslat=..., d_lat=..., d_distance=... ),
-        t=Quantity[PhysicalType('time')](value=f64[], unit=Unit("Myr"))
+        t=Quantity['time'](Array(0., dtype=float64), unit='Myr'),
+        frame=NoFrame()
     )
 
     """
@@ -101,7 +102,8 @@ def from_(
     PhaseSpacePosition(
         q=LonLatSphericalPos( lon=..., lat=..., distance=... ),
         p=LonCosLatSphericalVel( d_lon_coslat=..., d_lat=..., d_distance=... ),
-        t=Quantity[PhysicalType('time')](value=f64[], unit=Unit("Myr"))
+        t=Quantity['time'](Array(0., dtype=float64), unit='Myr'),
+        frame=NoFrame()
     )
 
     """

--- a/src/galax/_interop/galax_interop_astropy/dynamics.py
+++ b/src/galax/_interop/galax_interop_astropy/dynamics.py
@@ -59,7 +59,8 @@ def evaluate_orbit(
     >>> orbit
     Orbit(
       q=CartesianPos3D(...), p=CartesianVel3D(...),
-      t=Quantity[...](value=f64[4], unit=Unit("Myr")),
+      t=Quantity['time'](Array(..., dtype=float64), unit='Myr'),
+      frame=NoFrame(),
       potential=KeplerPotential(...),
       interpolant=None
     )
@@ -69,7 +70,8 @@ def evaluate_orbit(
     >>> orbit
     Orbit(
       q=CartesianPos3D(...), p=CartesianVel3D(...),
-      t=Quantity[...](value=f64[10], unit=Unit("Myr")),
+      t=Quantity['time'](Array(..., dtype=float64), unit='Myr'),
+      frame=NoFrame(),
       potential=KeplerPotential(...),
       interpolant=None
     )
@@ -87,7 +89,8 @@ def evaluate_orbit(
         ...
       ),
       p=CartesianVel3D(...),
-      t=Quantity[...](value=f64[10], unit=Unit("Myr")),
+      t=Quantity['time'](Array(..., dtype=float64), unit='Myr'),
+      frame=NoFrame(),
       potential=KeplerPotential(...),
       interpolant=None
     )

--- a/src/galax/coordinates/_src/ops/rotating.py
+++ b/src/galax/coordinates/_src/ops/rotating.py
@@ -293,7 +293,7 @@ class ConstantRotationZOperator(cxo.AbstractOperator):  # type: ignore[misc]
 
 
 @cxo.simplify_op.register  # type: ignore[misc]
-def _simplify_op_rotz(frame: ConstantRotationZOperator, /) -> cxo.AbstractOperator:
+def _simplify_op_rotz(op: ConstantRotationZOperator, /) -> cxo.AbstractOperator:
     """Simplify the operators in an PotentialFrame.
 
     Examples
@@ -311,6 +311,6 @@ def _simplify_op_rotz(frame: ConstantRotationZOperator, /) -> cxo.AbstractOperat
     Identity()
 
     """
-    if frame.Omega_z == 0:
+    if op.Omega_z == 0:
         return cxo.Identity()
-    return frame
+    return op

--- a/src/galax/coordinates/_src/psps/base.py
+++ b/src/galax/coordinates/_src/psps/base.py
@@ -800,7 +800,8 @@ def convert_psp_to_coordinax_coordinate(
     ...                             t=u.Quantity(0, "Gyr"))
     >>> convert(psp, cx.Coordinate)
     Coordinate(
-        data=Space({ 'length': FourVector( ... ), 'speed': CartesianVel3D( ... ) })
+        data=Space({ 'length': FourVector( ... ), 'speed': CartesianVel3D( ... ) }),
+        frame=NoFrame()
     )
 
     """

--- a/src/galax/coordinates/_src/psps/base.py
+++ b/src/galax/coordinates/_src/psps/base.py
@@ -3,7 +3,6 @@
 __all__ = ["AbstractBasePhaseSpacePosition", "ComponentShapeTuple"]
 
 from abc import abstractmethod
-from collections.abc import Mapping
 from dataclasses import replace
 from functools import partial
 from textwrap import indent
@@ -48,6 +47,28 @@ class AbstractBasePhaseSpacePosition(cx.frames.AbstractCoordinate):  # type: ign
     :math:`\boldsymbol{q}\in\mathbb{R}^3`, the conjugate momentum
     :math:`\boldsymbol{p}\in\mathbb{R}^3`, and the time
     :math:`t\in\mathbb{R}^1`.
+
+    Examples
+    --------
+    With the following imports:
+
+    >>> import unxt as u
+    >>> import galax.coordinates as gc
+
+    We can create a phase-space position from a mapping:
+
+    >>> obj = {"q": u.Quantity([1, 2, 3], "kpc"),
+    ...        "p": u.Quantity([4, 5, 6], "km/s"),
+    ...        "t": u.Quantity(0, "Gyr")}
+    >>> gc.PhaseSpacePosition.from_(obj)
+    PhaseSpacePosition(
+        q=CartesianPos3D( ... ),
+        p=CartesianVel3D( ... ),
+        t=Quantity['time'](Array(0, dtype=int64, ...), unit='Gyr'),
+        frame=NoFrame()
+    )
+
+
     """
 
     q: eqx.AbstractVar[cx.vecs.AbstractPos3D]
@@ -68,44 +89,10 @@ class AbstractBasePhaseSpacePosition(cx.frames.AbstractCoordinate):  # type: ign
     @classmethod
     @dispatch  # type: ignore[misc]
     def from_(
-        cls: "type[AbstractBasePhaseSpacePosition]", obj: Mapping[str, Any], /
+        cls: "type[AbstractBasePhaseSpacePosition]", *args: Any, **kwargs: Any
     ) -> "AbstractBasePhaseSpacePosition":
-        """Construct from a mapping.
-
-        Parameters
-        ----------
-        cls : type[:class:`~galax.coordinates.AbstractBasePhaseSpacePosition`]
-            The class to construct.
-        obj : Mapping[str, Any]
-            The mapping from which to construct.
-
-        Returns
-        -------
-        :class:`~galax.coordinates.AbstractBasePhaseSpacePosition`
-            The constructed phase-space position.
-
-        Examples
-        --------
-        With the following imports:
-
-        >>> import unxt as u
-        >>> import galax.coordinates as gc
-
-        We can create a phase-space position from a mapping:
-
-        >>> obj = {"q": u.Quantity([1, 2, 3], "kpc"),
-        ...        "p": u.Quantity([4, 5, 6], "km/s"),
-        ...        "t": u.Quantity(0, "Gyr")}
-        >>> gc.PhaseSpacePosition.from_(obj)
-        PhaseSpacePosition(
-            q=CartesianPos3D( ... ),
-            p=CartesianVel3D( ... ),
-            t=Quantity['time'](Array(0, dtype=int64, ...), unit='Gyr'),
-            frame=NoFrame()
-        )
-
-        """
-        return cls(**obj)
+        """Construct from arguments, defaulting to AbstractVector constructor."""
+        return cast(AbstractBasePhaseSpacePosition, super().from_(*args, **kwargs))
 
     # ==========================================================================
     # Coordinate API

--- a/src/galax/coordinates/_src/psps/base.py
+++ b/src/galax/coordinates/_src/psps/base.py
@@ -11,7 +11,7 @@ from typing import Any, NamedTuple, Self, cast
 import equinox as eqx
 import jax
 from jaxtyping import Shaped
-from plum import convert, dispatch
+from plum import conversion_method, convert, dispatch
 
 import coordinax as cx
 import quaxed.numpy as jnp
@@ -711,7 +711,6 @@ class AbstractBasePhaseSpacePosition(cx.frames.AbstractCoordinate):  # type: ign
 
 
 # =============================================================================
-# Helper functions
 
 # -----------------------------------------------
 # Register additional constructors
@@ -777,6 +776,35 @@ def from_(
         return obj
 
     return cls(**dict(field_items(obj)))
+
+
+# -----------------------------------------------
+# Converters
+
+
+@conversion_method(type_from=AbstractBasePhaseSpacePosition, type_to=cx.Coordinate)  # type: ignore[misc]
+def convert_psp_to_coordinax_coordinate(
+    obj: AbstractBasePhaseSpacePosition, /
+) -> cx.Coordinate:
+    """Convert a phase-space position to a coordinax coordinate.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import galax.coordinates as gc
+
+    We can create a phase-space position and convert it to a coordinax coordinate:
+
+    >>> psp = gc.PhaseSpacePosition(q=u.Quantity([1, 2, 3], "kpc"),
+    ...                             p=u.Quantity([4, 5, 6], "km/s"),
+    ...                             t=u.Quantity(0, "Gyr"))
+    >>> convert(psp, cx.Coordinate)
+    Coordinate(
+        data=Space({ 'length': FourVector( ... ), 'speed': CartesianVel3D( ... ) })
+    )
+
+    """
+    return cx.Coordinate(data=obj.data, frame=obj.frame)
 
 
 # -----------------------------------------------

--- a/src/galax/coordinates/_src/psps/base_composite.py
+++ b/src/galax/coordinates/_src/psps/base_composite.py
@@ -217,11 +217,13 @@ class AbstractCompositePhaseSpacePosition(  # type: ignore[misc,unused-ignore]
         CompositePhaseSpacePosition({'w1': PhaseSpacePosition(
             q=CartesianPos3D( ... ),
             p=CartesianVel3D( ... ),
-            t=Quantity[PhysicalType('time')](value=...i64[], unit=Unit("s"))
+            t=Quantity['time'](Array(7, dtype=int64, ...), unit='s'),
+            frame=NoFrame()
           ), 'w2': PhaseSpacePosition(
             q=CartesianPos3D( ... ),
             p=CartesianVel3D( ... ),
-            t=Quantity[PhysicalType('time')](value=...i64[], unit=Unit("s"))
+            t=Quantity['time'](Array(6, dtype=int64, ...), unit='s'),
+            frame=NoFrame()
         )})
 
         """
@@ -307,12 +309,14 @@ def vconvert(
     CompositePhaseSpacePosition({'psp1': PhaseSpacePosition(
             q=CylindricalPos( ... ),
             p=SphericalVel( ... ),
-            t=Quantity[...](value=...i64[], unit=Unit("s"))
+            t=Quantity['time'](Array(7, dtype=int64, ...), unit='s'),
+            frame=NoFrame()
         ),
         'psp2': PhaseSpacePosition(
             q=CylindricalPos( ... ),
             p=SphericalVel( ... ),
-            t=Quantity[...](value=...i64[], unit=Unit("s"))
+            t=Quantity['time'](Array(6, dtype=int64, ...), unit='s'),
+            frame=NoFrame()
     )})
 
     """

--- a/src/galax/coordinates/_src/psps/base_psp.py
+++ b/src/galax/coordinates/_src/psps/base_psp.py
@@ -84,7 +84,8 @@ def vconvert(
     >>> cx.vconvert({"q": cxv.LonLatSphericalPos, "p": cxv.LonCosLatSphericalVel}, psp)
     PhaseSpacePosition( q=LonLatSphericalPos(...),
                         p=LonCosLatSphericalVel(...),
-                        t=Quantity[...](value=...i64[], unit=Unit("Gyr")) )
+                        t=Quantity['time'](Array(0, dtype=int64, ...), unit='Gyr'),
+                        frame=NoFrame() )
 
     """
     q_cls = target["q"]
@@ -124,7 +125,8 @@ def vconvert(
     >>> cx.vconvert(cx.vecs.CylindricalPos, psp)
     PhaseSpacePosition( q=CylindricalPos(...),
                         p=CylindricalVel(...),
-                        t=Quantity[...](value=...i64[], unit=Unit("Gyr")) )
+                        t=Quantity['time'](Array(0, dtype=int64, ...), unit='Gyr'),
+                        frame=NoFrame() )
 
     If the new representation requires keyword arguments, they can be passed
     through:
@@ -132,7 +134,8 @@ def vconvert(
     >>> cx.vconvert(cx.vecs.ProlateSpheroidalPos, psp, Delta=u.Quantity(2.0, "kpc"))
     PhaseSpacePosition( q=ProlateSpheroidalPos(...),
                         p=ProlateSpheroidalVel(...),
-                        t=Quantity[...](value=...i64[], unit=Unit("Gyr")) )
+                        t=Quantity['time'](Array(0, dtype=int64, ...), unit='Gyr'),
+                        frame=NoFrame() )
 
     """
     target = {"q": target_position_cls, "p": target_position_cls.differential_cls}

--- a/src/galax/coordinates/_src/psps/core.py
+++ b/src/galax/coordinates/_src/psps/core.py
@@ -349,15 +349,16 @@ def from_(
     >>> import coordinax as cx
     >>> import galax.coordinates as gc
 
-    >>> data = u.Quantity([1, 2, 3, 4, 5, 6], "m")
-    >>> frame = cx.frames.Galactic()
+    >>> data = cx.Space(length=cx.CartesianPos3D.from_([1, 2, 3], "kpc"),
+    ...                 speed=cx.CartesianVel3D.from_([4, 5, 6], "km/s"))
+    >>> frame = cx.frames.NoFrame()
 
     >>> gc.PhaseSpacePosition.from_(data, frame)
     PhaseSpacePosition(
       q=CartesianPos3D( ... ),
       p=CartesianVel3D( ... ),
       t=None,
-      frame=Galactic()
+      frame=NoFrame()
     )
 
     """

--- a/src/galax/coordinates/_src/psps/core_composite.py
+++ b/src/galax/coordinates/_src/psps/core_composite.py
@@ -26,6 +26,7 @@ def _concat(values: Iterable[PyTree], time_sorter: Int[Array, "..."]) -> PyTree:
         *values,
     )
 
+
 def _to_frame_if_not_noframe(
     psp: AbstractPhaseSpacePosition, frame: cxf.AbstractReferenceFrame
 ) -> AbstractPhaseSpacePosition:
@@ -168,7 +169,9 @@ class CompositePhaseSpacePosition(AbstractCompositePhaseSpacePosition):
         # Transform all the PhaseSpacePositions to that frame. If the frames are
         # already `NoFrame`, we can skip this step, since no transformation is
         # possible in `NoFrame`.
-        allpsps = {k: _to_frame_if_not_noframe(psp) for k, psp in allpsps.items()}
+        allpsps = {
+            k: _to_frame_if_not_noframe(psp, frame) for k, psp in allpsps.items()
+        }
 
         # Now we can set all the PhaseSpacePositions
         super().__init__(allpsps)

--- a/src/galax/coordinates/_src/psps/core_composite.py
+++ b/src/galax/coordinates/_src/psps/core_composite.py
@@ -2,15 +2,17 @@
 
 __all__ = ["CompositePhaseSpacePosition"]
 
-from collections.abc import Iterable
-from typing import final
+from collections.abc import Iterable, Mapping
+from typing import Any, final
 
 import jax.tree as jtu
 from jaxtyping import Array, Int, PyTree, Shaped
 
 import coordinax as cx
+import coordinax.frames as cxf
 import quaxed.numpy as jnp
 import unxt as u
+from zeroth import zeroth
 
 from .base_composite import AbstractCompositePhaseSpacePosition
 from .base_psp import AbstractPhaseSpacePosition
@@ -22,6 +24,15 @@ def _concat(values: Iterable[PyTree], time_sorter: Int[Array, "..."]) -> PyTree:
             ..., time_sorter
         ],
         *values,
+    )
+
+def _to_frame_if_not_noframe(
+    psp: AbstractPhaseSpacePosition, frame: cxf.AbstractReferenceFrame
+) -> AbstractPhaseSpacePosition:
+    return (
+        psp
+        if isinstance(frame, cxf.NoFrame) and isinstance(psp.frame, cxf.NoFrame)
+        else psp.to_frame(frame)
     )
 
 
@@ -132,15 +143,35 @@ class CompositePhaseSpacePosition(AbstractCompositePhaseSpacePosition):
 
     _time_sorter: Shaped[Array, "alltimes"]
     _time_are_none: bool
+    _frame: cxf.NoFrame  # TODO: support frames
 
     def __init__(
         self,
-        psps: dict[str, AbstractPhaseSpacePosition]
+        psps: Mapping[str, AbstractPhaseSpacePosition]
         | tuple[tuple[str, AbstractPhaseSpacePosition], ...] = (),
         /,
+        frame: Any = None,
         **kwargs: AbstractPhaseSpacePosition,
     ) -> None:
-        super().__init__(psps, **kwargs)
+        # Aggregate all the PhaseSpacePositions
+        allpsps = dict(psps, **kwargs)
+
+        # Everything must be transformed to be in the same frame.
+        # Compute and store the frame
+        maybeframe = frame if frame is not None else zeroth(allpsps.values()).frame
+        frame = (
+            maybeframe
+            if isinstance(maybeframe, cxf.AbstractReferenceFrame)
+            else cxf.TransformedReferenceFrame.from_(maybeframe)
+        )
+        self._frame = frame
+        # Transform all the PhaseSpacePositions to that frame. If the frames are
+        # already `NoFrame`, we can skip this step, since no transformation is
+        # possible in `NoFrame`.
+        allpsps = {k: _to_frame_if_not_noframe(psp) for k, psp in allpsps.items()}
+
+        # Now we can set all the PhaseSpacePositions
+        super().__init__(allpsps)
 
         # TODO: check up on the shapes
 
@@ -182,3 +213,8 @@ class CompositePhaseSpacePosition(AbstractCompositePhaseSpacePosition):
         return jnp.concat([jnp.atleast_1d(psp.t) for psp in self.values()], axis=0)[
             self._time_sorter
         ]
+
+    @property
+    def frame(self) -> cxf.AbstractReferenceFrame:
+        """The reference frame."""
+        return self._frame

--- a/src/galax/coordinates/_src/psps/interp.py
+++ b/src/galax/coordinates/_src/psps/interp.py
@@ -2,6 +2,7 @@
 
 __all__ = ["InterpolatedPhaseSpacePosition", "PhaseSpacePositionInterpolant"]
 
+from dataclasses import KW_ONLY
 from typing import Protocol, final, runtime_checkable
 
 import equinox as eqx
@@ -68,6 +69,11 @@ class InterpolatedPhaseSpacePosition(AbstractPhaseSpacePosition):
 
     interpolant: PhaseSpacePositionInterpolant
     """The interpolation function."""
+
+    _: KW_ONLY
+
+    frame: cx.frames.NoFrame  # TODO: support frames
+    """The reference frame of the phase-space position."""
 
     def __call__(self, t: gt.BatchFloatQScalar) -> PhaseSpacePosition:
         """Call the interpolation."""

--- a/src/galax/coordinates/_src/psps/operator_compat.py
+++ b/src/galax/coordinates/_src/psps/operator_compat.py
@@ -56,7 +56,8 @@ def call(
     PhaseSpacePosition(
         q=CartesianPos3D( ... ),
         p=CartesianVel3D( ... ),
-        t=Quantity[PhysicalType('time')](value=...i64[], unit=Unit("Gyr"))
+        t=Quantity['time'](Array(0, dtype=int64, ...), unit='Gyr'),
+        frame=NoFrame()
     )
 
     >>> newpos = op(pos)
@@ -64,7 +65,8 @@ def call(
     PhaseSpacePosition(
         q=CartesianPos3D( ... ),
         p=CartesianVel3D( ... ),
-        t=Quantity[PhysicalType('time')](value=...i64[], unit=Unit("Gyr"))
+        t=Quantity['time'](Array(0, dtype=int64, ...), unit='Gyr'),
+        frame=NoFrame()
     )
 
     >>> newpos.q.x
@@ -328,6 +330,7 @@ def call(
     >>> op(psp)
     PhaseSpacePosition( q=CartesianPos3D( ... ),
                         p=CartesianVel3D( ... ),
-                        t=Quantity[...](value=...i64[], unit=Unit("Gyr")) )
+                        t=Quantity['time'](Array(0, dtype=int64, ...), unit='Gyr'),
+                        frame=NoFrame() )
     """
     return x

--- a/src/galax/coordinates/ops.py
+++ b/src/galax/coordinates/ops.py
@@ -3,11 +3,6 @@
 E.g. a translation.
 """
 
-from ._src.ops import rotating
-from ._src.ops.rotating import *  # noqa: F403
+__all__ = ["ConstantRotationZOperator"]
 
-__all__: list[str] = []
-__all__ += rotating.__all__
-
-# Clean up the namespace
-del rotating
+from ._src.ops.rotating import ConstantRotationZOperator

--- a/src/galax/dynamics/_src/integrate/funcs.py
+++ b/src/galax/dynamics/_src/integrate/funcs.py
@@ -121,7 +121,8 @@ def evaluate_orbit(
     >>> orbit
     Orbit(
       q=CartesianPos3D(...), p=CartesianVel3D(...),
-      t=Quantity[...](value=f64[4], unit=Unit("Myr")),
+      t=Quantity['time'](Array(..., dtype=float64), unit='Myr'),
+      frame=NoFrame(),
       potential=KeplerPotential(...),
       interpolant=None
     )
@@ -137,7 +138,8 @@ def evaluate_orbit(
     >>> orbit
     Orbit(
       q=CartesianPos3D(...), p=CartesianVel3D(...),
-      t=Quantity[...](value=f64[10], unit=Unit("Myr")),
+      t=Quantity['time'](Array(..., dtype=float64), unit='Myr'),
+      frame=NoFrame(),
       potential=KeplerPotential(...),
       interpolant=None
     )
@@ -148,7 +150,8 @@ def evaluate_orbit(
     >>> orbit
     Orbit(
         q=CartesianPos3D(...), p=CartesianVel3D(...),
-        t=Quantity[...](value=...f64[1], unit=Unit("Myr")),
+        t=Quantity['time'](Array([500.], dtype=float64, ...), unit='Myr'),
+        frame=NoFrame(),
         potential=KeplerPotential(...),
         interpolant=None
     )
@@ -166,7 +169,8 @@ def evaluate_orbit(
         ...
       ),
       p=CartesianVel3D(...),
-      t=Quantity[...](value=f64[10], unit=Unit("Myr")),
+      t=Quantity['time'](Array(..., dtype=float64), unit='Myr'),
+      frame=NoFrame(),
       potential=KeplerPotential(...),
       interpolant=None
     )
@@ -272,7 +276,8 @@ def evaluate_orbit(
     >>> orbit
     Orbit(
       q=CartesianPos3D(...), p=CartesianVel3D(...),
-      t=Quantity[...](value=f64[4], unit=Unit("Myr")),
+      t=Quantity['time'](Array(..., dtype=float64), unit='Myr'),
+      frame=NoFrame(),
       potential=KeplerPotential(...),
       interpolant=None
     )

--- a/src/galax/dynamics/_src/integrate/integrator.py
+++ b/src/galax/dynamics/_src/integrate/integrator.py
@@ -12,11 +12,11 @@ import equinox as eqx
 from jaxtyping import ArrayLike, Shaped
 from plum import dispatch
 
+import coordinax as cx
 import quaxed.numpy as jnp
 import unxt as u
 from unxt.quantity import AbstractQuantity, UncheckedQuantity as FastQ
 from xmmutablemap import ImmutableMap
-import coordinax as cx
 
 import galax.coordinates as gc
 import galax.typing as gt
@@ -86,7 +86,6 @@ class Integrator(eqx.Module, strict=True):  # type: ignore[call-arg,misc]
     PhaseSpacePosition(
         q=CartesianPos3D( ... ),
         p=CartesianVel3D( ... ),
-        t=Quantity[...](value=f64[], unit=Unit("Myr"))
         t=Quantity['time'](Array(1000., dtype=float64), unit='Myr'),
         frame=NoFrame()
     )
@@ -103,7 +102,6 @@ class Integrator(eqx.Module, strict=True):  # type: ignore[call-arg,misc]
     PhaseSpacePosition(
         q=CartesianPos3D( ... ),
         p=CartesianVel3D( ... ),
-        t=Quantity[...](value=f64[10], unit=Unit("Myr"))
         t=Quantity['time'](Array(..., dtype=float64), unit='Myr'),
         frame=NoFrame()
     )
@@ -506,7 +504,8 @@ def call(
             [ 6.247 -5.121  0.   ]>,
         p=<CartesianVel3D (d_x[kpc / Myr], d_y[kpc / Myr], d_z[kpc / Myr])
             [0.359 0.033 0.   ]>,
-        t=Quantity['time'](Array(1000., dtype=float64), unit='Myr'))
+        t=Quantity['time'](Array(1000., dtype=float64), unit='Myr'),
+        frame=NoFrame())
 
     >>> w = integrator(pot._vector_field, w0, t0=t0, t1=t1, units=galactic)
     >>> print(w)
@@ -515,7 +514,8 @@ def call(
             [ 6.247 -5.121  0.   ]>,
         p=<CartesianVel3D (d_x[kpc / Myr], d_y[kpc / Myr], d_z[kpc / Myr])
             [0.359 0.033 0.   ]>,
-        t=Quantity['time'](Array(1000., dtype=float64), unit='Myr'))
+        t=Quantity['time'](Array(1000., dtype=float64), unit='Myr'),
+        frame=NoFrame())
 
     >>> w = integrator(pot._vector_field, y0=w0, t0=t0, t1=t1, units=galactic)
     >>> print(w)
@@ -524,7 +524,8 @@ def call(
             [ 6.247 -5.121  0.   ]>,
         p=<CartesianVel3D (d_x[kpc / Myr], d_y[kpc / Myr], d_z[kpc / Myr])
             [0.359 0.033 0.   ]>,
-        t=Quantity['time'](Array(1000., dtype=float64), unit='Myr'))
+        t=Quantity['time'](Array(1000., dtype=float64), unit='Myr'),
+        frame=NoFrame())
 
     """
     # y0: Any, t0: Any, t1: Any
@@ -702,7 +703,8 @@ def call(
     PhaseSpacePosition(
         q=CartesianPos3D( ... ),
         p=CartesianVel3D( ... ),
-        t=Quantity[...](value=f64[], unit=Unit("Myr"))
+        t=Quantity['time'](Array(1000., dtype=float64), unit='Myr'),
+        frame=NoFrame()
     )
 
     """
@@ -756,16 +758,22 @@ def call(
     >>> integrator = gd.integrate.Integrator()
     >>> t0, t1 = u.Quantity(0, "Gyr"), u.Quantity(1, "Gyr")
     >>> w = integrator(pot._vector_field, w0, t0, t1, units=galactic)
-    >>> w
-    CompositePhaseSpacePosition({'w01': PhaseSpacePosition(
-        q=CartesianPos3D( ... ),
-        p=CartesianVel3D( ... ),
-        t=Quantity...,
-        'w02': PhaseSpacePosition(
-        q=CartesianPos3D( ... ),
-        p=CartesianVel3D( ... ),
-        t=Quantity...
-    )})
+    >>> print(w)
+    CompositePhaseSpacePosition(
+        w01=PhaseSpacePosition(
+            q=<CartesianPos3D (x[kpc], y[kpc], z[kpc])
+                [ 6.247 -5.121  0.   ]>,
+            p=<CartesianVel3D (d_x[kpc / Myr], d_y[kpc / Myr], d_z[kpc / Myr])
+                [0.359 0.033 0.   ]>,
+            t=Quantity['time'](Array(1000., dtype=float64), unit='Myr'),
+            frame=NoFrame()),
+        w02=PhaseSpacePosition(
+            q=<CartesianPos3D (x[kpc], y[kpc], z[kpc])
+                [5.121 6.247 0.   ]>,
+            p=<CartesianVel3D (d_x[kpc / Myr], d_y[kpc / Myr], d_z[kpc / Myr])
+                [-0.033  0.359  0.   ]>,
+            t=Quantity['time'](Array(1000., dtype=float64), unit='Myr'),
+            frame=NoFrame()))
 
     """
     # TODO: Interpolated form

--- a/src/galax/dynamics/_src/integrate/integrator.py
+++ b/src/galax/dynamics/_src/integrate/integrator.py
@@ -16,6 +16,7 @@ import quaxed.numpy as jnp
 import unxt as u
 from unxt.quantity import AbstractQuantity, UncheckedQuantity as FastQ
 from xmmutablemap import ImmutableMap
+import coordinax as cx
 
 import galax.coordinates as gc
 import galax.typing as gt
@@ -86,6 +87,8 @@ class Integrator(eqx.Module, strict=True):  # type: ignore[call-arg,misc]
         q=CartesianPos3D( ... ),
         p=CartesianVel3D( ... ),
         t=Quantity[...](value=f64[], unit=Unit("Myr"))
+        t=Quantity['time'](Array(1000., dtype=float64), unit='Myr'),
+        frame=NoFrame()
     )
     >>> w.shape
     ()
@@ -101,6 +104,8 @@ class Integrator(eqx.Module, strict=True):  # type: ignore[call-arg,misc]
         q=CartesianPos3D( ... ),
         p=CartesianVel3D( ... ),
         t=Quantity[...](value=f64[10], unit=Unit("Myr"))
+        t=Quantity['time'](Array(..., dtype=float64), unit='Myr'),
+        frame=NoFrame()
     )
     >>> ws.shape
     (10,)
@@ -134,7 +139,8 @@ class Integrator(eqx.Module, strict=True):  # type: ignore[call-arg,misc]
         x=Quantity[...](value=...f64[2], unit=Unit("kpc")),
         ... ),
       p=CartesianVel3D( ... ),
-      t=Quantity[...](value=...f64[], unit=Unit("Gyr"))
+      t=Quantity['time'](Array(2.71828183, dtype=float64, ...), unit='Gyr'),
+      frame=NoFrame()
     )
 
     The interpolant is vectorized:
@@ -146,7 +152,8 @@ class Integrator(eqx.Module, strict=True):  # type: ignore[call-arg,misc]
         x=Quantity[...](value=f64[2,100], unit=Unit("kpc")),
         ... ),
       p=CartesianVel3D( ... ),
-      t=Quantity[...](value=f64[100], unit=Unit("Gyr"))
+      t=Quantity['time'](Array(..., dtype=float64), unit='Gyr'),
+      frame=NoFrame()
     )
 
     And it works on batches:
@@ -161,7 +168,8 @@ class Integrator(eqx.Module, strict=True):  # type: ignore[call-arg,misc]
     PhaseSpacePosition(
         q=CartesianPos3D( ... ),
         p=CartesianVel3D( ... ),
-        t=Quantity[PhysicalType('time')](value=f64[100], unit=Unit("Gyr"))
+        t=Quantity['time'](Array(..., dtype=float64), unit='Gyr'),
+        frame=NoFrame()
     )
     """
 
@@ -285,6 +293,8 @@ class Integrator(eqx.Module, strict=True):  # type: ignore[call-arg,misc]
             out_cls = gc.PhaseSpacePosition
             out_kw = {}
 
+        out_kw["frame"] = cx.frames.NoFrame()  # TODO: determine the frame
+
         return out_cls(  # shape = (*batch, T)
             t=FastQ(solt, time),
             q=FastQ(solq, units["length"]),
@@ -374,7 +384,8 @@ def call(
     PhaseSpacePosition(
         q=CartesianPos3D( ... ),
         p=CartesianVel3D( ... ),
-        t=Quantity[...](value=f64[], unit=Unit("Myr"))
+        t=Quantity['time'](Array(1000., dtype=float64), unit='Myr'),
+        frame=NoFrame()
     )
     >>> w.shape
     ()
@@ -388,7 +399,8 @@ def call(
     PhaseSpacePosition(
         q=CartesianPos3D( ... ),
         p=CartesianVel3D( ... ),
-        t=Quantity[...](value=f64[10], unit=Unit("Myr"))
+        t=Quantity['time'](Array(..., dtype=float64), unit='Myr'),
+        frame=NoFrame()
     )
     >>> ws.shape
     (10,)

--- a/src/galax/dynamics/_src/mockstream/core.py
+++ b/src/galax/dynamics/_src/mockstream/core.py
@@ -34,6 +34,8 @@ class MockStreamArm(gc.AbstractPhaseSpacePosition):
         Array of times corresponding to the positions.
     release_time : Array[float, (*batch,)]
         Release time of the stream particles [Myr].
+    frame : AbstractReferenceFrame
+
     """
 
     q: cx.vecs.AbstractPos3D = eqx.field(converter=cx.vector)

--- a/src/galax/dynamics/_src/mockstream/core.py
+++ b/src/galax/dynamics/_src/mockstream/core.py
@@ -12,6 +12,7 @@ from jaxtyping import Array, Shaped
 import coordinax as cx
 import quaxed.numpy as jnp
 import unxt as u
+from zeroth import zeroth
 
 import galax.coordinates as gc
 import galax.typing as gt
@@ -46,6 +47,9 @@ class MockStreamArm(gc.AbstractPhaseSpacePosition):
 
     release_time: gt.QVecTime = eqx.field(converter=u.Quantity["time"].from_)
     """Release time of the stream particles [Myr]."""
+
+    frame: cx.frames.NoFrame  # TODO: support frames
+    """The reference frame of the phase-space position."""
 
     # ==========================================================================
     # Array properties
@@ -83,6 +87,7 @@ class MockStreamArm(gc.AbstractPhaseSpacePosition):
 @final
 class MockStream(gc.AbstractCompositePhaseSpacePosition):
     _time_sorter: Shaped[Array, "alltimes"]
+    _frame: cx.frames.NoFrame  # TODO: support frames
 
     def __init__(
         self,
@@ -90,6 +95,25 @@ class MockStream(gc.AbstractCompositePhaseSpacePosition):
         /,
         **kwargs: MockStreamArm,
     ) -> None:
+        # Aggregate all the MockStreamArm
+        allpsps = dict(psps, **kwargs)
+
+        # Everything must be transformed to be in the same frame.
+        # Compute and store the frame
+        self._frame = theframe = zeroth(allpsps.values()).frame
+        # Transform all the PhaseSpacePositions to that frame. If the frames are
+        # already `NoFrame`, we can skip this step, since no transformation is
+        # possible in `NoFrame`.
+        allpsps = {
+            k: (
+                psp
+                if isinstance(theframe, cx.frames.NoFrame)
+                and isinstance(psp.frame, cx.frames.NoFrame)
+                else psp.to_frame(theframe)
+            )
+            for k, psp in allpsps.items()
+        }
+
         super().__init__(psps, **kwargs)
 
         # TODO: check up on the shapes
@@ -127,3 +151,8 @@ class MockStream(gc.AbstractCompositePhaseSpacePosition):
         return jnp.concat([psp.release_time for psp in self.values()], axis=0)[
             self._time_sorter
         ]
+
+    @property
+    def frame(self) -> cx.frames.AbstractReferenceFrame:
+        """The reference frame of the phase-space position."""
+        return self._frame

--- a/src/galax/dynamics/_src/mockstream/df/base.py
+++ b/src/galax/dynamics/_src/mockstream/df/base.py
@@ -77,12 +77,14 @@ class AbstractStreamDF(eqx.Module, strict=True):  # type: ignore[call-arg, misc]
             q=CartesianPos3D( ... ),
             p=CartesianVel3D( ... ),
             t=Quantity...,
-            release_time=Quantity... ),
+            release_time=Quantity...,
+            frame=NoFrame() ),
           'trail': MockStreamArm(
             q=CartesianPos3D( ... ),
             p=CartesianVel3D( ... ),
             t=Quantity...,
-            release_time=Quantity...
+            release_time=Quantity...,
+            frame=NoFrame()
         )})
         """
         # Progenitor positions and times. The orbit times are used as the
@@ -112,15 +114,21 @@ class AbstractStreamDF(eqx.Module, strict=True):  # type: ignore[call-arg, misc]
             p=u.uconvert(pot.units["speed"], v_lead),
             t=ts,
             release_time=ts,
+            frame=prog_orbit.frame,
         )
         mock_trail = MockStreamArm(
             q=u.uconvert(pot.units["length"], x_trail),
             p=u.uconvert(pot.units["speed"], v_trail),
             t=ts,
             release_time=ts,
+            frame=prog_orbit.frame,
         )
 
-        return gc.CompositePhaseSpacePosition(lead=mock_lead, trail=mock_trail)
+        return gc.CompositePhaseSpacePosition(
+            lead=mock_lead,
+            trail=mock_trail,
+            frame=prog_orbit.frame,
+        )
 
     # TODO: keep units and PSP through this func
     @abc.abstractmethod

--- a/src/galax/dynamics/_src/mockstream/mockstream_generator.py
+++ b/src/galax/dynamics/_src/mockstream/mockstream_generator.py
@@ -11,6 +11,7 @@ import jax
 from jax.extend.backend import get_backend
 from jaxtyping import PRNGKeyArray
 
+import coordinax as cx
 import quaxed.numpy as jnp
 import unxt as u
 
@@ -239,18 +240,26 @@ class MockStreamGenerator(eqx.Module):  # type: ignore[misc]
 
         t = jnp.ones_like(ts) * ts.value[-1]  # TODO: ensure this time is correct
 
+        frame = (
+            prog_w0.frame
+            if isinstance(prog_w0, gc.PhaseSpacePosition)
+            else cx.frames.NoFrame()
+        )
+
         comps = {}
         comps["lead"] = MockStreamArm(
             q=u.Quantity(lead_arm_w[:, 0:3], self.units["length"]),
             p=u.Quantity(lead_arm_w[:, 3:6], self.units["speed"]),
             t=t,
             release_time=mock0["lead"].release_time,
+            frame=frame,
         )
         comps["trail"] = MockStreamArm(
             q=u.Quantity(trail_arm_w[:, 0:3], self.units["length"]),
             p=u.Quantity(trail_arm_w[:, 3:6], self.units["speed"]),
             t=t,
             release_time=mock0["trail"].release_time,
+            frame=frame,
         )
 
         return MockStream(comps), prog_o[-1]

--- a/src/galax/dynamics/_src/orbit.py
+++ b/src/galax/dynamics/_src/orbit.py
@@ -53,7 +53,8 @@ class Orbit(gc.AbstractPhaseSpacePosition):
     Orbit(
       q=CartesianPos3D( ... ),
       p=CartesianVel3D( ... ),
-      t=Quantity[...](value=f64[10], unit=Unit("Myr")),
+      t=Quantity['time'](Array(..., dtype=float64), unit='Myr'),
+      frame=NoFrame(),
       potential=KeplerPotential( ... ),
       interpolant=None
     )
@@ -63,7 +64,8 @@ class Orbit(gc.AbstractPhaseSpacePosition):
     Orbit(
       q=CartesianPos3D( ... ),
       p=CartesianVel3D( ... ),
-      t=Quantity[...](value=f64[10], unit=Unit("Myr")),
+      t=Quantity['time'](Array(..., dtype=float64), unit='Myr'),
+      frame=NoFrame(),
       potential=KeplerPotential( ... ),
       interpolant=Interpolant( ... )
     )
@@ -72,7 +74,8 @@ class Orbit(gc.AbstractPhaseSpacePosition):
     Orbit(
       q=CartesianPos3D( ... ),
       p=CartesianVel3D( ... ),
-      t=Quantity[...](value=...f64[1], unit=Unit("Gyr")),
+      t=Quantity['time'](Array([0.5], dtype=float64, ...), unit='Gyr'),
+      frame=NoFrame(),
       potential=KeplerPotential( ... ),
       interpolant=None
     )
@@ -90,6 +93,9 @@ class Orbit(gc.AbstractPhaseSpacePosition):
     """Array of times corresponding to the positions."""
 
     _: KW_ONLY
+
+    frame: cx.frames.NoFrame  # TODO: support frames
+    """The reference frame of the phase-space position."""
 
     potential: gp.AbstractBasePotential
     """Potential in which the orbit was integrated."""
@@ -121,6 +127,7 @@ class Orbit(gc.AbstractPhaseSpacePosition):
             q=w.q,
             p=w.p,
             t=t,
+            frame=w.frame,
             potential=potential,
             interpolant=getattr(w, "interpolant", None),
         )
@@ -136,7 +143,14 @@ class Orbit(gc.AbstractPhaseSpacePosition):
             "Orbit was not integrated with interpolation.",
         )
         qp = interpolant(t)
-        return Orbit(q=qp.q, p=qp.p, t=qp.t, potential=self.potential, interpolant=None)
+        return Orbit(
+            q=qp.q,
+            p=qp.p,
+            t=qp.t,
+            potential=self.potential,
+            interpolant=None,
+            frame=self.frame,
+        )
 
     # ==========================================================================
     # Array properties
@@ -184,7 +198,8 @@ class Orbit(gc.AbstractPhaseSpacePosition):
           p=CartesianVel3D(
             d_x=Quantity[...]( value=f64[10], unit=Unit("kpc / Myr") ),
             ... ),
-          t=Quantity[PhysicalType('time')](value=f64[10], unit=Unit("Myr")),
+          t=Quantity['time'](Array(..., dtype=float64), unit='Myr'),
+          frame=NoFrame(),
           potential=KeplerPotential( ... ),
           interpolant=None
         )
@@ -217,7 +232,7 @@ class Orbit(gc.AbstractPhaseSpacePosition):
         ...     q=u.Quantity([8., 0., 0.], "kpc"),
         ...     p=u.Quantity([0., 230, 0.], "km/s"),
         ...     t=u.Quantity(0, "Myr"))
-        >>> ts = u.Quantity(jnp.linspace(0, 1, 10), "Gyr")
+        >>> ts = u.Quantity(jnp.linspace(0, 1, 11), "Gyr")
         >>> orbit = gd.evaluate_orbit(pot, w0, ts)
 
         >>> orbit[0:2]
@@ -230,7 +245,8 @@ class Orbit(gc.AbstractPhaseSpacePosition):
             d_x=Quantity[...]( value=f64[2], unit=Unit("kpc / Myr") ),
             ...
           ),
-          t=Quantity[...](value=f64[2], unit=Unit("Myr")),
+          t=Quantity['time'](Array([  0., 100.], dtype=float64), unit='Myr'),
+          frame=NoFrame(),
           potential=KeplerPotential( ... ),
           interpolant=None
         )
@@ -266,7 +282,8 @@ class Orbit(gc.AbstractPhaseSpacePosition):
         PhaseSpacePosition(
           q=CartesianPos3D( ... ),
           p=CartesianVel3D( ... ),
-          t=Quantity[...](value=f64[], unit=Unit("Myr"))
+          t=Quantity['time'](Array(0., dtype=float64), unit='Myr'),
+          frame=NoFrame()
         )
         >>> orbit[0].t
         Quantity['time'](Array(0., dtype=float64), unit='Myr')

--- a/tests/unit/dynamics/test_orbit.py
+++ b/tests/unit/dynamics/test_orbit.py
@@ -7,6 +7,7 @@ import jax.random as jr
 import pytest
 from plum import convert
 
+import coordinax as cx
 import quaxed.numpy as jnp
 import unxt as u
 from unxt.unitsystems import galactic
@@ -44,7 +45,14 @@ class TestOrbit(AbstractPhaseSpacePosition_Test[gd.Orbit]):
         t = u.Quantity(
             jr.normal(next(subkeys), shape[-1:]), unit=potential.units["time"]
         )
-        return w_cls(q=q, p=p, t=t, potential=potential, interpolant=None)
+        return w_cls(
+            q=q,
+            p=p,
+            t=t,
+            potential=potential,
+            interpolant=None,
+            frame=cx.frames.NoFrame(),
+        )
 
     @pytest.fixture
     def w(
@@ -58,7 +66,7 @@ class TestOrbit(AbstractPhaseSpacePosition_Test[gd.Orbit]):
     def test_getitem_int(self, w: T) -> None:
         """Test :meth:`~galax.coordinates.AbstractPhaseSpacePosition.__getitem__`."""
         assert not isinstance(w[0], type(w))
-        assert w[0] == gc.PhaseSpacePosition(q=w.q[0], p=w.p[0], t=w.t[0])
+        assert jnp.all(w[0] == gc.PhaseSpacePosition(q=w.q[0], p=w.p[0], t=w.t[0]))
 
     @override
     def test_getitem_boolarray(self, w: T, shape: gt.Shape) -> None:


### PR DESCRIPTION
This PR starts the process of transitioning PSP to the coordinax.Coordinate object framework.
Two things need more work:
1. the time storage of the PSP
2. enabling frames beyond NoFrame and then registering the dispatches for frame transforms.