### PR TITLE
feat(dynamics): enable q,p tuple array input to integrator 

### DIFF
--- a/src/galax/dynamics/_src/integrate/funcs.py
+++ b/src/galax/dynamics/_src/integrate/funcs.py
@@ -31,7 +31,7 @@ _select_w0: Callable[[Array, Array, Array], Array] = jax.numpy.vectorize(
 @dispatch
 def evaluate_orbit(
     pot: gp.AbstractBasePotential,
-    w0: gc.PhaseSpacePosition | gt.BatchVec6,
+    w0: gc.PhaseSpacePosition | gt.BatchQParr | gt.BatchVec6,
     t: Any,
     /,
     *,
@@ -49,22 +49,26 @@ def evaluate_orbit(
     ----------
     pot : :class:`~galax.potential.AbstractBasePotential`
         The potential in which to integrate the orbit.
-    w0 : PhaseSpacePosition | Array[float, (*batch, 6)]
+    w0 : PhaseSpacePosition | Array[number, (*batch, 6)]
         The phase-space position (includes velocity and time) from which to
         integrate. Integration includes the time of the initial position, so be
         sure to set the initial time to the desired value. See the `t` argument
         for more details.
 
-        - :class:`~galax.dynamics.PhaseSpacePosition`[float, (*batch,)]:
+        - :class:`~galax.dynamics.PhaseSpacePosition`[number, (*batch,)]:
             The full phase-space position, including position, velocity, and
             time. `w0` will be integrated from ``w0.t`` to ``t[0]``, then
             integrated from ``t[0]`` to ``t[1]``, returning the orbit calculated
             at `t`. If `w0.t` is `None`, it is assumed to be `t[0]`.
-        - Array[float, (*batch, 6)]:
+        - tuple[Array[number, (*batch, 3)], Array[number, (*batch, 3)]]:
+            A :class:`~galax.coordinates.PhaseSpacePosition` will be
+            constructed, interpreting the array as the  'q', 'p', with 't' set
+            to ``t[0]``.
+        - Array[number, (*batch, 6)]:
             A :class:`~galax.coordinates.PhaseSpacePosition` will be
             constructed, interpreting the array as the  'q', 'p' (each
-            Array[float, (*batch, 3)]) arguments, with 't' set to ``t[0]``.
-    t: Quantity[float, (time,), 'time']
+            Array[number, (*batch, 3)]) arguments, with 't' set to ``t[0]``.
+    t: Quantity[number, (time,), 'time']
         Array of times at which to compute the orbit. The first element should
         be the initial time and the last element should be the final time and
         the array should be monotonically moving from the first to final time.
@@ -109,10 +113,10 @@ def evaluate_orbit(
     We can then integrate an initial phase-space position in this potential to
     get an orbit:
 
-    >>> w0 = gc.PhaseSpacePosition(q=u.Quantity([10., 0., 0.], "kpc"),
-    ...                            p=u.Quantity([0., 200, 0.], "km/s"),
+    >>> w0 = gc.PhaseSpacePosition(q=u.Quantity([10, 0, 0], "kpc"),
+    ...                            p=u.Quantity([0, 200, 0], "km/s"),
     ...                            t=u.Quantity(-100, "Myr"))
-    >>> ts = u.Quantity(jnp.linspace(0., 1, 4), "Gyr")
+    >>> ts = u.Quantity(jnp.linspace(0, 1, 4), "Gyr")
     >>> orbit = gd.evaluate_orbit(potential, w0, ts)
     >>> orbit
     Orbit(
@@ -128,7 +132,7 @@ def evaluate_orbit(
     defined at `t=-100`, but the orbit is integrated from `t=0` to `t=1000`.
     Changing the number of times is easy:
 
-    >>> ts = u.Quantity(jnp.linspace(0., 1, 10), "Gyr")
+    >>> ts = u.Quantity(jnp.linspace(0, 1, 10), "Gyr")
     >>> orbit = gd.evaluate_orbit(potential, w0, ts)
     >>> orbit
     Orbit(
@@ -151,7 +155,7 @@ def evaluate_orbit(
 
     We can also integrate a batch of orbits at once:
 
-    >>> w0 = gc.PhaseSpacePosition(q=u.Quantity([[10., 0, 0], [10., 0, 0]], "kpc"),
+    >>> w0 = gc.PhaseSpacePosition(q=u.Quantity([[10, 0, 0], [10., 0, 0]], "kpc"),
     ...                            p=u.Quantity([[0, 200, 0], [0, 220, 0]], "km/s"),
     ...                            t=u.Quantity([-100, -150], "Myr"))
     >>> orbit = gd.evaluate_orbit(potential, w0, ts)
@@ -171,8 +175,8 @@ def evaluate_orbit(
     time at which the position is given. As noted earlier, this can be used to
     integrate from a different time than the initial time of the position:
 
-    >>> w0 = gc.PhaseSpacePosition(q=u.Quantity([10., 0., 0.], "kpc"),
-    ...                            p=u.Quantity([0., 200, 0.], "km/s"),
+    >>> w0 = gc.PhaseSpacePosition(q=u.Quantity([10, 0, 0], "kpc"),
+    ...                            p=u.Quantity([0, 200, 0], "km/s"),
     ...                            t=u.Quantity(0, "Myr"))
     >>> ts = u.Quantity(jnp.linspace(0.3, 1, 8), "Gyr")
     >>> orbit = gd.evaluate_orbit(potential, w0, ts)
@@ -260,10 +264,10 @@ def evaluate_orbit(
     We can then integrate an initial phase-space position in this potential to
     get an orbit:
 
-    >>> w0 = gc.PhaseSpacePosition(q=u.Quantity([10., 0., 0.], "kpc"),
-    ...                            p=u.Quantity([0., 200, 0.], "km/s"),
+    >>> w0 = gc.PhaseSpacePosition(q=u.Quantity([10, 0, 0], "kpc"),
+    ...                            p=u.Quantity([0, 200, 0], "km/s"),
     ...                            t=u.Quantity(-100, "Myr"))
-    >>> ts = jnp.linspace(0., 1000, 4)  # (1 Gyr, 4 steps)
+    >>> ts = jnp.linspace(0, 1000, 4)  # (1 Gyr, 4 steps)
     >>> orbit = gd.evaluate_orbit(potential, w0, t=ts)
     >>> orbit
     Orbit(

--- a/src/galax/dynamics/_src/integrate/integrator.py
+++ b/src/galax/dynamics/_src/integrate/integrator.py
@@ -12,7 +12,7 @@ import equinox as eqx
 from jaxtyping import ArrayLike, Shaped
 from plum import dispatch
 
-import quaxed.numpy as xp
+import quaxed.numpy as jnp
 import unxt as u
 from unxt.quantity import UncheckedQuantity as FastQ
 from xmmutablemap import ImmutableMap
@@ -66,8 +66,8 @@ class Integrator(eqx.Module, strict=True):  # type: ignore[call-arg,misc]
 
     Then we define initial conditions:
 
-    >>> w0 = gc.PhaseSpacePosition(q=u.Quantity([10., 0., 0.], "kpc"),
-    ...                            p=u.Quantity([0., 200., 0.], "km/s"))
+    >>> w0 = gc.PhaseSpacePosition(q=u.Quantity([10, 0, 0], "kpc"),
+    ...                            p=u.Quantity([0, 200, 0], "km/s"))
 
     (Note that the ``t`` attribute is not used.)
 
@@ -110,7 +110,7 @@ class Integrator(eqx.Module, strict=True):  # type: ignore[call-arg,misc]
     conditions at once, returning a batch of final conditions (or a batch of
     conditions at the requested times ``saveat``):
 
-    >>> w0 = gc.PhaseSpacePosition(q=u.Quantity([[10., 0, 0], [11., 0, 0]], "kpc"),
+    >>> w0 = gc.PhaseSpacePosition(q=u.Quantity([[10, 0, 0], [11, 0, 0]], "kpc"),
     ...                            p=u.Quantity([[0, 200, 0], [0, 210, 0]], "km/s"))
     >>> ws = integrator(pot._vector_field, w0, t0, t1, units=galactic)
     >>> ws.shape
@@ -151,7 +151,7 @@ class Integrator(eqx.Module, strict=True):  # type: ignore[call-arg,misc]
 
     And it works on batches:
 
-    >>> w0 = gc.PhaseSpacePosition(q=u.Quantity([[10., 0, 0], [11., 0, 0]], "kpc"),
+    >>> w0 = gc.PhaseSpacePosition(q=u.Quantity([[10, 0, 0], [11, 0, 0]], "kpc"),
     ...                            p=u.Quantity([[0, 200, 0], [0, 210, 0]], "km/s"))
     >>> ws = integrator(pot._vector_field, w0, t0, t1, units=galactic,
     ...                 interpolated=True)
@@ -189,7 +189,8 @@ class Integrator(eqx.Module, strict=True):  # type: ignore[call-arg,misc]
     def _call_(
         self,
         field: VectorField,
-        y0: gt.BatchVec6,
+        q0: gt.BatchQarr,
+        p0: gt.BatchQarr,
         t0: Time,
         t1: Time,
         /,
@@ -205,16 +206,16 @@ class Integrator(eqx.Module, strict=True):  # type: ignore[call-arg,misc]
 
         I/O shapes:
 
-        - y0=(6,), t0=(), t1=(), saveat=() -> ()
-        - y0=(6,), t0=(), t1=(), saveat=(T,) -> (T,)
-        - y0=(*batch,6), t0=(), t1=(), saveat=() -> (*batch,)
-        - y0=(*batch,6), t0=(), t1=(), saveat=(T) -> (*batch,T)
+        - q0=(3,), p0=(3,), t0=(), t1=(), saveat=() -> ()
+        - q0=(3,), p0=(3,), t0=(), t1=(), saveat=(T,) -> (T,)
+        - q0=(*B,3), p0=(*B,3), t0=(), t1=(), saveat=() -> (*B,)
+        - q0=(*B,3), p0=(*B,3), t0=(), t1=(), saveat=(T) -> (*B,T)
 
         Parameters
         ----------
         field : `galax.dynamics.integrate.VectorField`
             The field to integrate. Excluded from JIT.
-        y0 : Array[float, (*batch, 6)]
+        q0, p0 : Array[float, (*batch, 3)]
             Initial conditions. Can have any (or no) batch dimensions. Included
             in JIT.
         t0, t1 : scalar
@@ -256,7 +257,7 @@ class Integrator(eqx.Module, strict=True):  # type: ignore[call-arg,misc]
             solver=self.Solver(**self.solver_kw),
             t0=t0_,
             t1=t1_,
-            y0=y0,
+            y0=(q0, p0),
             dt0=None,
             args=(),
             saveat=save_at,
@@ -266,13 +267,14 @@ class Integrator(eqx.Module, strict=True):  # type: ignore[call-arg,misc]
 
         # Reshape (T, *batch) to (*batch, T)
         # soln.ts is already in the correct shape
-        ys = xp.moveaxis(soln.ys, 0, -2)
+        solq = jnp.moveaxis(soln.ys[0], 0, -2)
+        solp = jnp.moveaxis(soln.ys[1], 0, -2)
 
         # Parse the solution, (unbatching time when saveat is None)
         t_dim_sel = -1 if saveat is None else slice(None)
         solt = soln.ts[..., t_dim_sel]
-        solq = ys[..., t_dim_sel, 0:3]
-        solp = ys[..., t_dim_sel, 3:6]
+        solq = solq[..., t_dim_sel, :]
+        solp = solp[..., t_dim_sel, :]
 
         # ---------------------------------------
         # Return
@@ -318,7 +320,7 @@ class Integrator(eqx.Module, strict=True):  # type: ignore[call-arg,misc]
 def call(
     self: Integrator,
     field: VectorField,
-    y0: gt.BatchVec6,
+    qp0: gt.BatchQParr,
     t0: Time,
     t1: Time,
     /,
@@ -351,8 +353,8 @@ def call(
 
     We define initial conditions:
 
-    >>> w0 = gc.PhaseSpacePosition(q=u.Quantity([10., 0., 0.], "kpc"),
-    ...                            p=u.Quantity([0., 200., 0.], "km/s")
+    >>> w0 = gc.PhaseSpacePosition(q=u.Quantity([10, 0, 0], "kpc"),
+    ...                            p=u.Quantity([0, 200, 0], "km/s")
     ...                            ).w(units="galactic")
     >>> w0.shape
     (6,)
@@ -394,7 +396,53 @@ def call(
 
     """
     return self._call_(
-        field, y0, t0, t1, saveat=saveat, units=units, interpolated=interpolated
+        field,
+        qp0[0],  # q
+        qp0[1],  # p
+        t0,
+        t1,
+        saveat=saveat,
+        units=units,
+        interpolated=interpolated,
+    )
+
+
+@Integrator.__call__.dispatch(precedence=2)
+@eqx.filter_jit  # @partial(jax.jit, static_argnums=(0, 1), static_argnames=("units", "interpolated"))  # noqa: E501
+def call(
+    self: Integrator,
+    field: VectorField,
+    y0: gt.BatchVec6,
+    t0: Time,
+    t1: Time,
+    /,
+    *,
+    units: u.AbstractUnitSystem,
+    saveat: Times | None = None,
+    interpolated: bool = False,
+) -> gc.PhaseSpacePosition | gc.InterpolatedPhaseSpacePosition:
+    """Run the integrator.
+
+    This is the base dispatch for the integrator and handles the shape cases
+    that `diffrax.diffeqsolve` can handle without application of `jax.vmap`
+    or `jax.numpy.vectorize`.
+
+    I/O shapes:
+
+    - y0=(6,), t0=(), t1=(), saveat=() -> ()
+    - y0=(6,), t0=(), t1=(), saveat=(T,) -> (T,)
+    - y0=(*batch,6), t0=(), t1=(), saveat=() -> (*batch,)
+    - y0=(*batch,6), t0=(), t1=(), saveat=(T) -> (*batch,T)
+
+    """
+    return self(  # redispatch to the q,p form
+        field,
+        (y0[..., 0:3], y0[..., 3:6]),
+        t0,
+        t1,
+        saveat=saveat,
+        units=units,
+        interpolated=interpolated,
     )
 
 
@@ -423,11 +471,8 @@ def call(
 
     We define initial conditions:
 
-    >>> w0 = gc.PhaseSpacePosition(q=u.Quantity([10., 0., 0.], "kpc"),
-    ...                            p=u.Quantity([0., 200., 0.], "km/s")
-    ...                            ).w(units="galactic")
-    >>> w0.shape
-    (6,)
+    >>> w0 = gc.PhaseSpacePosition(q=u.Quantity([10, 0, 0], "kpc"),
+    ...                            p=u.Quantity([0, 200, 0], "km/s"))
 
     (Note that the ``t`` attribute is not used.)
 
@@ -498,6 +543,48 @@ def call(
 def call(
     self: Integrator,
     field: VectorField,
+    y0: gt.BatchableQParr,
+    t0: Shaped[u.Quantity["time"], "*#batch"] | Shaped[ArrayLike, "*#batch"] | Time,
+    t1: Shaped[u.Quantity["time"], "*#batch"] | Shaped[ArrayLike, "*#batch"] | Time,
+    /,
+    *,
+    units: u.AbstractUnitSystem,
+    saveat: Times | None = None,
+    **kwargs: Any,
+) -> gc.PhaseSpacePosition | gc.InterpolatedPhaseSpacePosition:
+    """Run the integrator, vectorizing in the initial/final times.
+
+    I/O shapes:
+
+    - y0=(*#B,6), t0=(*#B,), t1=(), saveat=() -> (*B,)
+    - y0=(*#B,6), t0=(), t1=(*#B,), saveat=() -> (*B,)
+    - y0=(*#B,6), t0=(*#B), t1=(*#B,), saveat=() -> (*B,)
+    - y0=(*#B,6), t0=(*#B,), t1=(), saveat=(T,) -> (*B,T)
+    - y0=(*#B,6), t0=(), t1=(*#B,), saveat=(T,) -> (*B,T)
+    - y0=(*#B,6), t0=(*#B), t1=(*#B,), saveat=(T,) -> (*B,T)
+
+    """
+    # Vectorize the call
+    # This depends on the shape of saveat
+    vec_call = jnp.vectorize(
+        lambda *args: self._call_(*args, units=units, saveat=saveat, **kwargs),
+        signature="(3),(3),(),()->(T)" if saveat is not None else "(3),(3),(),()->()",
+        excluded=(0,),
+    )
+
+    # TODO: vectorize with units!
+    time = units["time"]
+    t0_: gt.VecTime = FastQ.from_(t0, time).ustrip(time)
+    t1_: gt.VecTime = FastQ.from_(t1, time).ustrip(time)
+
+    return vec_call(field, y0[0], y0[1], t0_, t1_)
+
+
+@Integrator.__call__.dispatch(precedence=1)
+@eqx.filter_jit
+def call(
+    self: Integrator,
+    field: VectorField,
     y0: gt.BatchableVec6,
     t0: Shaped[u.Quantity["time"], "*#batch"] | Shaped[ArrayLike, "*#batch"] | Time,
     t1: Shaped[u.Quantity["time"], "*#batch"] | Shaped[ArrayLike, "*#batch"] | Time,
@@ -531,7 +618,7 @@ def call(
     once, returning a batch of final conditions (or a batch of conditions at
     the requested times):
 
-    >>> w0 = gc.PhaseSpacePosition(q=u.Quantity([[10., 0, 0], [11., 0, 0]], "kpc"),
+    >>> w0 = gc.PhaseSpacePosition(q=u.Quantity([[10, 0, 0], [11, 0, 0]], "kpc"),
     ...                            p=u.Quantity([[0, 200, 0], [0, 210, 0]], "km/s"))
 
     Now we can integrate the phase-space position for 1 Gyr, getting the
@@ -547,20 +634,15 @@ def call(
     (2,)
 
     """
-    # Vectorize the call
-    # This depends on the shape of saveat
-    vec_call = xp.vectorize(
-        lambda *args: self._call_(*args, units=units, saveat=saveat, **kwargs),
-        signature="(6),(),()->(T)" if saveat is not None else "(6),(),()->()",
-        excluded=(0,),
+    return self(  # redispatch to the q,p form
+        field,
+        (y0[..., 0:3], y0[..., 3:6]),
+        t0,
+        t1,
+        units=units,
+        saveat=saveat,
+        **kwargs,
     )
-
-    # TODO: vectorize with units!
-    time = units["time"]
-    t0_: gt.VecTime = FastQ.from_(t0, time).ustrip(time)
-    t1_: gt.VecTime = FastQ.from_(t1, time).ustrip(time)
-
-    return vec_call(field, y0, t0_, t1_)
 
 
 # -------------------------------------------
@@ -584,7 +666,6 @@ def call(
 
     Examples
     --------
-    >>> import quaxed.numpy as xp
     >>> import unxt as u
     >>> from unxt.unitsystems import galactic
     >>> import galax.coordinates as gc
@@ -593,8 +674,8 @@ def call(
 
     We define initial conditions and a potential:
 
-    >>> w0 = gc.PhaseSpacePosition(q=u.Quantity([10., 0., 0.], "kpc"),
-    ...                            p=u.Quantity([0., 200., 0.], "km/s"))
+    >>> w0 = gc.PhaseSpacePosition(q=u.Quantity([10, 0, 0], "kpc"),
+    ...                            p=u.Quantity([0, 200, 0], "km/s"))
 
     >>> pot = gp.HernquistPotential(m_tot=u.Quantity(1e12, "Msun"),
     ...                             r_s=u.Quantity(5, "kpc"), units="galactic")
@@ -614,7 +695,7 @@ def call(
     """
     return self(
         field,
-        w0.w(units=units),
+        w0._qp(units=units),  # noqa: SLF001
         t0,
         t1,
         saveat=saveat,
@@ -640,7 +721,6 @@ def call(
 
     Examples
     --------
-    >>> import quaxed.numpy as xp
     >>> import unxt as u
     >>> from unxt.unitsystems import galactic
     >>> import galax.coordinates as gc
@@ -649,10 +729,10 @@ def call(
 
     We define initial conditions and a potential:
 
-    >>> w01 = gc.PhaseSpacePosition(q=u.Quantity([10., 0., 0.], "kpc"),
-    ...                             p=u.Quantity([0., 200., 0.], "km/s"))
-    >>> w02 = gc.PhaseSpacePosition(q=u.Quantity([0., 10., 0.], "kpc"),
-    ...                             p=u.Quantity([-200., 0., 0.], "km/s"))
+    >>> w01 = gc.PhaseSpacePosition(q=u.Quantity([10, 0, 0], "kpc"),
+    ...                             p=u.Quantity([0, 200, 0], "km/s"))
+    >>> w02 = gc.PhaseSpacePosition(q=u.Quantity([0, 10, 0], "kpc"),
+    ...                             p=u.Quantity([-200, 0, 0], "km/s"))
     >>> w0 = gc.CompositePhaseSpacePosition(w01=w01, w02=w02)
 
     >>> pot = gp.HernquistPotential(m_tot=u.Quantity(1e12, "Msun"),

--- a/src/galax/dynamics/_src/integrate/type_hints.py
+++ b/src/galax/dynamics/_src/integrate/type_hints.py
@@ -9,21 +9,24 @@ import galax.typing as gt
 class VectorField(Protocol):
     """Protocol for the integration callable."""
 
-    def __call__(self, t: gt.FloatScalar, w: gt.Vec6, args: tuple[Any, ...]) -> gt.Vec6:
+    def __call__(
+        self, t: gt.FloatScalar, w: gt.QParr, args: tuple[Any, ...]
+    ) -> gt.PAarr:
         """Integration function.
 
         Parameters
         ----------
         t : float
             The time. This is the integration variable.
-        w : Array[float, (6,)]
+        qp : Array[number, (3,)], Array[number, (3,)]
             The position and velocity.
         args : tuple[Any, ...]
             Additional arguments.
 
         Returns
         -------
-        Array[float, (6,)]
-            Velocity and acceleration [v (3,), a (3,)].
+        Array[number, (3,)], Array[number, (3,)]
+            Velocity and acceleration p, a.
+
         """
         ...

--- a/src/galax/potential/_src/base.py
+++ b/src/galax/potential/_src/base.py
@@ -167,7 +167,7 @@ class AbstractBasePotential(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
         grad_op = u.experimental.grad(
             self._potential, units=(self.units["length"], self.units["time"])
         )
-        return grad_op(q, t)
+        return grad_op(q.astype(float), t)
 
     def gradient(
         self: "AbstractBasePotential", *args: Any, **kwargs: Any
@@ -278,9 +278,9 @@ class AbstractBasePotential(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
     def _vector_field(
         self,
         t: gt.BatchableFloatScalar,
-        w: gt.BatchableVec6,
+        qp: gt.BatchableQParr,
         args: tuple[Any, ...],  # noqa: ARG002
-    ) -> gt.BatchVec6:
+    ) -> gt.BatchPAarr:
         r"""Differential equation derivative for dynamics.
 
         This is Hamilton's equations for motion for a particle in a potential.
@@ -293,22 +293,23 @@ class AbstractBasePotential(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
         ----------
         t : float
             Time at which to evaluate the derivative.
-        w : Array[float, (6,)]
-            Phase-space position [q (3,), p (3,)].
+        qp : Array[float, (3,)], Array[float, (3,)]
+            Phase-space position q, p.
         args : tuple
             Additional arguments to pass to the derivative. Not used, but
             required by some dynamics solvers.
 
         Returns
         -------
-        dw : Array[float, (6,)]
-            Derivative [p (3,), a (3,)] at the phase-space position.
+        dw : Array[float, (3,)], Array[float, (3,)]
+            Derivative p, a at the phase-space position.
         """
+        q, p = qp
         a = -self._gradient(
-            FastQ(w[..., 0:3], self.units["length"]),
+            FastQ(q, self.units["length"]),
             FastQ(t, self.units["time"]),
         ).ustrip(self.units["acceleration"])  # TODO: not require unit munging
-        return jnp.hstack([w[..., 3:6], a])  # v, a
+        return (p, a)
 
     def evaluate_orbit(
         self,

--- a/src/galax/potential/_src/base.py
+++ b/src/galax/potential/_src/base.py
@@ -277,10 +277,10 @@ class AbstractBasePotential(eqx.Module, metaclass=ModuleMeta, strict=True):  # t
     @partial(jax.jit, inline=True)  # TODO: inline?
     def _vector_field(
         self,
-        t: gt.FloatScalar,
-        w: gt.Vec6,
+        t: gt.BatchableFloatScalar,
+        w: gt.BatchableVec6,
         args: tuple[Any, ...],  # noqa: ARG002
-    ) -> gt.Vec6:
+    ) -> gt.BatchVec6:
         r"""Differential equation derivative for dynamics.
 
         This is Hamilton's equations for motion for a particle in a potential.

--- a/src/galax/typing.py
+++ b/src/galax/typing.py
@@ -82,6 +82,7 @@ QVecTime: TypeAlias = Float[AbstractQuantity, "time"]
 # Scalars
 
 BatchFloatScalar: TypeAlias = Shaped[FloatScalar, "*batch"]
+BatchableFloatScalar: TypeAlias = Shaped[FloatScalar, "*#batch"]
 
 BatchableFloatQScalar: TypeAlias = Shaped[FloatQScalar, "*#batch"]
 
@@ -143,10 +144,20 @@ SpecificEnergyBatchScalar: TypeAlias = Float[u.Quantity["specific_energy"], "*ba
 
 # =============================================================================
 
-Qarr: TypeAlias = Vec3
+Qarr: TypeAlias = Shaped[Array, "3"]
 BatchQarr: TypeAlias = Shaped[Qarr, "*batch"]
+BatchableQarr: TypeAlias = Shaped[Qarr, "*#batch"]
 
-Parr: TypeAlias = Vec3
+Parr: TypeAlias = Shaped[Array, "3"]
 BatchParr: TypeAlias = Shaped[Parr, "*batch"]
+BatchableParr: TypeAlias = Shaped[Parr, "*#batch"]
 
+Aarr: TypeAlias = Shaped[Array, "3"]
+BatchAarr: TypeAlias = Shaped[Aarr, "*batch"]
+
+QParr: TypeAlias = tuple[Qarr, Parr]
 BatchQParr: TypeAlias = tuple[BatchQarr, BatchParr]
+BatchableQParr: TypeAlias = tuple[BatchableQarr, BatchableParr]
+
+PAarr: TypeAlias = tuple[Parr, Aarr]
+BatchPAarr: TypeAlias = tuple[BatchParr, BatchAarr]

--- a/src/galax/typing.py
+++ b/src/galax/typing.py
@@ -148,9 +148,17 @@ Qarr: TypeAlias = Shaped[Array, "3"]
 BatchQarr: TypeAlias = Shaped[Qarr, "*batch"]
 BatchableQarr: TypeAlias = Shaped[Qarr, "*#batch"]
 
+Q: TypeAlias = Shaped[AbstractQuantity, "3"]
+BatchQ: TypeAlias = Shaped[Q, "*batch"]
+BatchableQ: TypeAlias = Shaped[Q, "*#batch"]
+
 Parr: TypeAlias = Shaped[Array, "3"]
 BatchParr: TypeAlias = Shaped[Parr, "*batch"]
 BatchableParr: TypeAlias = Shaped[Parr, "*#batch"]
+
+P: TypeAlias = Shaped[AbstractQuantity, "3"]
+BatchP: TypeAlias = Shaped[P, "*batch"]
+BatchableP: TypeAlias = Shaped[P, "*#batch"]
 
 Aarr: TypeAlias = Shaped[Array, "3"]
 BatchAarr: TypeAlias = Shaped[Aarr, "*batch"]
@@ -158,6 +166,10 @@ BatchAarr: TypeAlias = Shaped[Aarr, "*batch"]
 QParr: TypeAlias = tuple[Qarr, Parr]
 BatchQParr: TypeAlias = tuple[BatchQarr, BatchParr]
 BatchableQParr: TypeAlias = tuple[BatchableQarr, BatchableParr]
+
+QP: TypeAlias = tuple[Q, P]
+BatchQP: TypeAlias = tuple[BatchQ, BatchP]
+BatchableQP: TypeAlias = tuple[BatchableQ, BatchableP]
 
 PAarr: TypeAlias = tuple[Parr, Aarr]
 BatchPAarr: TypeAlias = tuple[BatchParr, BatchAarr]

--- a/src/galax/typing.py
+++ b/src/galax/typing.py
@@ -1,4 +1,10 @@
-"""Type hints for galax."""
+"""Type hints for galax.
+
+As indicated by `__all__`, this module does not export any names. The type hints
+defined here may be changed or removed without notice. They are intended for use
+in other modules within the `galax` package.
+
+"""
 
 __all__: list[str] = []
 
@@ -133,3 +139,14 @@ SpeedBatchableVec3: TypeAlias = Shaped[SpeedVec3, "*#batch"]
 
 SpecificEnergyScalar: TypeAlias = Float[u.Quantity["specific_energy"], ""]
 SpecificEnergyBatchScalar: TypeAlias = Float[u.Quantity["specific_energy"], "*batch"]
+
+
+# =============================================================================
+
+Qarr: TypeAlias = Vec3
+BatchQarr: TypeAlias = Shaped[Qarr, "*batch"]
+
+Parr: TypeAlias = Vec3
+BatchParr: TypeAlias = Shaped[Parr, "*batch"]
+
+BatchQParr: TypeAlias = tuple[BatchQarr, BatchParr]


### PR DESCRIPTION
This splits q,p in the integration, which makes for a better pytree and also paves the way for unitful integration, when `quaxify(diffrax.diffeqsolve)` is enabled for Quantities.