### PR TITLE
🎨 style(coordinates): rename PSP base classes

### DIFF
--- a/src/galax/coordinates/__init__.py
+++ b/src/galax/coordinates/__init__.py
@@ -12,7 +12,7 @@ with install_import_hook("galax.coordinates", RUNTIME_TYPECHECKER):
     from ._src.psps import (
         AbstractBasePhaseSpacePosition,
         AbstractCompositePhaseSpacePosition,
-        AbstractPhaseSpacePosition,
+        AbstractOnePhaseSpacePosition,
         ComponentShapeTuple,
         CompositePhaseSpacePosition,
         InterpolatedPhaseSpacePosition,
@@ -26,7 +26,7 @@ __all__ = [
     "frames",
     # Contents
     "AbstractBasePhaseSpacePosition",
-    "AbstractPhaseSpacePosition",
+    "AbstractOnePhaseSpacePosition",
     "PhaseSpacePosition",
     "AbstractCompositePhaseSpacePosition",
     "CompositePhaseSpacePosition",

--- a/src/galax/coordinates/__init__.py
+++ b/src/galax/coordinates/__init__.py
@@ -10,9 +10,9 @@ from galax.setup_package import RUNTIME_TYPECHECKER
 with install_import_hook("galax.coordinates", RUNTIME_TYPECHECKER):
     from . import frames, ops
     from ._src.psps import (
-        AbstractBasePhaseSpacePosition,
         AbstractCompositePhaseSpacePosition,
         AbstractOnePhaseSpacePosition,
+        AbstractPhaseSpacePosition,
         ComponentShapeTuple,
         CompositePhaseSpacePosition,
         InterpolatedPhaseSpacePosition,
@@ -25,7 +25,7 @@ __all__ = [
     "ops",
     "frames",
     # Contents
-    "AbstractBasePhaseSpacePosition",
+    "AbstractPhaseSpacePosition",
     "AbstractOnePhaseSpacePosition",
     "PhaseSpacePosition",
     "AbstractCompositePhaseSpacePosition",

--- a/src/galax/coordinates/_src/ops/rotating.py
+++ b/src/galax/coordinates/_src/ops/rotating.py
@@ -14,7 +14,7 @@ import coordinax.ops as cxo
 import quaxed.numpy as jnp
 import unxt as u
 
-from galax.coordinates._src.psps.base_psp import AbstractPhaseSpacePosition
+from galax.coordinates._src.psps.base_psp import AbstractOnePhaseSpacePosition
 
 vec_matmul = jnp.vectorize(jnp.matmul, signature="(3,3),(3)->(3)")
 
@@ -248,8 +248,8 @@ class ConstantRotationZOperator(cxo.AbstractOperator):  # type: ignore[misc]
 
     @cxo.AbstractOperator.__call__.dispatch
     def __call__(
-        self: "ConstantRotationZOperator", psp: AbstractPhaseSpacePosition, /
-    ) -> AbstractPhaseSpacePosition:
+        self: "ConstantRotationZOperator", psp: AbstractOnePhaseSpacePosition, /
+    ) -> AbstractOnePhaseSpacePosition:
         """Apply the translation to the coordinates.
 
         Examples

--- a/src/galax/coordinates/_src/psps/__init__.py
+++ b/src/galax/coordinates/_src/psps/__init__.py
@@ -6,7 +6,7 @@ This is private API.
 
 __all__ = [
     "AbstractBasePhaseSpacePosition",
-    "AbstractPhaseSpacePosition",
+    "AbstractOnePhaseSpacePosition",
     "PhaseSpacePosition",
     "AbstractCompositePhaseSpacePosition",
     "CompositePhaseSpacePosition",
@@ -19,7 +19,7 @@ __all__ = [
 
 from .base import AbstractBasePhaseSpacePosition, ComponentShapeTuple
 from .base_composite import AbstractCompositePhaseSpacePosition
-from .base_psp import AbstractPhaseSpacePosition
+from .base_psp import AbstractOnePhaseSpacePosition
 from .core import PhaseSpacePosition
 from .core_composite import CompositePhaseSpacePosition
 from .interp import InterpolatedPhaseSpacePosition, PhaseSpacePositionInterpolant

--- a/src/galax/coordinates/_src/psps/__init__.py
+++ b/src/galax/coordinates/_src/psps/__init__.py
@@ -5,7 +5,7 @@ This is private API.
 """
 
 __all__ = [
-    "AbstractBasePhaseSpacePosition",
+    "AbstractPhaseSpacePosition",
     "AbstractOnePhaseSpacePosition",
     "PhaseSpacePosition",
     "AbstractCompositePhaseSpacePosition",
@@ -17,7 +17,7 @@ __all__ = [
     "ComponentShapeTuple",
 ]
 
-from .base import AbstractBasePhaseSpacePosition, ComponentShapeTuple
+from .base import AbstractPhaseSpacePosition, ComponentShapeTuple
 from .base_composite import AbstractCompositePhaseSpacePosition
 from .base_psp import AbstractOnePhaseSpacePosition
 from .core import PhaseSpacePosition

--- a/src/galax/coordinates/_src/psps/base.py
+++ b/src/galax/coordinates/_src/psps/base.py
@@ -1,6 +1,6 @@
 """ABC for phase-space positions."""
 
-__all__ = ["AbstractBasePhaseSpacePosition", "ComponentShapeTuple"]
+__all__ = ["AbstractPhaseSpacePosition", "ComponentShapeTuple"]
 
 from abc import abstractmethod
 from dataclasses import replace
@@ -40,7 +40,7 @@ class ComponentShapeTuple(NamedTuple):
 
 
 # TODO: make it strict=True
-class AbstractBasePhaseSpacePosition(cx.frames.AbstractCoordinate):  # type: ignore[misc]
+class AbstractPhaseSpacePosition(cx.frames.AbstractCoordinate):  # type: ignore[misc]
     r"""ABC underlying phase-space positions and their composites.
 
     The phase-space position is a point in the 3+3+1-dimensional phase space
@@ -90,10 +90,10 @@ class AbstractBasePhaseSpacePosition(cx.frames.AbstractCoordinate):  # type: ign
     @classmethod
     @dispatch
     def from_(
-        cls: "type[AbstractBasePhaseSpacePosition]", *args: Any, **kwargs: Any
-    ) -> "AbstractBasePhaseSpacePosition":
+        cls: "type[AbstractPhaseSpacePosition]", *args: Any, **kwargs: Any
+    ) -> "AbstractPhaseSpacePosition":
         """Construct from arguments, defaulting to AbstractVector constructor."""
-        return cast(AbstractBasePhaseSpacePosition, super().from_(*args, **kwargs))
+        return cast(AbstractPhaseSpacePosition, super().from_(*args, **kwargs))
 
     # ==========================================================================
     # Coordinate API
@@ -134,7 +134,7 @@ class AbstractBasePhaseSpacePosition(cx.frames.AbstractCoordinate):  # type: ign
     @dispatch(precedence=-1)
     def vconvert(
         self, target: Any, *args: Any, **kwargs: Any
-    ) -> "AbstractBasePhaseSpacePosition":
+    ) -> "AbstractPhaseSpacePosition":
         return cx.vconvert(target, self, *args, **kwargs)
 
     @dispatch
@@ -144,7 +144,7 @@ class AbstractBasePhaseSpacePosition(cx.frames.AbstractCoordinate):  # type: ign
         velocity_cls: type[cx.vecs.AbstractVel] | None = None,
         /,
         **kwargs: Any,
-    ) -> "AbstractBasePhaseSpacePosition":
+    ) -> "AbstractPhaseSpacePosition":
         """Return with the components transformed.
 
         Parameters
@@ -332,8 +332,8 @@ class AbstractBasePhaseSpacePosition(cx.frames.AbstractCoordinate):  # type: ign
 
     @dispatch
     def __getitem__(
-        self: "AbstractBasePhaseSpacePosition", index: Any
-    ) -> "AbstractBasePhaseSpacePosition":
+        self: "AbstractPhaseSpacePosition", index: Any
+    ) -> "AbstractPhaseSpacePosition":
         """Return a new object with the given slice applied.
 
         Examples
@@ -374,12 +374,12 @@ class AbstractBasePhaseSpacePosition(cx.frames.AbstractCoordinate):  # type: ign
 
     @dispatch.abstract
     def __add__(
-        self: "AbstractBasePhaseSpacePosition", other: Any, /
-    ) -> "AbstractBasePhaseSpacePosition":
+        self: "AbstractPhaseSpacePosition", other: Any, /
+    ) -> "AbstractPhaseSpacePosition":
         """Add to a phase-space positions."""
         raise NotImplementedError  # pragma: no cover
 
-    def __neg__(self) -> "AbstractBasePhaseSpacePosition":
+    def __neg__(self) -> "AbstractPhaseSpacePosition":
         raise NotImplementedError  # TODO: implement
 
     # ==========================================================================
@@ -722,22 +722,22 @@ class AbstractBasePhaseSpacePosition(cx.frames.AbstractCoordinate):  # type: ign
 # Register additional constructors
 
 
-@AbstractBasePhaseSpacePosition.from_.dispatch  # type: ignore[attr-defined,misc]
+@AbstractPhaseSpacePosition.from_.dispatch  # type: ignore[attr-defined,misc]
 def from_(
-    cls: type[AbstractBasePhaseSpacePosition], obj: AbstractBasePhaseSpacePosition, /
-) -> AbstractBasePhaseSpacePosition:
-    """Construct from a `AbstractBasePhaseSpacePosition`.
+    cls: type[AbstractPhaseSpacePosition], obj: AbstractPhaseSpacePosition, /
+) -> AbstractPhaseSpacePosition:
+    """Construct from a `AbstractPhaseSpacePosition`.
 
     Parameters
     ----------
-    cls : type[:class:`~galax.coordinates.AbstractBasePhaseSpacePosition`]
+    cls : type[:class:`~galax.coordinates.AbstractPhaseSpacePosition`]
         The class to construct.
-    obj : :class:`~galax.coordinates.AbstractBasePhaseSpacePosition`
+    obj : :class:`~galax.coordinates.AbstractPhaseSpacePosition`
         The phase-space position object from which to construct.
 
     Returns
     -------
-    :class:`~galax.coordinates.AbstractBasePhaseSpacePosition`
+    :class:`~galax.coordinates.AbstractPhaseSpacePosition`
         The constructed phase-space position.
 
     Raises
@@ -788,9 +788,9 @@ def from_(
 # Converters
 
 
-@conversion_method(type_from=AbstractBasePhaseSpacePosition, type_to=cx.Coordinate)  # type: ignore[arg-type,type-abstract]
+@conversion_method(type_from=AbstractPhaseSpacePosition, type_to=cx.Coordinate)  # type: ignore[arg-type,type-abstract]
 def convert_psp_to_coordinax_coordinate(
-    obj: AbstractBasePhaseSpacePosition, /
+    obj: AbstractPhaseSpacePosition, /
 ) -> cx.Coordinate:
     """Convert a phase-space position to a coordinax coordinate.
 
@@ -818,12 +818,12 @@ def convert_psp_to_coordinax_coordinate(
 # Addition
 
 
-@AbstractBasePhaseSpacePosition.__add__.dispatch  # type: ignore[misc]
+@AbstractPhaseSpacePosition.__add__.dispatch  # type: ignore[misc]
 def add(
-    self: AbstractBasePhaseSpacePosition,
-    other: AbstractBasePhaseSpacePosition,
+    self: AbstractPhaseSpacePosition,
+    other: AbstractPhaseSpacePosition,
     /,
-) -> AbstractBasePhaseSpacePosition:
+) -> AbstractPhaseSpacePosition:
     """Add two phase-space positions.
 
     Examples

--- a/src/galax/coordinates/_src/psps/base.py
+++ b/src/galax/coordinates/_src/psps/base.py
@@ -159,7 +159,7 @@ class AbstractBasePhaseSpacePosition(cx.frames.AbstractCoordinate):  # type: ign
 
         Returns
         -------
-        w : :class:`~galax.coordinates.AbstractPhaseSpacePosition`
+        w : :class:`~galax.coordinates.AbstractOnePhaseSpacePosition`
             The phase-space position with the components transformed.
 
         Examples
@@ -214,7 +214,7 @@ class AbstractBasePhaseSpacePosition(cx.frames.AbstractCoordinate):  # type: ign
 
         Returns
         -------
-        w : :class:`~galax.coordinates.AbstractPhaseSpacePosition`
+        w : :class:`~galax.coordinates.AbstractOnePhaseSpacePosition`
             The phase-space position with the components transformed.
 
         Examples
@@ -484,7 +484,7 @@ class AbstractBasePhaseSpacePosition(cx.frames.AbstractCoordinate):  # type: ign
         -------
         Array[float, (*batch, Q + P)]
             The phase-space position as a 6-vector in Cartesian coordinates.
-            This will have shape :attr:`AbstractPhaseSpacePosition.full_shape`.
+            This will have shape :attr:`AbstractOnePhaseSpacePosition.full_shape`.
 
         Examples
         --------

--- a/src/galax/coordinates/_src/psps/base_composite.py
+++ b/src/galax/coordinates/_src/psps/base_composite.py
@@ -19,14 +19,14 @@ from xmmutablemap import ImmutableMap
 from zeroth import zeroth
 
 import galax.typing as gt
-from .base import AbstractBasePhaseSpacePosition, ComponentShapeTuple
+from .base import AbstractPhaseSpacePosition, ComponentShapeTuple
 from .utils import PSPVConvertOptions
 
 
 # Note: cannot have `strict=True` because of inheriting from ImmutableMap.
 class AbstractCompositePhaseSpacePosition(  # type: ignore[misc,unused-ignore]
-    AbstractBasePhaseSpacePosition,
-    ImmutableMap[str, AbstractBasePhaseSpacePosition],  # type: ignore[misc]
+    AbstractPhaseSpacePosition,
+    ImmutableMap[str, AbstractPhaseSpacePosition],  # type: ignore[misc]
     strict=False,  # type: ignore[call-arg]
 ):
     r"""Abstract base class of composite phase-space positions.
@@ -42,7 +42,7 @@ class AbstractCompositePhaseSpacePosition(  # type: ignore[misc,unused-ignore]
 
     The components are stored as a dictionary and can be key accessed. However,
     the composite phase-space position itself acts as a single
-    `AbstractBasePhaseSpacePosition` object, so you can access the composite
+    `AbstractPhaseSpacePosition` object, so you can access the composite
     positions, velocities, and times as if they were a single object. In this
     base class the composition of the components is abstract and must be
     implemented in the subclasses.
@@ -94,16 +94,16 @@ class AbstractCompositePhaseSpacePosition(  # type: ignore[misc,unused-ignore]
     2
     """
 
-    _data: dict[str, AbstractBasePhaseSpacePosition]
+    _data: dict[str, AbstractPhaseSpacePosition]
 
     def __init__(
         self,
         psps: (
-            dict[str, AbstractBasePhaseSpacePosition]
-            | tuple[tuple[str, AbstractBasePhaseSpacePosition], ...]
+            dict[str, AbstractPhaseSpacePosition]
+            | tuple[tuple[str, AbstractPhaseSpacePosition], ...]
         ) = (),
         /,
-        **kwargs: AbstractBasePhaseSpacePosition,
+        **kwargs: AbstractPhaseSpacePosition,
     ) -> None:
         ImmutableMap.__init__(self, psps, **kwargs)  # <- ImmutableMap.__init__
 
@@ -194,7 +194,7 @@ class AbstractCompositePhaseSpacePosition(  # type: ignore[misc,unused-ignore]
     # ---------------------------------------------------------------
     # Getitem
 
-    @AbstractBasePhaseSpacePosition.__getitem__.dispatch
+    @AbstractPhaseSpacePosition.__getitem__.dispatch
     def __getitem__(
         self: "AbstractCompositePhaseSpacePosition", key: Any
     ) -> "AbstractCompositePhaseSpacePosition":
@@ -230,10 +230,10 @@ class AbstractCompositePhaseSpacePosition(  # type: ignore[misc,unused-ignore]
         # Get from each value, e.g. a slice
         return type(self)(**{k: v[key] for k, v in self.items()})
 
-    @AbstractBasePhaseSpacePosition.__getitem__.dispatch
+    @AbstractPhaseSpacePosition.__getitem__.dispatch
     def __getitem__(
         self: "AbstractCompositePhaseSpacePosition", key: str
-    ) -> AbstractBasePhaseSpacePosition:
+    ) -> AbstractPhaseSpacePosition:
         """Get item from the key.
 
         Examples

--- a/src/galax/coordinates/_src/psps/base_psp.py
+++ b/src/galax/coordinates/_src/psps/base_psp.py
@@ -10,11 +10,11 @@ from plum import dispatch
 import coordinax as cx
 import unxt as u
 
-from .base import AbstractBasePhaseSpacePosition
+from .base import AbstractPhaseSpacePosition
 from .utils import PSPVConvertOptions
 
 
-class AbstractOnePhaseSpacePosition(AbstractBasePhaseSpacePosition):
+class AbstractOnePhaseSpacePosition(AbstractPhaseSpacePosition):
     r"""Abstract base class of phase-space positions.
 
     The phase-space position is a point in the 3+3+1-dimensional phase space

--- a/src/galax/coordinates/_src/psps/base_psp.py
+++ b/src/galax/coordinates/_src/psps/base_psp.py
@@ -1,6 +1,6 @@
 """galax: Galactic Dynamics in Jax."""
 
-__all__ = ["AbstractPhaseSpacePosition"]
+__all__ = ["AbstractOnePhaseSpacePosition"]
 
 from dataclasses import replace
 from typing import Any
@@ -14,7 +14,7 @@ from .base import AbstractBasePhaseSpacePosition
 from .utils import PSPVConvertOptions
 
 
-class AbstractPhaseSpacePosition(AbstractBasePhaseSpacePosition):
+class AbstractOnePhaseSpacePosition(AbstractBasePhaseSpacePosition):
     r"""Abstract base class of phase-space positions.
 
     The phase-space position is a point in the 3+3+1-dimensional phase space
@@ -37,7 +37,7 @@ class AbstractPhaseSpacePosition(AbstractBasePhaseSpacePosition):
     # ==========================================================================
     # Convenience methods
 
-    def to_units(self, units: Any) -> "AbstractPhaseSpacePosition":
+    def to_units(self, units: Any) -> "AbstractOnePhaseSpacePosition":
         """Return a new object with the components converted to the given units."""
         usys = u.unitsystem(units)
         return replace(
@@ -59,10 +59,10 @@ class AbstractPhaseSpacePosition(AbstractBasePhaseSpacePosition):
 @dispatch
 def vconvert(
     target: PSPVConvertOptions,
-    psp: AbstractPhaseSpacePosition,
+    psp: AbstractOnePhaseSpacePosition,
     /,
     **kwargs: Any,
-) -> AbstractPhaseSpacePosition:
+) -> AbstractOnePhaseSpacePosition:
     """Convert the phase-space position to a different representation.
 
     Examples
@@ -100,10 +100,10 @@ def vconvert(
 @dispatch
 def vconvert(
     target_position_cls: type[cx.vecs.AbstractPos],
-    psp: AbstractPhaseSpacePosition,
+    psp: AbstractOnePhaseSpacePosition,
     /,
     **kwargs: Any,
-) -> AbstractPhaseSpacePosition:
+) -> AbstractOnePhaseSpacePosition:
     """Convert the phase-space position to a different representation.
 
     Examples

--- a/src/galax/coordinates/_src/psps/core.py
+++ b/src/galax/coordinates/_src/psps/core.py
@@ -16,7 +16,7 @@ from dataclassish.converters import Optional, Unless
 from unxt.quantity import AbstractQuantity
 
 import galax.typing as gt
-from .base import AbstractBasePhaseSpacePosition, ComponentShapeTuple
+from .base import AbstractPhaseSpacePosition, ComponentShapeTuple
 from .base_composite import AbstractCompositePhaseSpacePosition
 from .base_psp import AbstractOnePhaseSpacePosition
 from galax.coordinates._src.frames import SimulationFrame
@@ -163,7 +163,7 @@ class PhaseSpacePosition(AbstractOnePhaseSpacePosition):
     # ---------------------------------------------------------------
     # Getitem
 
-    @AbstractBasePhaseSpacePosition.__getitem__.dispatch
+    @AbstractPhaseSpacePosition.__getitem__.dispatch
     def __getitem__(
         self: "PhaseSpacePosition", index: tuple[Any, ...]
     ) -> "PhaseSpacePosition":
@@ -225,7 +225,7 @@ class PhaseSpacePosition(AbstractOnePhaseSpacePosition):
 
         return replace(self, q=self.q[index], p=self.p[index], t=self.t[tindex])
 
-    @AbstractBasePhaseSpacePosition.__getitem__.dispatch
+    @AbstractPhaseSpacePosition.__getitem__.dispatch
     def __getitem__(
         self: "PhaseSpacePosition", index: slice | int
     ) -> "PhaseSpacePosition":
@@ -301,7 +301,7 @@ class PhaseSpacePosition(AbstractOnePhaseSpacePosition):
 
 
 # TODO: generalize
-@AbstractBasePhaseSpacePosition.from_.dispatch(precedence=1)
+@AbstractPhaseSpacePosition.from_.dispatch(precedence=1)
 @partial(eqx.filter_jit, inline=True)
 def from_(
     cls: type[PhaseSpacePosition], obj: AbstractCompositePhaseSpacePosition, /
@@ -335,7 +335,7 @@ def from_(
     return cls(q=obj.q, p=obj.p, t=obj.t)
 
 
-@AbstractBasePhaseSpacePosition.from_.dispatch
+@AbstractPhaseSpacePosition.from_.dispatch
 def from_(
     cls: type[PhaseSpacePosition],
     data: cx.Space,

--- a/src/galax/coordinates/_src/psps/core.py
+++ b/src/galax/coordinates/_src/psps/core.py
@@ -18,13 +18,13 @@ from unxt.quantity import AbstractQuantity
 import galax.typing as gt
 from .base import AbstractBasePhaseSpacePosition, ComponentShapeTuple
 from .base_composite import AbstractCompositePhaseSpacePosition
-from .base_psp import AbstractPhaseSpacePosition
+from .base_psp import AbstractOnePhaseSpacePosition
 from galax.coordinates._src.frames import SimulationFrame
 from galax.utils._shape import batched_shape, vector_batched_shape
 
 
 @final
-class PhaseSpacePosition(AbstractPhaseSpacePosition):
+class PhaseSpacePosition(AbstractOnePhaseSpacePosition):
     r"""Phase-Space Position with time.
 
     The phase-space position is a point in the 7-dimensional phase space

--- a/src/galax/coordinates/_src/psps/core_composite.py
+++ b/src/galax/coordinates/_src/psps/core_composite.py
@@ -15,7 +15,7 @@ import unxt as u
 from zeroth import zeroth
 
 from .base_composite import AbstractCompositePhaseSpacePosition
-from .base_psp import AbstractPhaseSpacePosition
+from .base_psp import AbstractOnePhaseSpacePosition
 from galax.coordinates._src.frames import SimulationFrame
 
 
@@ -43,7 +43,7 @@ class CompositePhaseSpacePosition(AbstractCompositePhaseSpacePosition):
     ----------
     psps: dict | tuple, optional positional-only
         initialize from a (key, value) mapping or tuple.
-    **kwargs : AbstractPhaseSpacePosition
+    **kwargs : AbstractOnePhaseSpacePosition
         The name=value pairs of the phase-space positions.
 
     Notes
@@ -139,11 +139,11 @@ class CompositePhaseSpacePosition(AbstractCompositePhaseSpacePosition):
 
     def __init__(
         self,
-        psps: Mapping[str, AbstractPhaseSpacePosition]
-        | tuple[tuple[str, AbstractPhaseSpacePosition], ...] = (),
+        psps: Mapping[str, AbstractOnePhaseSpacePosition]
+        | tuple[tuple[str, AbstractOnePhaseSpacePosition], ...] = (),
         /,
         frame: Any = None,
-        **kwargs: AbstractPhaseSpacePosition,
+        **kwargs: AbstractOnePhaseSpacePosition,
     ) -> None:
         # Aggregate all the PhaseSpacePositions
         allpsps = dict(psps, **kwargs)

--- a/src/galax/coordinates/_src/psps/interp.py
+++ b/src/galax/coordinates/_src/psps/interp.py
@@ -13,7 +13,7 @@ import unxt as u
 
 import galax.typing as gt
 from .base import ComponentShapeTuple
-from .base_psp import AbstractPhaseSpacePosition
+from .base_psp import AbstractOnePhaseSpacePosition
 from .core import PhaseSpacePosition
 from galax.coordinates._src.frames import SimulationFrame
 from galax.utils._shape import batched_shape, vector_batched_shape
@@ -43,7 +43,7 @@ class PhaseSpacePositionInterpolant(Protocol):
 
 
 @final
-class InterpolatedPhaseSpacePosition(AbstractPhaseSpacePosition):
+class InterpolatedPhaseSpacePosition(AbstractOnePhaseSpacePosition):
     """Interpolated phase-space position."""
 
     q: cx.vecs.AbstractPos3D = eqx.field(converter=cx.vector)

--- a/src/galax/coordinates/_src/psps/operator_compat.py
+++ b/src/galax/coordinates/_src/psps/operator_compat.py
@@ -12,7 +12,7 @@ import coordinax as cx
 import coordinax.ops as cxo
 import unxt as u
 
-from .base_psp import AbstractPhaseSpacePosition
+from .base_psp import AbstractOnePhaseSpacePosition
 
 batched_matmul = quaxify(jnp.vectorize(jnp.matmul, signature="(3,3),(3)->(3)"))
 
@@ -23,13 +23,13 @@ batched_matmul = quaxify(jnp.vectorize(jnp.matmul, signature="(3,3),(3)->(3)"))
 @cxo.AbstractOperator.__call__.dispatch
 def call(
     self: cxo.AbstractOperator,
-    x: AbstractPhaseSpacePosition,
+    x: AbstractOnePhaseSpacePosition,
     /,
-) -> AbstractPhaseSpacePosition:
+) -> AbstractOnePhaseSpacePosition:
     """Apply the operator to a phase-space-time position.
 
     This method calls the method that operates on
-    ``AbstractPhaseSpacePosition`` by separating the time component from
+    ``AbstractOnePhaseSpacePosition`` by separating the time component from
     the rest of the phase-space position.  Subclasses can implement that
     method to avoid having to implement for both phase-space-time and
     phase-space positions.  Alternatively, they can implement this method
@@ -82,8 +82,8 @@ def call(
 
 @cxo.AbstractOperator.__call__.dispatch
 def call(
-    self: cxo.AbstractCompositeOperator, x: AbstractPhaseSpacePosition, /
-) -> AbstractPhaseSpacePosition:
+    self: cxo.AbstractCompositeOperator, x: AbstractOnePhaseSpacePosition, /
+) -> AbstractOnePhaseSpacePosition:
     """Apply the operator to the coordinates."""
     for op in self.operators:
         x = op(x)
@@ -96,8 +96,8 @@ def call(
 
 @cxo.AbstractOperator.__call__.dispatch
 def call(
-    self: cxo.GalileanSpatialTranslation, psp: AbstractPhaseSpacePosition, /
-) -> AbstractPhaseSpacePosition:
+    self: cxo.GalileanSpatialTranslation, psp: AbstractOnePhaseSpacePosition, /
+) -> AbstractOnePhaseSpacePosition:
     """Apply the translation to the coordinates.
 
     Examples
@@ -147,8 +147,8 @@ def call(
 
 @cxo.AbstractOperator.__call__.dispatch
 def call(
-    self: cxo.GalileanTranslation, psp: AbstractPhaseSpacePosition, /
-) -> AbstractPhaseSpacePosition:
+    self: cxo.GalileanTranslation, psp: AbstractOnePhaseSpacePosition, /
+) -> AbstractOnePhaseSpacePosition:
     """Apply the translation to the coordinates.
 
     Examples
@@ -204,9 +204,9 @@ def call(
 @cxo.AbstractOperator.__call__.dispatch
 def call(
     self: cxo.GalileanBoost,
-    psp: AbstractPhaseSpacePosition,
+    psp: AbstractOnePhaseSpacePosition,
     /,
-) -> AbstractPhaseSpacePosition:
+) -> AbstractOnePhaseSpacePosition:
     """Apply the translation to the coordinates.
 
     Examples
@@ -252,8 +252,8 @@ def call(
 
 @cxo.AbstractOperator.__call__.dispatch
 def call(
-    self: cxo.GalileanRotation, psp: AbstractPhaseSpacePosition, /
-) -> AbstractPhaseSpacePosition:
+    self: cxo.GalileanRotation, psp: AbstractOnePhaseSpacePosition, /
+) -> AbstractOnePhaseSpacePosition:
     """Apply the translation to the coordinates.
 
     Examples
@@ -308,9 +308,9 @@ def call(
 @cxo.AbstractOperator.__call__.dispatch(precedence=1)
 def call(
     self: cxo.Identity,  # noqa: ARG001
-    x: AbstractPhaseSpacePosition,
+    x: AbstractOnePhaseSpacePosition,
     /,
-) -> AbstractPhaseSpacePosition:
+) -> AbstractOnePhaseSpacePosition:
     """Apply the Identity operation.
 
     This is the identity operation, which does nothing to the input.

--- a/src/galax/dynamics/_src/funcs.py
+++ b/src/galax/dynamics/_src/funcs.py
@@ -107,7 +107,7 @@ def specific_angular_momentum(w: cx.Space) -> gt.BatchQVec3:
 
 @dispatch
 @partial(jax.jit, inline=True)
-def specific_angular_momentum(w: gc.AbstractBasePhaseSpacePosition) -> gt.BatchQVec3:
+def specific_angular_momentum(w: gc.AbstractPhaseSpacePosition) -> gt.BatchQVec3:
     r"""Compute the specific angular momentum.
 
     .. math::

--- a/src/galax/dynamics/_src/integrate/integrator.py
+++ b/src/galax/dynamics/_src/integrate/integrator.py
@@ -664,7 +664,7 @@ def call(
 def call(
     self: Integrator,
     field: AbstractDynamicsField,
-    w0: gc.AbstractPhaseSpacePosition,
+    w0: gc.AbstractOnePhaseSpacePosition,
     t0: Any,
     t1: Any,
     /,

--- a/src/galax/dynamics/_src/mockstream/core.py
+++ b/src/galax/dynamics/_src/mockstream/core.py
@@ -21,7 +21,7 @@ from galax.utils._shape import batched_shape, vector_batched_shape
 
 
 @final
-class MockStreamArm(gc.AbstractPhaseSpacePosition):
+class MockStreamArm(gc.AbstractOnePhaseSpacePosition):
     """Component of a mock stream object.
 
     Parameters

--- a/src/galax/dynamics/_src/orbit.py
+++ b/src/galax/dynamics/_src/orbit.py
@@ -23,7 +23,7 @@ from galax.typing import BatchFloatQScalar, QVec1, QVecTime
 from galax.utils._shape import batched_shape, vector_batched_shape
 
 
-class Orbit(gc.AbstractPhaseSpacePosition):
+class Orbit(gc.AbstractOnePhaseSpacePosition):
     """Represents an orbit.
 
     An orbit is a set of positions and velocities (conjugate momenta) as a
@@ -118,7 +118,7 @@ class Orbit(gc.AbstractPhaseSpacePosition):
     @classmethod
     def _from_psp(
         cls,
-        w: gc.AbstractPhaseSpacePosition,
+        w: gc.AbstractOnePhaseSpacePosition,
         t: QVecTime,
         potential: gp.AbstractBasePotential,
     ) -> "Orbit":

--- a/src/galax/dynamics/_src/orbit.py
+++ b/src/galax/dynamics/_src/orbit.py
@@ -167,7 +167,7 @@ class Orbit(gc.AbstractOnePhaseSpacePosition):
     # -------------------------------------------------------------------------
     # Getitem
 
-    @gc.AbstractBasePhaseSpacePosition.__getitem__.dispatch
+    @gc.AbstractPhaseSpacePosition.__getitem__.dispatch
     def __getitem__(self: "Orbit", index: tuple[Any, ...]) -> "Orbit":
         """Get a multi-index selection of the orbit.
 
@@ -215,7 +215,7 @@ class Orbit(gc.AbstractOnePhaseSpacePosition):
 
         return replace(self, q=self.q[index], p=self.p[index], t=self.t[tindex])
 
-    @gc.AbstractBasePhaseSpacePosition.__getitem__.dispatch
+    @gc.AbstractPhaseSpacePosition.__getitem__.dispatch
     def __getitem__(self: "Orbit", index: slice) -> "Orbit":
         """Slice the orbit.
 
@@ -259,7 +259,7 @@ class Orbit(gc.AbstractOnePhaseSpacePosition):
 
         return replace(self, q=self.q[index], p=self.p[index], t=self.t[tindex])
 
-    @gc.AbstractBasePhaseSpacePosition.__getitem__.dispatch
+    @gc.AbstractPhaseSpacePosition.__getitem__.dispatch
     def __getitem__(self: "Orbit", index: int) -> gc.PhaseSpacePosition:
         """Get the orbit at a specific time.
 
@@ -291,7 +291,7 @@ class Orbit(gc.AbstractOnePhaseSpacePosition):
         """
         return gc.PhaseSpacePosition(q=self.q[index], p=self.p[index], t=self.t[index])
 
-    @gc.AbstractBasePhaseSpacePosition.__getitem__.dispatch
+    @gc.AbstractPhaseSpacePosition.__getitem__.dispatch
     def __getitem__(
         self: "Orbit", index: Int[Array, "..."] | Bool[Array, "..."] | ndarray
     ) -> "Orbit":

--- a/src/galax/potential/_src/funcs.py
+++ b/src/galax/potential/_src/funcs.py
@@ -39,7 +39,7 @@ HessianVec: TypeAlias = Shaped[u.Quantity["1/s^2"], "*#shape 3 3"]
 @dispatch
 def potential(
     pot: AbstractBasePotential,
-    pspt: gc.AbstractPhaseSpacePosition | cx.FourVector,
+    pspt: gc.AbstractOnePhaseSpacePosition | cx.FourVector,
     /,
 ) -> u.Quantity["specific energy"]:
     """Compute the potential energy at the given position(s).
@@ -47,7 +47,7 @@ def potential(
     Parameters
     ----------
     pot : :class:`~galax.potential.AbstractBasePotential`, positional-only
-    pspt : :class:`~galax.coordinates.AbstractPhaseSpacePosition`, positional-only
+    pspt : :class:`~galax.coordinates.AbstractOnePhaseSpacePosition`, positional-only
         The phase-space + time position to compute the value of the
         potential.
 
@@ -87,7 +87,7 @@ def potential(
     Quantity[...](Array([-1.20227527, -0.5126519 ], dtype=float64), unit='kpc2 / Myr2')
 
     Instead of passing a
-    :class:`~galax.coordinates.AbstractPhaseSpacePosition`,
+    :class:`~galax.coordinates.AbstractOnePhaseSpacePosition`,
     we can instead pass a :class:`~coordinax.FourVector`:
 
     >>> w = cx.FourVector(q=u.Quantity([1, 2, 3], "kpc"), t=u.Quantity(0, "Gyr"))
@@ -264,7 +264,7 @@ def potential(
 @dispatch
 def gradient(
     pot: AbstractBasePotential,
-    pspt: gc.AbstractPhaseSpacePosition | cx.FourVector,
+    pspt: gc.AbstractOnePhaseSpacePosition | cx.FourVector,
     /,
 ) -> cx.vecs.CartesianAcc3D:
     """Compute the gradient of the potential at the given position(s).
@@ -273,7 +273,7 @@ def gradient(
     ----------
     pot : :class:`~galax.potential.AbstractBasePotential`, positional-only
         The potential to compute the gradient of.
-    pspt : :class:`~galax.coordinates.AbstractPhaseSpacePosition`,
+    pspt : :class:`~galax.coordinates.AbstractOnePhaseSpacePosition`,
     positional-only
         The phase-space + time position to compute the gradient.
 
@@ -315,7 +315,7 @@ def gradient(
         [[0.086 0.172 0.258]
          [0.027 0.033 0.04 ]]>
 
-    Instead of passing a :class:`~galax.coordinates.AbstractPhaseSpacePosition`,
+    Instead of passing a :class:`~galax.coordinates.AbstractOnePhaseSpacePosition`,
     we can instead pass a :class:`~vector.FourVector`:
 
     >>> w = cx.FourVector(q=u.Quantity([1, 2, 3], "kpc"), t=u.Quantity(0, "Gyr"))
@@ -525,7 +525,7 @@ def gradient(
 @dispatch
 def laplacian(
     pot: AbstractBasePotential,
-    pspt: gc.AbstractPhaseSpacePosition | cx.FourVector,
+    pspt: gc.AbstractOnePhaseSpacePosition | cx.FourVector,
     /,
 ) -> u.Quantity["1/s^2"]:
     """Compute the laplacian of the potential at the given position(s).
@@ -534,7 +534,7 @@ def laplacian(
     ----------
     pot : :class:`~galax.potential.AbstractBasePotential`, positional-only
         The potential to compute the laplacian of.
-    pspt : :class:`~galax.coordinates.AbstractPhaseSpacePosition`,
+    pspt : :class:`~galax.coordinates.AbstractOnePhaseSpacePosition`,
     positional-only
         The phase-space + time position to compute the laplacian.
 
@@ -573,7 +573,7 @@ def laplacian(
     >>> pot.laplacian(w)
     Quantity[...](Array([2.77555756e-17, 0.00000000e+00], dtype=float64), unit='1 / Myr2')
 
-    Instead of passing a :class:`~galax.coordinates.AbstractPhaseSpacePosition`,
+    Instead of passing a :class:`~galax.coordinates.AbstractOnePhaseSpacePosition`,
     we can instead pass a :class:`~vector.FourVector`:
 
     >>> w = cx.FourVector(q=u.Quantity([1, 2, 3], "kpc"), t=u.Quantity(0, "Gyr"))
@@ -758,7 +758,7 @@ def laplacian(pot: AbstractBasePotential, q: Any, /, *, t: Any) -> u.Quantity["1
 @dispatch
 def density(
     pot: AbstractBasePotential,
-    pspt: gc.AbstractPhaseSpacePosition | cx.FourVector,
+    pspt: gc.AbstractOnePhaseSpacePosition | cx.FourVector,
     /,
 ) -> u.Quantity["mass density"]:
     """Compute the density at the given position(s).
@@ -767,7 +767,7 @@ def density(
     ----------
     pot : :class:`~galax.potential.AbstractBasePotential`, positional-only
         The potential to compute the density of.
-    pspt : :class:`~galax.coordinates.AbstractPhaseSpacePosition`
+    pspt : :class:`~galax.coordinates.AbstractOnePhaseSpacePosition`
         The phase-space + time position to compute the density.
 
     Returns
@@ -805,7 +805,7 @@ def density(
     >>> pot.density(w)
     Quantity['mass density'](Array([0., 0.], dtype=float64), unit='solMass / kpc3')
 
-    Instead of passing a :class:`~galax.coordinates.AbstractPhaseSpacePosition`,
+    Instead of passing a :class:`~galax.coordinates.AbstractOnePhaseSpacePosition`,
     we can instead pass a :class:`~vector.FourVector`:
 
     >>> w = cx.FourVector(q=u.Quantity([1, 2, 3], "kpc"), t=u.Quantity(0, "Gyr"))
@@ -978,14 +978,14 @@ def density(
 @dispatch
 def hessian(
     pot: AbstractBasePotential,
-    pspt: gc.AbstractPhaseSpacePosition | cx.FourVector,
+    pspt: gc.AbstractOnePhaseSpacePosition | cx.FourVector,
     /,
 ) -> gt.BatchQMatrix33:
     """Compute the hessian of the potential at the given position(s).
 
     Parameters
     ----------
-    pspt : :class:`~galax.coordinates.AbstractPhaseSpacePosition`
+    pspt : :class:`~galax.coordinates.AbstractOnePhaseSpacePosition`
         The phase-space + time position to compute the hessian of the potential.
 
     Returns
@@ -1032,7 +1032,7 @@ def hessian(
                           [-0.00622549, -0.00778186, -0.00268042]]], dtype=float64),
                   unit='1 / Myr2')
 
-    Instead of passing a :class:`~galax.coordinates.AbstractPhaseSpacePosition`,
+    Instead of passing a :class:`~galax.coordinates.AbstractOnePhaseSpacePosition`,
     we can instead pass a :class:`~vector.FourVector`:
 
     >>> w = cx.FourVector(q=u.Quantity([1, 2, 3], "kpc"), t=u.Quantity(0, "Gyr"))
@@ -1277,7 +1277,7 @@ def acceleration(
         [[-0.086 -0.172 -0.258]
          [-0.027 -0.033 -0.04 ]]>
 
-    Instead of passing a :class:`~galax.coordinates.AbstractPhaseSpacePosition`,
+    Instead of passing a :class:`~galax.coordinates.AbstractOnePhaseSpacePosition`,
     we can instead pass a :class:`~vector.FourVector`:
 
     >>> w = cx.FourVector(q=u.Quantity([1, 2, 3], "kpc"), t=u.Quantity(0, "Gyr"))
@@ -1393,7 +1393,7 @@ def tidal_tensor(
                           [-0.00622549, -0.00778186, -0.00268042]]], dtype=float64),
                     unit='1 / Myr2')
 
-    Instead of passing a :class:`~galax.coordinates.AbstractPhaseSpacePosition`,
+    Instead of passing a :class:`~galax.coordinates.AbstractOnePhaseSpacePosition`,
     we can instead pass a :class:`~vector.FourVector`:
 
     >>> w = cx.FourVector(q=u.Quantity([1, 2, 3], "kpc"), t=u.Quantity(0, "Gyr"))
@@ -1663,7 +1663,7 @@ def circular_velocity(
 @dispatch
 @partial(jax.jit, inline=True)
 def circular_velocity(
-    pot: AbstractBasePotential, w: gc.AbstractPhaseSpacePosition, /
+    pot: AbstractBasePotential, w: gc.AbstractOnePhaseSpacePosition, /
 ) -> gt.BatchableRealQScalar:
     """Estimate the circular velocity at the given position.
 

--- a/src/galax/potential/_src/utils.py
+++ b/src/galax/potential/_src/utils.py
@@ -63,7 +63,7 @@ def parse_to_quantity(
 
 @dispatch
 def parse_to_quantity(
-    x: gc.AbstractPhaseSpacePosition, /, **_: Any
+    x: gc.AbstractOnePhaseSpacePosition, /, **_: Any
 ) -> Shaped[AbstractQuantity, "*batch 3"]:
     return parse_to_quantity(x.q)
 

--- a/tests/unit/coordinates/psp/test_base_psp.py
+++ b/tests/unit/coordinates/psp/test_base_psp.py
@@ -1,4 +1,4 @@
-"""Test `galax.coordinates.AbstractPhaseSpacePosition`."""
+"""Test `galax.coordinates.AbstractOnePhaseSpacePosition`."""
 
 from __future__ import annotations
 
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from pytest import FixtureRequest  # noqa: PT013
 
 
-T = TypeVar("T", bound=gc.AbstractPhaseSpacePosition)
+T = TypeVar("T", bound=gc.AbstractOnePhaseSpacePosition)
 
 potentials = [
     KeplerPotential(m_tot=u.Quantity(1e12, "Msun"), units=galactic),
@@ -41,8 +41,8 @@ def return_keys(num: int, key: Array | int = 0) -> Iterable[jr.PRNGKey]:
     return newkey, iter(subkeys)
 
 
-class AbstractPhaseSpacePosition_Test(Generic[T], metaclass=ABCMeta):
-    """Test :class:`~galax.coordinates.AbstractPhaseSpacePosition`."""
+class AbstractOnePhaseSpacePosition_Test(Generic[T], metaclass=ABCMeta):
+    """Test :class:`~galax.coordinates.AbstractOnePhaseSpacePosition`."""
 
     @pytest.fixture(scope="class", params=[(10,), (5, 4)], ids=lambda param: str(param))
     def shape(self, request: FixtureRequest) -> gt.Shape:
@@ -73,13 +73,13 @@ class AbstractPhaseSpacePosition_Test(Generic[T], metaclass=ABCMeta):
     # Attributes
 
     def test_q(self, w: T, shape: gt.Shape) -> None:
-        """Test :attr:`~galax.coordinates.AbstractPhaseSpacePosition.q`."""
+        """Test :attr:`~galax.coordinates.AbstractOnePhaseSpacePosition.q`."""
         assert hasattr(w, "q")
         assert w.q.shape == shape
         assert len(w.q.components) == 3
 
     def test_p(self, w: T, shape: gt.Shape) -> None:
-        """Test :attr:`~galax.coordinates.AbstractPhaseSpacePosition.p`."""
+        """Test :attr:`~galax.coordinates.AbstractOnePhaseSpacePosition.p`."""
         assert hasattr(w, "p")
         assert w.p.shape == w.q.shape
         assert w.p.shape == shape
@@ -89,7 +89,7 @@ class AbstractPhaseSpacePosition_Test(Generic[T], metaclass=ABCMeta):
     # Array properties
 
     def test_shape(self, w: T, shape: gt.Shape) -> None:
-        """Test :attr:`~galax.coordinates.AbstractPhaseSpacePosition.shape`."""
+        """Test :attr:`~galax.coordinates.AbstractOnePhaseSpacePosition.shape`."""
         # Check existence
         assert hasattr(w, "shape")
 
@@ -103,7 +103,7 @@ class AbstractPhaseSpacePosition_Test(Generic[T], metaclass=ABCMeta):
         assert w.shape == shape
 
     def test_ndim(self, w: T) -> None:
-        """Test :attr:`~galax.coordinates.AbstractPhaseSpacePosition.ndim`."""
+        """Test :attr:`~galax.coordinates.AbstractOnePhaseSpacePosition.ndim`."""
         # Check existence
         assert hasattr(w, "ndim")
 
@@ -112,7 +112,7 @@ class AbstractPhaseSpacePosition_Test(Generic[T], metaclass=ABCMeta):
         assert w.ndim == w.q.ndim
 
     def test_len(self, w: T) -> None:
-        """Test :meth:`~galax.coordinates.AbstractPhaseSpacePosition.__len__`."""
+        """Test :meth:`~galax.coordinates.AbstractOnePhaseSpacePosition.__len__`."""
         # Check existence
         assert hasattr(w, "__len__")
 
@@ -123,22 +123,22 @@ class AbstractPhaseSpacePosition_Test(Generic[T], metaclass=ABCMeta):
     # ----------------------------
 
     def test_getitem_int(self, w: T) -> None:
-        """Test :meth:`~galax.coordinates.AbstractPhaseSpacePosition.__getitem__`."""
+        """Test `~galax.coordinates.AbstractOnePhaseSpacePosition.__getitem__`."""
         assert jnp.all(w[0] == replace(w, q=w.q[0], p=w.p[0], t=w.t[0]))
 
     def test_getitem_slice(self, w: T) -> None:
-        """Test :meth:`~galax.coordinates.AbstractPhaseSpacePosition.__getitem__`."""
+        """Test `~galax.coordinates.AbstractOnePhaseSpacePosition.__getitem__`."""
         assert jnp.all(w[:5] == replace(w, q=w.q[:5], p=w.p[:5], t=w.t[:5]))
 
     def test_getitem_boolarray(self, w: T) -> None:
-        """Test :meth:`~galax.coordinates.AbstractPhaseSpacePosition.__getitem__`."""
+        """Test `~galax.coordinates.AbstractPhaseSpacePosition.__getitem__`."""
         idx = jnp.ones(w.q.shape, dtype=bool)
         idx = idx.at[::2].set(values=False)
 
         assert all(w[idx] == replace(w, q=w.q[idx], p=w.p[idx], t=w.t[idx]))
 
     def test_getitem_intarray(self, w: T) -> None:
-        """Test :meth:`~galax.coordinates.AbstractPhaseSpacePosition.__getitem__`."""
+        """Test `~galax.coordinates.AbstractPhaseSpacePosition.__getitem__`."""
         idx = jnp.asarray([0, 2, 1])
         assert jnp.all(w[idx] == replace(w, q=w.q[idx], p=w.p[idx], t=w.t[idx]))
 
@@ -161,7 +161,7 @@ class AbstractPhaseSpacePosition_Test(Generic[T], metaclass=ABCMeta):
     # Convenience methods
 
     def test_w(self, w: T) -> None:
-        """Test :meth:`~galax.coordinates.AbstractPhaseSpacePosition.w`."""
+        """Test :meth:`~galax.coordinates.AbstractOnePhaseSpacePosition.w`."""
         # Check existence
         assert hasattr(w, "w")
 
@@ -169,7 +169,7 @@ class AbstractPhaseSpacePosition_Test(Generic[T], metaclass=ABCMeta):
         assert w.w(units=galactic).shape[:-1] == w.full_shape[:-1]
 
     def test_wt(self, w: T) -> None:
-        """Test :meth:`~galax.coordinates.AbstractPhaseSpacePosition.wt`."""
+        """Test :meth:`~galax.coordinates.AbstractOnePhaseSpacePosition.wt`."""
         wt = w.wt(units=galactic)
         assert wt.shape == w.full_shape
         assert jnp.array_equal(wt[..., 0], w.t.decompose(galactic).value)
@@ -181,7 +181,7 @@ class AbstractPhaseSpacePosition_Test(Generic[T], metaclass=ABCMeta):
         )
 
     def test_to_units(self, w: T) -> None:
-        """Test :meth:`~galax.coordinates.AbstractPhaseSpacePosition.to_units`."""
+        """Test :meth:`~galax.coordinates.AbstractOnePhaseSpacePosition.to_units`."""
         w2 = w.to_units("solarsystem")
         # TODO: more detailed tests
         assert w2.q.x.unit == "AU"
@@ -211,7 +211,7 @@ class AbstractPhaseSpacePosition_Test(Generic[T], metaclass=ABCMeta):
 
     @pytest.mark.parametrize("pot", potentials, ids=lambda p: type(p).__name__)
     def test_total_energy(self, w: T, pot: AbstractBasePotential) -> None:
-        """Test :meth:`~galax.coordinates.AbstractPhaseSpacePosition.energy`."""
+        """Test :meth:`~galax.coordinates.AbstractOnePhaseSpacePosition.energy`."""
         pe = w.total_energy(pot)
         assert pe.shape == w.shape  # confirm relation to shape and components
         # definitional
@@ -231,14 +231,14 @@ class AbstractPhaseSpacePosition_Test(Generic[T], metaclass=ABCMeta):
 ##############################################################################
 
 
-class TestAbstractPhaseSpacePosition(AbstractPhaseSpacePosition_Test[T]):
-    """Test :class:`~galax.coordinates.AbstractPhaseSpacePosition`."""
+class TestAbstractOnePhaseSpacePosition(AbstractOnePhaseSpacePosition_Test[T]):
+    """Test :class:`~galax.coordinates.AbstractOnePhaseSpacePosition`."""
 
     @pytest.fixture(scope="class")
     def w_cls(self) -> type[T]:
         """Return the class of a phase-space position."""
 
-        class PSP(gc.AbstractPhaseSpacePosition):
+        class PSP(gc.AbstractOnePhaseSpacePosition):
             """A phase-space position."""
 
             q: cx.vecs.AbstractPos3D = eqx.field(converter=cx.vector)

--- a/tests/unit/coordinates/psp/test_psp.py
+++ b/tests/unit/coordinates/psp/test_psp.py
@@ -3,10 +3,10 @@
 import pytest
 
 import galax.coordinates as gc
-from .test_base_psp import AbstractPhaseSpacePosition_Test
+from .test_base_psp import AbstractOnePhaseSpacePosition_Test
 
 
-class TestPhaseSpacePosition(AbstractPhaseSpacePosition_Test[gc.PhaseSpacePosition]):
+class TestPhaseSpacePosition(AbstractOnePhaseSpacePosition_Test[gc.PhaseSpacePosition]):
     """Test :class:`~galax.coordinates.PhaseSpacePosition`."""
 
     @pytest.fixture(scope="class")

--- a/tests/unit/dynamics/test_orbit.py
+++ b/tests/unit/dynamics/test_orbit.py
@@ -15,12 +15,15 @@ import galax.coordinates as gc
 import galax.dynamics as gd
 import galax.potential as gp
 import galax.typing as gt
-from ..coordinates.psp.test_base_psp import AbstractPhaseSpacePosition_Test, return_keys
+from ..coordinates.psp.test_base_psp import (
+    AbstractOnePhaseSpacePosition_Test,
+    return_keys,
+)
 
 T = TypeVar("T", bound=gd.Orbit)
 
 
-class TestOrbit(AbstractPhaseSpacePosition_Test[gd.Orbit]):
+class TestOrbit(AbstractOnePhaseSpacePosition_Test[gd.Orbit]):
     """Test :class:`~galax.coordinates.PhaseSpacePosition`."""
 
     @pytest.fixture(scope="class")
@@ -63,13 +66,13 @@ class TestOrbit(AbstractPhaseSpacePosition_Test[gd.Orbit]):
     # ===============================================================
 
     def test_getitem_int(self, w: T) -> None:
-        """Test :meth:`~galax.coordinates.AbstractPhaseSpacePosition.__getitem__`."""
+        """Test ``AbstractOnePhaseSpacePosition.__getitem__``."""
         assert not isinstance(w[0], type(w))
         assert jnp.all(w[0] == gc.PhaseSpacePosition(q=w.q[0], p=w.p[0], t=w.t[0]))
 
     @override
     def test_getitem_boolarray(self, w: T, shape: gt.Shape) -> None:
-        """Test :meth:`~galax.coordinates.AbstractPhaseSpacePosition.__getitem__`."""
+        """Test ``AbstractOnePhaseSpacePosition.__getitem__``."""
         idx = jnp.ones(len(w.q), dtype=bool)
         idx = idx.at[::2].set(values=False)
         tidx = Ellipsis if idx.ndim < w.ndim else idx
@@ -81,7 +84,7 @@ class TestOrbit(AbstractPhaseSpacePosition_Test[gd.Orbit]):
         assert jnp.array_equal(new.t, w.t[tidx])
 
     def test_getitem_intarray(self, w: T, shape: gt.Shape) -> None:
-        """Test :meth:`~galax.coordinates.AbstractPhaseSpacePosition.__getitem__`."""
+        """Test ``AbstractOnePhaseSpacePosition.__getitem__``."""
         idx = jnp.asarray([0, 2, 1])
         tidx = Ellipsis if idx.ndim < w.ndim else idx
 
@@ -94,7 +97,7 @@ class TestOrbit(AbstractPhaseSpacePosition_Test[gd.Orbit]):
     # ===============================================================
 
     def test_wt(self, w: T) -> None:
-        """Test :meth:`~galax.coordinates.AbstractPhaseSpacePosition.wt`."""
+        """Test :meth:`~galax.coordinates.AbstractOnePhaseSpacePosition.wt`."""
         wt = w.wt(units=galactic)
         assert wt.shape == w.full_shape
         assert jnp.array_equal(


### PR DESCRIPTION
I don't think people are using the ABCs yet. This does not impact the user-facing class PhaseSpacePosition.