### PR TITLE
✨ feat(dynamics): term selection is now solver dependent

### DIFF
--- a/src/galax/dynamics/_src/fields/base.py
+++ b/src/galax/dynamics/_src/fields/base.py
@@ -15,6 +15,8 @@ import jax
 from jaxtyping import PyTree
 from plum import dispatch
 
+import unxt as u
+
 
 class AbstractDynamicsField(eqx.Module, strict=True):  # type: ignore[misc,call-arg]
     """ABC for dynamics fields.
@@ -25,6 +27,8 @@ class AbstractDynamicsField(eqx.Module, strict=True):  # type: ignore[misc,call-
     equation types.
 
     """
+
+    units: eqx.AbstractVar[u.AbstractUnitSystem]
 
     @abc.abstractmethod
     def __call__(

--- a/src/galax/dynamics/_src/integrate/utils.py
+++ b/src/galax/dynamics/_src/integrate/utils.py
@@ -27,7 +27,7 @@ def converter_dynamicsolver(obj: Any, /) -> DynamicsSolver:
     >>> import diffrax
     >>> from galax.dynamics.integrate import DynamicsSolver, DiffEqSolver
 
-    >>> diffeqsolve = DynamicsSolver(DiffEqSolver(solver=diffrax.Dopri5()))
+    >>> diffeqsolve = DynamicsSolver(DiffEqSolver(diffrax.Dopri5()))
     >>> converter_dynamicsolver(diffeqsolve)
     DynamicsSolver(
       diffeqsolver=DiffEqSolver(
@@ -37,7 +37,7 @@ def converter_dynamicsolver(obj: Any, /) -> DynamicsSolver:
       )
     )
 
-    >>> diffeqsolve = DiffEqSolver(solver=diffrax.Dopri5())
+    >>> diffeqsolve = DiffEqSolver(diffrax.Dopri5())
     >>> converter_dynamicsolver(diffeqsolve)
     DynamicsSolver(
       diffeqsolver=DiffEqSolver(

--- a/src/galax/dynamics/_src/solve/utils.py
+++ b/src/galax/dynamics/_src/solve/utils.py
@@ -26,7 +26,7 @@ def converter_diffeqsolver(obj: Any, /) -> DiffEqSolver:
     >>> import diffrax
     >>> from galax.dynamics.integrate import DynamicsSolver, DiffEqSolver
 
-    >>> diffeqsolve = DiffEqSolver(solver=diffrax.Dopri5())
+    >>> diffeqsolve = DiffEqSolver(diffrax.Dopri5())
     >>> converter_diffeqsolver(diffeqsolve)
     DiffEqSolver(
       solver=Dopri5(scan_kind=None),
@@ -49,7 +49,7 @@ def converter_diffeqsolver(obj: Any, /) -> DiffEqSolver:
     if isinstance(obj, DiffEqSolver):
         out = obj
     elif isinstance(obj, diffrax.AbstractSolver):
-        out = DiffEqSolver(solver=obj)
+        out = DiffEqSolver(obj)
     else:
         msg = f"cannot convert {obj} to a `DiffEqSolver`."
         raise TypeError(msg)

--- a/uv.lock
+++ b/uv.lock
@@ -654,7 +654,7 @@ wheels = [
 
 [[package]]
 name = "galax"
-version = "0.0.3.dev179+g9c4c1585.d20250114"
+version = "0.0.3.dev186+g54022637.d20250114"
 source = { editable = "." }
 dependencies = [
     { name = "astropy" },


### PR DESCRIPTION
@jnibauer, based on our discussion of the symplectic solver structures I made this PR, which changes `terms` from a `property` to a method that dispatches on the solver type. Now calling `terms(solver)` will e.g. return an `ODETerm(jit(self.__call__))` for Dopri8 but `(ODETerm(jit(self._call_q)), ODETerm(jit(self._call_p)))` for the symplectic solver. With this pattern it's easy for the same field type, e.g. HamiltonianField to support any required terms structure for any solver.

Closes #534