### PR TITLE
✨ feat(dynamics): nbody field

### DIFF
--- a/src/galax/dynamics/_src/fields/__init__.py
+++ b/src/galax/dynamics/_src/fields/__init__.py
@@ -4,7 +4,8 @@ This is private API.
 
 """
 
-__all__ = ["AbstractDynamicsField", "HamiltonianField"]
+__all__ = ["AbstractDynamicsField", "HamiltonianField", "NBodyField"]
 
 from .base import AbstractDynamicsField
 from .hamiltonian import HamiltonianField
+from .nbody import NBodyField

--- a/src/galax/dynamics/_src/fields/nbody.py
+++ b/src/galax/dynamics/_src/fields/nbody.py
@@ -1,0 +1,128 @@
+"""Field for N-Body dynamics."""
+
+__all__ = ["NBodyField"]
+
+from typing import Any, final
+
+import equinox as eqx
+import jax
+from jaxtyping import Array, Shaped
+from plum import dispatch
+
+import quaxed.numpy as jnp
+import unxt as u
+from unxt.quantity import UncheckedQuantity as FastQ
+
+import galax.potential as gp
+import galax.typing as gt
+from .base import AbstractDynamicsField
+
+
+@final
+class NBodyField(AbstractDynamicsField, strict=True):  # type: ignore[call-arg]
+    r"""Dynamics field for N-Body EoM.
+
+    .. warning::
+
+        The call method currently returns a `tuple[Array[float, (3,)],
+        Array[float, (3,)]]`. In future, when `unxt.Quantity` is registered with
+        `quax.quaxify` for `diffrax.diffeqsolve` then this will return
+        `tuple[Quantity[float, (3,), 'length'], Quantity[float, (3,),
+        'speed']]`. Later, when `coordinax.AbstractVector` is registered with
+        `quax.quaxify` for `diffrax.diffeqsolve` then this will return
+        `tuple[CartesianPos3D, CartesianVel3D]`.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import galax.dynamics as gd
+
+    >>> q = u.Quantity([[-1, 0, 0], [1, 0, 0]], "AU") / 2
+    >>> p = u.Quantity([[0, -1, 0], [0, 1, 0]], "km/s") * 25
+
+    >>> solver = gd.integrate.DynamicsSolver()
+
+    >>> field = gd.fields.NBodyField(
+    ...     masses=u.Quantity([1, 1], "Msun"),
+    ...     eps=u.Quantity(1e-4, "AU"),
+    ...     external_potential=gp.NullPotential(units="solarsystem"))
+
+    >>> t0, t1 = u.Quantity(0, "yr"), u.Quantity(2, "yr")
+    >>> soln = solver.solve(field, (q, p), t0, t1)
+
+    >>> soln.ys[0][-1, :, :].round(4)
+    Array([[ 0.799 , -0.6521,  0.    ],
+           [-0.799 ,  0.6521,  0.    ]], dtype=float64)
+
+    """
+
+    #: masses of each particle.
+    masses: Shaped[u.Quantity["mass"], "N"]
+
+    #: softening length.
+    eps: Shaped[u.Quantity["length"], ""]
+
+    #: Potential.
+    external_potential: gp.AbstractBasePotential = eqx.field(
+        default=gp.NullPotential(units="galactic")
+    )
+
+    @property
+    def units(self) -> u.AbstractUnitSystem:
+        return self.external_potential.units
+
+    @property
+    def _G(self) -> gt.RealSz0:
+        us = self.units
+        unit = us["length"] ** 3 / (us["mass"] * us["time"] ** 2)
+        return self.external_potential.constants["G"].ustrip(unit)
+
+    @dispatch.abstract
+    def __call__(
+        self, t: Any, qp: tuple[Any, Any], args: tuple[Any, ...], /
+    ) -> tuple[Any, Any]:
+        raise NotImplementedError  # pragma: no cover
+
+
+@NBodyField.__call__.dispatch  # type: ignore[misc]
+@jax.jit  # type: ignore[misc]
+def __call__(
+    self: "NBodyField",
+    t: gt.Scalar,
+    xv: tuple[Shaped[Array, "N 3"], Shaped[Array, "N 3"]],
+    args: Any,  # noqa: ARG001
+    /,
+) -> tuple[Shaped[Array, "N 3"], Shaped[Array, "N 3"]]:
+    # Break apart the input.
+    units = self.units
+    x, v = xv
+
+    # Compute the difference vectors ri - rj between all pairs of points
+    diffs = x[:, None, :] - x[None, :, :]  # (N, N, 3)
+
+    # Compute softened squared distances.
+    eps = self.eps.ustrip(units["length"])
+    d2s = jnp.sum(diffs**2, axis=-1)[:, :, None] + eps**2  # (N, N, 1)
+    ds = jnp.sqrt(d2s)  # (N, N, 1)
+
+    # Compute pairwise forces.
+    ms = self.masses.ustrip(units["mass"])  # (N,)
+    m2s = ms[:, None, None] * ms[None, :, None]  # (N, N, 1)
+    forces = self._G * m2s / d2s * diffs / ds  # (N, N, 3)
+
+    # Remove self-interaction forces
+    mask = 1 - jnp.eye(len(x))[:, :, None]  # Shape (N, N, 1)
+    forces = forces * mask
+
+    # Sum forces -> acceleration.
+    a_self = jnp.sum(forces, axis=0) / ms[:, None]  # (N, 3)
+
+    # Compute acceleration due to external potential.
+    a_external = self.external_potential._gradient(  # noqa: SLF001
+        FastQ(x, units["length"]), FastQ(t, units["time"])
+    ).ustrip(units["acceleration"])
+
+    # Total acceleration.
+    a_tot = a_self - a_external
+
+    return v, a_tot

--- a/src/galax/dynamics/fields.py
+++ b/src/galax/dynamics/fields.py
@@ -1,5 +1,5 @@
 """:mod:`galax.dynamics.fields`."""
 
-__all__ = ["AbstractDynamicsField", "HamiltonianField"]
+__all__ = ["AbstractDynamicsField", "HamiltonianField", "NBodyField"]
 
-from ._src.fields import AbstractDynamicsField, HamiltonianField
+from ._src.fields import AbstractDynamicsField, HamiltonianField, NBodyField

--- a/uv.lock
+++ b/uv.lock
@@ -654,7 +654,7 @@ wheels = [
 
 [[package]]
 name = "galax"
-version = "0.0.3.dev190+g1689d605.d20250114"
+version = "0.0.3.dev187+gc1fbbb79.d20250115"
 source = { editable = "." }
 dependencies = [
     { name = "astropy" },


### PR DESCRIPTION
N-Bodies!
This is better than #419 

A good followup would be to figure out how to separate the external potential from the n-body stuff and combine 2 Field objects.

Example:

```python
q = u.Quantity([[-1, 0, 0], [1, 0, 0]], "AU") / 2
p = u.Quantity([[0, -1, 0], [0, 1, 0]], "km/s") * 25

solver = gd.integrate.DynamicsSolver()

field = gd.fields.NBodyField(
    masses=u.Quantity([1, 1], "Msun"),
    eps=u.Quantity(1e-4, "AU"),
    external_potential=gp.NullPotential(units="solarsystem"),
)

t0, t1 = u.Quantity(0, "yr"), u.Quantity(2, "yr")
soln = solver.solve(field, (q, p), t0, t1, saveat=jnp.linspace(t0, t1, 10_00))
```

```python
plt.plot(soln.ys[0][:, 0, 0], soln.ys[0][:, 0, 1])
plt.plot(soln.ys[0][:, 1, 0], soln.ys[0][:, 1, 1])
plt.show()
```
![980e8a55-2fda-4878-8cdb-01348aa78938](https://github.com/user-attachments/assets/f2c503f2-a188-4a66-ac40-3c795e9aa2e3)