### PR TITLE
💥 boom(dynamics): change integrators kwarg "interpolated" to "dense"

### DIFF
--- a/src/galax/dynamics/_src/integrate/funcs.py
+++ b/src/galax/dynamics/_src/integrate/funcs.py
@@ -219,22 +219,24 @@ def evaluate_orbit(
     # Initial integration `w0.t` to `t[0]`.
     # TODO: get diffrax's `solver_state` to speed the second integration.
     # TODO: get diffrax's `controller_state` to speed the second integration.
+    # TODO: `max_steps` as kwarg.
     qp0 = integrator(
         field,
         w0,
-        tw0,  # t0
-        jnp.full_like(tw0, fill_value=t[0]),  # t1
-        interpolated=False,
+        tw0,
+        jnp.full_like(tw0, fill_value=t[0]),
+        dense=False,
     )
 
     # Orbit integration `t[0]` to `t[-1]`
+    # TODO: `max_steps` as kwarg.
     ws = integrator(
         field,
         qp0,
         t[0],
         t[-1],
         saveat=t,
-        interpolated=interpolated,
+        dense=interpolated,
     )
 
     # Return the orbit object

--- a/src/galax/dynamics/_src/integrate/interp.py
+++ b/src/galax/dynamics/_src/integrate/interp.py
@@ -48,7 +48,7 @@ class Interpolant(AbstractVectorizedDenseInterpolation):
 
     >>> integrator = gd.integrate.Integrator()
     >>> t0, t1 = u.Quantity(0, "Gyr"), u.Quantity(1, "Gyr")
-    >>> w = integrator(gd.fields.HamiltonianField(pot), w0, t0, t1, interpolated=True)
+    >>> w = integrator(gd.fields.HamiltonianField(pot), w0, t0, t1, dense=True)
     >>> type(w)
     <class 'galax.coordinates...InterpolatedPhaseSpacePosition'>
 


### PR DESCRIPTION
Almost have the `Integrator` as a lightweight wrapper around `DynamicsSolver` that just returns a `PhaseSpacePosition` instead of a `diffrax.Solution` object. Then we can switch `evaluate_orbit` to using `DynamicsSolver`, and move `Integrator` into a gala compatibility section.