### PR TITLE
✨ feat(potential): refactor special composite potentials

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -50,28 +50,14 @@ input::
     >>> import galax.potential as gp
     >>> mw = gp.MilkyWayPotential()
     >>> mw
-    MilkyWayPotential({'disk': MiyamotoNagaiPotential(
-      units=LTMAUnitSystem( ... ),
-      constants=ImmutableMap({'G': ...}),
-      m_tot=ConstantParameter( value=Quantity[...](value=...f64[], unit=Unit("solMass")) ),
-      a=ConstantParameter( value=Quantity[...](value=...f64[], unit=Unit("kpc")) ),
-      b=ConstantParameter( value=Quantity[...](value=...f64[], unit=Unit("kpc")) )
-    ), 'halo': NFWPotential(
-      units=LTMAUnitSystem( ... ),
-      constants=ImmutableMap({'G': ...}),
-      m=ConstantParameter( value=Quantity[...](value=...f64[], unit=Unit("solMass")) ),
-      r_s=ConstantParameter( value=Quantity[...](value=...f64[], unit=Unit("kpc")) )
-    ), 'bulge': HernquistPotential(
-      units=LTMAUnitSystem( ... ),
-      constants=ImmutableMap({'G': ...}),
-      m_tot=ConstantParameter( value=Quantity[...](value=...f64[], unit=Unit("solMass")) ),
-      r_s=ConstantParameter( value=Quantity[...](value=...f64[], unit=Unit("kpc")) )
-    ), 'nucleus': HernquistPotential(
-      units=LTMAUnitSystem( ... ),
-      constants=ImmutableMap({'G': ...}),
-      m_tot=ConstantParameter( value=Quantity[...](value=...f64[], unit=Unit("solMass")) ),
-      r_s=ConstantParameter( value=Quantity[...](value=...f64[], unit=Unit("kpc")) )
-    )})
+    MilkyWayPotential(
+      disk=MiyamotoNagaiPotential(...),
+      halo=NFWPotential(...),
+      bulge=HernquistPotential(...),
+      nucleus=HernquistPotential(...),
+      units=...,
+      constants=...
+    )
 
 This model, by default, contains four distinct potential components as listed in
 the output above: disk, bulge, nucleus, and halo components. You can configure
@@ -150,9 +136,16 @@ phase-space positions at times::
 
     >>> orbit
     Orbit(
-      q=CartesianPos3D(
-        x=Quantity[PhysicalType('length')](value=f64[2000], unit=Unit("kpc")),
-        ...
+        q=CartesianPos3D(
+          x=Quantity[PhysicalType('length')](value=f64[2000], unit=Unit("kpc")),
+          ...
+        ),
+        p=CartesianVel3D(...),
+        t=Quantity['time'](Array([...], dtype=float64), unit='Myr'),
+        frame=SimulationFrame(),
+        potential=MilkyWayPotential(...),
+        interpolant=None
+    )
 
 :class:`~galax.dynamics.Orbit` objects have many of their own useful methods for
 performing common tasks, like plotting an orbit::

--- a/src/galax/_interop/galax_interop_gala/potential.py
+++ b/src/galax/_interop/galax_interop_gala/potential.py
@@ -1576,9 +1576,12 @@ def gala_to_galax(pot: galap.BovyMWPotential2014, /) -> gp.BovyMWPotential2014:
 
     >>> pot = galap.BovyMWPotential2014()
     >>> gp.io.convert_potential(gp.io.GalaxLibrary, pot)
-    BovyMWPotential2014({'disk': MiyamotoNagaiPotential( ... ),
-                        'bulge': PowerLawCutoffPotential( ... ),
-                        'halo': NFWPotential( ... )})
+    BovyMWPotential2014(
+      disk=MiyamotoNagaiPotential( ... ),
+      bulge=PowerLawCutoffPotential( ... ),
+      halo=NFWPotential( ... ),
+      units=..., constants=...
+    )
 
     .. skip: end
 
@@ -1645,9 +1648,12 @@ def gala_to_galax(pot: galap.LM10Potential, /) -> gp.LM10Potential:
 
     >>> pot = galap.LM10Potential()
     >>> gp.io.convert_potential(gp.io.GalaxLibrary, pot)
-    LM10Potential({'disk': MiyamotoNagaiPotential( ... ),
-                   'bulge': HernquistPotential( ... ),
-                   'halo': LMJ09LogarithmicPotential( ... )})
+    LM10Potential(
+      disk=MiyamotoNagaiPotential( ... ),
+      bulge=HernquistPotential( ... ),
+      halo=LMJ09LogarithmicPotential( ... ),
+      units=..., constants=...
+    )
 
     """
     return gp.LM10Potential(
@@ -1711,10 +1717,13 @@ def gala_to_galax(pot: galap.MilkyWayPotential, /) -> gp.MilkyWayPotential:
 
     >>> pot = galap.MilkyWayPotential()
     >>> gp.io.convert_potential(gp.io.GalaxLibrary, pot)
-    MilkyWayPotential({'disk': MiyamotoNagaiPotential( ... ),
-                       'halo': NFWPotential( ... ),
-                       'bulge': HernquistPotential( ... ),
-                       'nucleus': HernquistPotential( ... )})
+    MilkyWayPotential(
+      disk=MiyamotoNagaiPotential( ... ),
+      halo=NFWPotential( ... ),
+      bulge=HernquistPotential( ... ),
+      nucleus=HernquistPotential( ... ),
+      units=..., constants=...
+    )
 
     """  # noqa: E501
     return gp.MilkyWayPotential(
@@ -1778,10 +1787,13 @@ def gala_to_galax(pot: galap.MilkyWayPotential2022, /) -> gp.MilkyWayPotential20
 
     >>> pot = galap.MilkyWayPotential2022()
     >>> gp.io.convert_potential(gp.io.GalaxLibrary, pot)
-    MilkyWayPotential2022({'disk': MN3Sech2Potential( ... ),
-                           'halo': NFWPotential( ... ),
-                           'bulge': HernquistPotential( ... ),
-                           'nucleus': HernquistPotential( ... )})
+    MilkyWayPotential2022(
+      disk=MN3Sech2Potential( ... ),
+      halo=NFWPotential( ... ),
+      bulge=HernquistPotential( ... ),
+      nucleus=HernquistPotential( ... ),
+      units=..., constants=...
+    )
 
     """  # noqa: E501
     return gp.MilkyWayPotential2022(

--- a/src/galax/potential/_src/base_single.py
+++ b/src/galax/potential/_src/base_single.py
@@ -3,7 +3,7 @@ __all__ = ["AbstractSinglePotential"]
 import abc
 import uuid
 from dataclasses import KW_ONLY
-from typing import Any, cast
+from typing import Any
 
 import equinox as eqx
 
@@ -42,6 +42,6 @@ class AbstractSinglePotential(AbstractPotential, strict=True):
             return NotImplemented
 
         if isinstance(other, CompositePotential):
-            return cast(CompositePotential, other.__ror__(self))
+            return other.__ror__(self)
 
         return CompositePotential({str(uuid.uuid4()): self, str(uuid.uuid4()): other})

--- a/src/galax/potential/_src/composite.py
+++ b/src/galax/potential/_src/composite.py
@@ -5,21 +5,65 @@ __all__ = ["CompositePotential"]
 
 from dataclasses import KW_ONLY
 from types import MappingProxyType
-from typing import ClassVar, final
+from typing import Any, ClassVar, TypeAlias, cast, final
 
 import equinox as eqx
 
 import unxt as u
 from xmmutablemap import ImmutableMap
+from zeroth import zeroth
 
 from .base import AbstractPotential, default_constants
 from .base_multi import AbstractCompositePotential
 from .params.attr import CompositeParametersAttribute
 
+ArgPotential: TypeAlias = (
+    dict[str, AbstractPotential] | tuple[tuple[str, AbstractPotential], ...]
+)
+
+
+class UnitsOptionEnum(eqx.Enumeration):  # type: ignore[misc]
+    """Enum for units option."""
+
+    FIRST = "first"
+
 
 @final
-class CompositePotential(AbstractCompositePotential):
-    """Composite Potential."""
+class CompositePotential(
+    AbstractCompositePotential,
+    ImmutableMap[str, AbstractPotential],  # type: ignore[misc]
+    strict=False,
+):
+    """Composite Potential.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import galax.potential as gp
+
+    >>> pot = gp.CompositePotential(
+    ...     bulge=gp.HernquistPotential(m_tot=u.Quantity(1e11, "Msun"), r_s=u.Quantity(2, "kpc"), units="galactic"),
+    ...     disk=gp.KuzminPotential(m_tot=u.Quantity(1e12, "Msun"), a=u.Quantity(10, "kpc"), units="galactic"),
+    ...     halo=gp.NFWPotential(m=u.Quantity(1e12, "Msun"), r_s=u.Quantity(10, "kpc"), units="galactic"),
+    ... )
+
+    >>> pot.keys()
+    dict_keys(['bulge', 'disk', 'halo'])
+
+    >>> "halo" in pot
+    True
+
+    >>> len(pot)
+    3
+
+    >>> pot["disk"]
+    KuzminPotential(
+      units=..., constants=ImmutableMap({'G': ...}),
+      m_tot=ConstantParameter( ... ),
+      a=ConstantParameter( ... )
+    )
+
+    """  # noqa: E501
 
     parameters: ClassVar = CompositeParametersAttribute(MappingProxyType({}))
 
@@ -31,3 +75,37 @@ class CompositePotential(AbstractCompositePotential):
     constants: ImmutableMap[str, u.Quantity] = eqx.field(
         default=default_constants, converter=ImmutableMap
     )
+
+    def __init__(
+        self,
+        potentials: ArgPotential = (),
+        /,
+        *,
+        units: Any = UnitsOptionEnum.FIRST,
+        constants: Any = default_constants,
+        **kwargs: AbstractPotential,
+    ) -> None:
+        ImmutableMap.__init__(self, potentials, **kwargs)  # <- ImmutableMap.__init__
+
+        # __post_init__ stuff:
+        # Check that all potentials have the same unit system
+        usys = (
+            zeroth(self.values()).units
+            if units is UnitsOptionEnum.FIRST
+            else u.unitsystem(units)
+        )
+        if not all(p.units == usys for p in self.values()):
+            msg = "all potentials must have the same unit system"
+            raise ValueError(msg)
+        object.__setattr__(self, "units", usys)  # TODO: not call `object.__setattr__`
+
+        # TODO: some similar check that the same constants are the same, e.g.
+        #       `G` is the same for all potentials. Or use `constants` to update
+        #       the `constants` of every potential (before `super().__init__`)
+        object.__setattr__(self, "constants", ImmutableMap(constants))
+
+        # Apply the unit system to any parameters.
+        self._apply_unitsystem()
+
+    def __repr__(self) -> str:  # TODO: not need this hack
+        return cast(str, ImmutableMap.__repr__(self))

--- a/src/galax/potential/_src/params/attr.py
+++ b/src/galax/potential/_src/params/attr.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, NoReturn, final
 from .field import ParameterField
 
 if TYPE_CHECKING:
-    from galax.potential import AbstractPotential
+    import galax.potential  # noqa: ICN001
 
 
 @dataclass(frozen=True, slots=True)
@@ -81,8 +81,8 @@ class ParametersAttribute(AbstractParametersAttribute):
 
     def __get__(
         self,
-        instance: "AbstractPotential | None",
-        owner: "type[AbstractPotential] | None",
+        instance: "galax.potential.AbstractPotential | None",
+        owner: "type[galax.potential.AbstractPotential] | None",
     ) -> "MappingProxyType[str, ParameterField]":
         # Called from the class
         if instance is None:
@@ -126,8 +126,8 @@ class CompositeParametersAttribute(AbstractParametersAttribute):
 
     def __get__(
         self,
-        instance: "AbstractCompositePotential | None",
-        owner: "type[AbstractCompositePotential] | None",
+        instance: "galax.potential.AbstractCompositePotential | None",
+        owner: "type[galax.potential.AbstractCompositePotential] | None",
     ) -> "MappingProxyType[str, ParameterField]":
         # Called from the class
         if instance is None:

--- a/tests/unit/potential/builtin/special/test_bovymwpotential2014.py
+++ b/tests/unit/potential/builtin/special/test_bovymwpotential2014.py
@@ -9,11 +9,11 @@ import unxt as u
 import galax.potential as gp
 import galax.typing as gt
 from ...io.test_gala import parametrize_test_method_gala
-from ...test_composite import AbstractCompositePotential_Test
+from .test_composite import AbstractSpecialCompositePotential_Test
 from galax._interop.optional_deps import GSL_ENABLED, OptDeps
 
 
-class TestBovyMWPotential2014(AbstractCompositePotential_Test):
+class TestBovyMWPotential2014(AbstractSpecialCompositePotential_Test):
     """Test the `galax.potential.BovyMWPotential2014` class."""
 
     @pytest.fixture(scope="class")
@@ -25,11 +25,7 @@ class TestBovyMWPotential2014(AbstractCompositePotential_Test):
         self, pot_cls: type[gp.BovyMWPotential2014]
     ) -> dict[str, dict[str, u.Quantity]]:
         """Composite potential."""
-        return {
-            "disk": pot_cls._default_disk,
-            "bulge": pot_cls._default_bulge,
-            "halo": pot_cls._default_halo,
-        }
+        return {"disk": pot_cls.disk, "bulge": pot_cls.bulge, "halo": pot_cls.halo}
 
     # ==========================================================================
 

--- a/tests/unit/potential/builtin/special/test_composite.py
+++ b/tests/unit/potential/builtin/special/test_composite.py
@@ -1,0 +1,29 @@
+"""Tests for the `galax.potential.` class."""
+
+from typing import Any
+
+import pytest
+
+import unxt as u
+
+import galax.potential as gp
+from ...test_composite import AbstractCompositePotential_Test
+from galax.potential._src.builtin.special import AbstractSpecialPotential
+
+
+class AbstractSpecialCompositePotential_Test(AbstractCompositePotential_Test):
+    """Test the `galax.potential.AbstractCompositePotential` class."""
+
+    def test_init_too_many_args(
+        self,
+        pot_cls: type[AbstractSpecialPotential],
+        pot_map: dict[str, Any],
+    ) -> None:
+        """Test that the potential raises an error when given too many arguments."""
+        with pytest.raises(ValueError, match="invalid keys"):
+            _ = pot_cls(
+                **pot_map,
+                not_expected=gp.KeplerPotential(
+                    m_tot=u.Quantity(1, "solMass"), units="galactic"
+                ),
+            )

--- a/tests/unit/potential/builtin/special/test_lm10.py
+++ b/tests/unit/potential/builtin/special/test_lm10.py
@@ -8,11 +8,11 @@ import unxt as u
 
 import galax.potential as gp
 import galax.typing as gt
-from ...test_composite import AbstractCompositePotential_Test
+from .test_composite import AbstractSpecialCompositePotential_Test
 from galax._interop.optional_deps import OptDeps
 
 
-class TestLM10Potential(AbstractCompositePotential_Test):
+class TestLM10Potential(AbstractSpecialCompositePotential_Test):
     """Test the `galax.potential.LM10Potential` class."""
 
     @pytest.fixture(scope="class")
@@ -22,13 +22,9 @@ class TestLM10Potential(AbstractCompositePotential_Test):
     @pytest.fixture(scope="class")
     def pot_map(
         self, pot_cls: type[gp.LM10Potential]
-    ) -> dict[str, dict[str, u.Quantity]]:
+    ) -> dict[str, dict[str, gp.AbstractPotential]]:
         """Composite potential."""
-        return {
-            "disk": pot_cls._default_disk,
-            "bulge": pot_cls._default_bulge,
-            "halo": pot_cls._default_halo,
-        }
+        return {"disk": pot_cls.disk, "bulge": pot_cls.bulge, "halo": pot_cls.halo}
 
     # ==========================================================================
 

--- a/tests/unit/potential/builtin/special/test_milkywaypotential.py
+++ b/tests/unit/potential/builtin/special/test_milkywaypotential.py
@@ -10,12 +10,10 @@ import unxt as u
 
 import galax.potential as gp
 import galax.typing as gt
-from ...test_composite import AbstractCompositePotential_Test
-
-##############################################################################
+from .test_composite import AbstractSpecialCompositePotential_Test
 
 
-class TestMilkyWayPotential(AbstractCompositePotential_Test):
+class TestMilkyWayPotential(AbstractSpecialCompositePotential_Test):
     """Test the `galax.potential.MilkyWayPotential` class."""
 
     @pytest.fixture(scope="class")
@@ -28,10 +26,10 @@ class TestMilkyWayPotential(AbstractCompositePotential_Test):
     ) -> dict[str, dict[str, u.Quantity]]:
         """Composite potential."""
         return {
-            "disk": pot_cls._default_disk,
-            "halo": pot_cls._default_halo,
-            "bulge": pot_cls._default_bulge,
-            "nucleus": pot_cls._default_nucleus,
+            "disk": pot_cls.disk,
+            "halo": pot_cls.halo,
+            "bulge": pot_cls.bulge,
+            "nucleus": pot_cls.nucleus,
         }
 
     @pytest.fixture(scope="class")

--- a/tests/unit/potential/builtin/special/test_milkywaypotential2022.py
+++ b/tests/unit/potential/builtin/special/test_milkywaypotential2022.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING
 
 import pytest
 from plum import convert
@@ -10,17 +9,11 @@ import quaxed.numpy as qnp
 import unxt as u
 
 import galax.typing as gt
-from ...test_composite import AbstractCompositePotential_Test
+from .test_composite import AbstractSpecialCompositePotential_Test
 from galax.potential import MilkyWayPotential2022
 
-if TYPE_CHECKING:
-    from galax.potential import AbstractPotential
 
-
-##############################################################################
-
-
-class TestMilkyWayPotential2022(AbstractCompositePotential_Test):
+class TestMilkyWayPotential2022(AbstractSpecialCompositePotential_Test):
     """Test the `galax.potential.MilkyWayPotential2022` class."""
 
     @pytest.fixture(scope="class")
@@ -33,10 +26,10 @@ class TestMilkyWayPotential2022(AbstractCompositePotential_Test):
     ) -> dict[str, dict[str, u.Quantity]]:
         """Composite potential."""
         return {
-            "disk": pot_cls._default_disk,
-            "halo": pot_cls._default_halo,
-            "bulge": pot_cls._default_bulge,
-            "nucleus": pot_cls._default_nucleus,
+            "disk": pot_cls.disk,
+            "halo": pot_cls.halo,
+            "bulge": pot_cls.bulge,
+            "nucleus": pot_cls.nucleus,
         }
 
     @pytest.fixture(scope="class")
@@ -86,7 +79,7 @@ class TestMilkyWayPotential2022(AbstractCompositePotential_Test):
     # ---------------------------------
     # Convenience methods
 
-    def test_tidal_tensor(self, pot: AbstractPotential, x: gt.QuSz3) -> None:
+    def test_tidal_tensor(self, pot: gp.AbstractPotential, x: gt.QuSz3) -> None:
         """Test the `AbstractPotential.tidal_tensor` method."""
         expect = u.Quantity(
             [


### PR DESCRIPTION
Splitting how composite potentials work.
They all still have dict methods and should work the same, but now the special potentials are built around a dataclass structure. It's much cleaner and more introspectable.
The general `CompositePotential` remains the same.