### PR TITLE
♻️ refactor(potential): _potential works on arrays directly

### DIFF
--- a/src/galax/_interop/galax_interop_astropy/__init__.py
+++ b/src/galax/_interop/galax_interop_astropy/__init__.py
@@ -5,3 +5,4 @@ __all__: list[str] = []
 from .coordinates import *
 from .dynamics import *
 from .potential import *
+from .unxt import *

--- a/src/galax/_interop/galax_interop_astropy/potential.py
+++ b/src/galax/_interop/galax_interop_astropy/potential.py
@@ -18,6 +18,18 @@ import galax.typing as gt
 
 
 @dispatch
+def parse_to_quantity_or_array(value: APYQuantity, /, **kw: Any) -> gt.BtRealQuSz3:
+    q = convert(value, FastQ)
+    return parse_to_quantity_or_array(q, **kw)
+
+
+@dispatch
+def parse_to_quantity_or_array(rep: BaseRepresentation, /, **kw: Any) -> gt.BtRealQuSz3:
+    cart = convert(rep, cx.CartesianPos3D)
+    return parse_to_quantity_or_array(cart, **kw)
+
+
+@dispatch
 def parse_to_quantity(value: APYQuantity, /, **kw: Any) -> gt.BtRealQuSz3:
     q = convert(value, FastQ)
     return parse_to_quantity(q, **kw)

--- a/src/galax/_interop/galax_interop_astropy/unxt.py
+++ b/src/galax/_interop/galax_interop_astropy/unxt.py
@@ -1,0 +1,27 @@
+"""Compatibility."""
+
+__all__: list[str] = []
+
+from typing import Any
+
+import astropy.units as apyu
+from plum import dispatch
+
+import unxt as u
+
+from galax.utils._unxt import AllowValue
+
+
+@dispatch  # TODO: type annotate by value
+def ustrip(flag: type[AllowValue], unit: Any, x: apyu.Quantity, /) -> Any:  # noqa: ARG001
+    """Strip the units from a quantity.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> q = u.Quantity(1000, "m")
+    >>> u.ustrip(AllowValue, "km", q)
+    Array(1., dtype=float64, ...)
+
+    """
+    return u.ustrip(unit, x)

--- a/src/galax/potential/_src/base_multi.py
+++ b/src/galax/potential/_src/base_multi.py
@@ -29,10 +29,10 @@ class AbstractCompositePotential(AbstractPotential):
 
     # === Potential ===
 
-    @partial(jax.jit, inline=True)
+    @partial(jax.jit)
     def _potential(
-        self, q: gt.BtQuSz3, t: gt.BBtRealQuSz0, /
-    ) -> gt.SpecificEnergyBtSz0:
+        self, q: gt.BtQuSz3 | gt.BtSz3, t: gt.BBtRealQuSz0 | gt.BBtRealSz0, /
+    ) -> gt.BtSz0:
         return jnp.sum(
             jnp.array([p._potential(q, t) for p in self.values()]),  # noqa: SLF001
             axis=0,

--- a/src/galax/potential/_src/builtin/null.py
+++ b/src/galax/potential/_src/builtin/null.py
@@ -4,7 +4,7 @@ __all__ = ["NullPotential"]
 
 from dataclasses import KW_ONLY
 from functools import partial
-from typing import final
+from typing import Any, final
 
 import equinox as eqx
 import jax
@@ -47,16 +47,9 @@ class NullPotential(AbstractSinglePotential):
         default=default_constants, converter=ImmutableMap
     )
 
-    @partial(jax.jit, inline=True)
-    def _potential(
-        self,
-        q: gt.BtQuSz3,
-        t: gt.BBtRealQuSz0,  # noqa: ARG002
-        /,
-    ) -> gt.SpecificEnergyBtSz0:
-        return u.Quantity(  # TODO: better unit handling
-            jnp.zeros(q.shape[:-1], dtype=q.dtype), galactic["specific energy"]
-        )
+    @partial(jax.jit)
+    def _potential(self, q: gt.BtQuSz3 | gt.BtSz3, _: Any, /) -> gt.BtSz0:
+        return jnp.zeros(q.shape[:-1], dtype=q.dtype)
 
     @partial(jax.jit, inline=True)
     def _gradient(self, q: gt.BtQuSz3, /, _: gt.RealQuSz0) -> gt.BtQuSz3:

--- a/src/galax/potential/_src/builtin/special.py
+++ b/src/galax/potential/_src/builtin/special.py
@@ -93,10 +93,10 @@ class AbstractSpecialPotential(AbstractCompositePotential):  # TODO: make public
     # === Potential ===
 
     @override
-    @partial(jax.jit, inline=True)
+    @partial(jax.jit)
     def _potential(
-        self, q: gt.BtQuSz3, t: gt.BBtRealQuSz0, /
-    ) -> gt.SpecificEnergyBtSz0:
+        self, q: gt.BtQuSz3 | gt.BtSz3, t: gt.BBtRealQuSz0 | gt.BBtRealSz0, /
+    ) -> gt.BtSz0:
         return jnp.sum(
             jnp.array([getattr(self, k)._potential(q, t) for k in self._keys]),  # noqa: SLF001
             axis=0,

--- a/src/galax/potential/_src/params/field.py
+++ b/src/galax/potential/_src/params/field.py
@@ -92,7 +92,8 @@ class ParameterField:
     >>> class KeplerPotential(gp.AbstractSinglePotential):
     ...     mass: gp.params.ParameterField = gp.params.ParameterField(dimensions="mass")
     ...     def _potential(self, q, t):
-    ...         return -self.constants["G"] * self.mass(t) / jnp.linalg.norm(q, axis=-1)
+    ...         out = -self.constants["G"] * self.mass(t) / jnp.linalg.norm(q, axis=-1)
+    ...         return out.ustrip(self.units["specific energy"])
 
     The `mass` parameter is a `ParameterField` that has dimensions of mass.
     This can be a constant value or a function of time.

--- a/src/galax/typing.py
+++ b/src/galax/typing.py
@@ -91,9 +91,14 @@ QuSz3: TypeAlias = Shaped[AbstractQuantity, "3"]
 BtQuSz3: TypeAlias = Shaped[QuSz3, "*batch"]
 BBtQuSz3: TypeAlias = Shaped[QuSz3, "*#batch"]
 
+FloatSz3: TypeAlias = Float[Array, "3"]
 FloatQuSz3: TypeAlias = Float[AbstractQuantity, "3"]
 BtFloatQuSz3: TypeAlias = Float[QuSz3, "*batch"]
 BBtFloatQuSz3: TypeAlias = Float[QuSz3, "*#batch"]
+
+RealSz3: TypeAlias = Real[Array, "3"]
+BtRealSz3: TypeAlias = Shaped[RealSz3, "*batch"]
+BBtRealSz3: TypeAlias = Shaped[RealSz3, "*#batch"]
 
 RealQuSz3: TypeAlias = Real[AbstractQuantity, "3"]
 BtRealQuSz3: TypeAlias = Shaped[RealQuSz3, "*batch"]
@@ -129,6 +134,7 @@ SzTime: TypeAlias = Shaped[Array, "time"]
 QuSzTime: TypeAlias = Shaped[AbstractQuantity, "time"]
 
 # A float array with any shape.
+FloatSzAny: TypeAlias = Float[Array, "..."]
 FloatQuSzAny: TypeAlias = Float[AbstractQuantity, "..."]
 
 # ================================

--- a/src/galax/utils/_unxt.py
+++ b/src/galax/utils/_unxt.py
@@ -44,7 +44,12 @@ class AllowValue:
 
 
 @dispatch
-def ustrip(flag: type[AllowValue], unit: Any, x: Array, /) -> Array:  # noqa: ARG001
+def ustrip(
+    flag: type[AllowValue],  # noqa: ARG001
+    unit: Any,  # noqa: ARG001
+    x: Array | float | int,
+    /,
+) -> Array | float | int:
     """Strip the units from a value. This is a no-op.
 
     Examples

--- a/tests/unit/potential/builtin/nfw/test_triaxialnfw.py
+++ b/tests/unit/potential/builtin/nfw/test_triaxialnfw.py
@@ -57,9 +57,8 @@ class TestTriaxialNFWPotential(
 
     def test_potential(self, pot: TriaxialNFWPotential, x: gt.QuSz3) -> None:
         expect = u.Quantity(-1.06475915, unit="kpc2 / Myr2")
-        assert jnp.isclose(
-            pot.potential(x, t=0), expect, atol=u.Quantity(1e-8, expect.unit)
-        )
+        got = pot.potential(x, t=0)
+        assert jnp.isclose(got, expect, atol=u.Quantity(1e-8, expect.unit))
 
     def test_gradient(self, pot: TriaxialNFWPotential, x: gt.QuSz3) -> None:
         expect = u.Quantity([0.03189139, 0.0604938, 0.13157674], "kpc / Myr2")

--- a/tests/unit/potential/test_base.py
+++ b/tests/unit/potential/test_base.py
@@ -19,6 +19,7 @@ import galax.potential.params as gpp
 import galax.typing as gt
 from .io.test_gala import GalaIOMixin
 from galax.potential._src.base import default_constants
+from galax.utils._unxt import AllowValue
 
 
 class AbstractPotential_Test(GalaIOMixin, metaclass=ABCMeta):
@@ -204,24 +205,30 @@ class TestAbstractPotential(AbstractPotential_Test):
     HAS_GALA_COUNTERPART: ClassVar[bool] = False
 
     @pytest.fixture(scope="class")
-    def pot_cls(self) -> type[gp.AbstractPotential]:
+    def pot_cls(self, units) -> type[gp.AbstractPotential]:
+        usys = units
+        constants_in_usys = {k: v.decompose(usys) for k, v in default_constants.items()}
+
         class TestPotential(gp.AbstractPotential):
             m_tot: gpp.AbstractParameter = gpp.ParameterField(
                 dimensions="mass", default=u.Quantity(1e12, "Msun")
             )
             units: u.AbstractUnitSystem = eqx.field(default=galactic, static=True)
             constants: ImmutableMap[str, u.Quantity] = eqx.field(
-                default=default_constants, converter=ImmutableMap
+                default=ImmutableMap(constants_in_usys),
+                converter=ImmutableMap,
             )
 
             @partial(jax.jit, inline=True)
             def _potential(  # TODO: inputs w/ units
-                self, q: gt.BtQuSz3, t: gt.BBtRealQuSz0, /
-            ) -> gt.SpecificEnergyBtSz0:
+                self, xyz: gt.BtQuSz3 | gt.BtSz3, t: gt.BBtRealQuSz0 | gt.BBtRealSz0, /
+            ) -> gt.BtSz0:
+                m_tot = self.m_tot(t, ustrip=self.units["mass"])
+                xyz = u.ustrip(AllowValue, self.units["length"], xyz)
                 return (
-                    self.constants["G"]
-                    * self.m_tot(t)
-                    / jnp.linalg.vector_norm(q, axis=-1)
+                    self.constants["G"].value
+                    * m_tot
+                    / jnp.linalg.vector_norm(xyz, axis=-1)
                 )
 
         return TestPotential
@@ -244,11 +251,9 @@ class TestAbstractPotential(AbstractPotential_Test):
 
     def test_potential(self, pot: gp.AbstractPotential, x: gt.QuSz3) -> None:
         """Test the `AbstractPotential.potential` method."""
-        assert jnp.allclose(
-            pot.potential(x, t=0),
-            u.Quantity(1.20227527, "kpc2/Myr2"),
-            atol=u.Quantity(1e-8, "kpc2/Myr2"),
-        )
+        exp = u.Quantity(1.20227527, "kpc2/Myr2")
+        got = pot.potential(x, t=0)
+        assert jnp.allclose(got, exp, atol=u.Quantity(1e-8, "kpc2/Myr2"))
 
     # ---------------------------------
 
@@ -263,10 +268,9 @@ class TestAbstractPotential(AbstractPotential_Test):
     def test_density(self, pot: gp.AbstractPotential, x: gt.QuSz3) -> None:
         """Test the `AbstractPotential.density` method."""
         # TODO: fix negative density!!!
-        expect = u.Quantity(-2.647e-7, pot.units["mass density"])
-        assert jnp.allclose(
-            pot.density(x, t=0), expect, atol=u.Quantity(1e-8, expect.unit)
-        )
+        got = pot.density(x, t=0)
+        exp = u.Quantity(-4.90989768e-07, pot.units["mass density"])
+        assert jnp.allclose(got, exp, atol=u.Quantity(1e-8, exp.unit))
 
     def test_hessian(self, pot: gp.AbstractPotential, x: gt.QuSz3) -> None:
         """Test the `AbstractPotential.hessian` method."""


### PR DESCRIPTION
```python
pot = gp.BurkertPotential(m=1e12, r_s=2, units="galactic")

w = gc.PhaseSpaceCoordinate(
    q=u.Quantity([1, 2, 3], "kpc"),
    p=u.Quantity([4, 5, 6], "km/s"),
    t=u.Quantity(0, "Gyr"),
)


@jax.jit
def func(*args):
    return pot._potential(*args)


# %time jax.block_until_ready(func(w))
# %timeit jax.block_until_ready(func(w))

print("HERE", jax.block_until_ready(func(xyz, t)))  # trigger jit
%timeit jax.block_until_ready(func(xyz, t))
```

@jnibauer The time comes out almost identical to a hand implementation of the Burkert potential! 
This shows the path for performance optimization: Arrays in -> Arrays out. Q & higher in -> Q & higher out.
