### PR TITLE
Bugfix: Use "jnp.logical_or" instead of "or" for JAX tracer support

### DIFF
--- a/src/galax/potential/_src/builtin/multipole.py
+++ b/src/galax/potential/_src/builtin/multipole.py
@@ -195,18 +195,10 @@ class MultipolePotential(AbstractMultipolePotential):
         os_shape, ot_shape = self.OSlm(t).shape, self.OTlm(t).shape
         # TODO: check shape across time.
         msg = "I/OSlm and I/OTlm must have the shape (l_max + 1, l_max + 1)."
-        _ = eqx.error_if(
-            t,
-            jnp.array(
-                [
-                    is_shape != shape,
-                    it_shape != shape,
-                    os_shape != shape,
-                    ot_shape != shape,
-                ]
-            ).any(),
-            msg,
+        pred = jnp.any(
+            jnp.array([x != shape for x in (is_shape, it_shape, os_shape, ot_shape)])
         )
+        _ = eqx.error_if(t, pred, msg)
 
     @partial(jax.jit)
     def _potential(

--- a/src/galax/potential/_src/builtin/multipole.py
+++ b/src/galax/potential/_src/builtin/multipole.py
@@ -11,6 +11,7 @@ from dataclasses import KW_ONLY
 from functools import partial
 from typing import final
 
+import equinox as eqx
 import jax
 from equinox import field
 from jax.scipy.special import sph_harm
@@ -63,12 +64,11 @@ class MultipoleInnerPotential(AbstractMultipolePotential):
         t = u.Quantity(0.0, "Gyr")
         s_shape, t_shape = self.Slm(t).shape, self.Tlm(t).shape
         # TODO: check shape across time.
-        if s_shape != shape or t_shape != shape:
-            msg = (
-                "Slm and Tlm must have the shape (l_max + 1, l_max + 1)."
-                f"Slm shape: {s_shape}, Tlm shape: {t_shape}"
-            )
-            raise ValueError(msg)
+        msg = (
+            "Slm and Tlm must have the shape (l_max + 1, l_max + 1). "
+            f"Slm shape: {s_shape}, Tlm shape: {t_shape}"
+        )
+        _ = eqx.error_if(t, jnp.logical_or(s_shape != shape, t_shape != shape), msg)
 
     @partial(jax.jit)
     def _potential(
@@ -125,12 +125,11 @@ class MultipoleOuterPotential(AbstractMultipolePotential):
         t = u.Quantity(0.0, "Gyr")
         s_shape, t_shape = self.Slm(t).shape, self.Tlm(t).shape
         # TODO: check shape across time.
-        if s_shape != shape or t_shape != shape:
-            msg = (
-                "Slm and Tlm must have the shape (l_max + 1, l_max + 1)."
-                f"Slm shape: {s_shape}, Tlm shape: {t_shape}"
-            )
-            raise ValueError(msg)
+        msg = (
+            "Slm and Tlm must have the shape (l_max + 1, l_max + 1). "
+            f"Slm shape: {s_shape}, Tlm shape: {t_shape}"
+        )
+        _ = eqx.error_if(t, jnp.logical_or(s_shape != shape, t_shape != shape), msg)
 
     @partial(jax.jit)
     def _potential(
@@ -195,14 +194,19 @@ class MultipolePotential(AbstractMultipolePotential):
         is_shape, it_shape = self.ISlm(t).shape, self.ITlm(t).shape
         os_shape, ot_shape = self.OSlm(t).shape, self.OTlm(t).shape
         # TODO: check shape across time.
-        if (
-            is_shape != shape
-            or it_shape != shape
-            or os_shape != shape
-            or ot_shape != shape
-        ):
-            msg = "I/OSlm and I/OTlm must have the shape (l_max + 1, l_max + 1)."
-            raise ValueError(msg)
+        msg = "I/OSlm and I/OTlm must have the shape (l_max + 1, l_max + 1)."
+        _ = eqx.error_if(
+            t,
+            jnp.array(
+                [
+                    is_shape != shape,
+                    it_shape != shape,
+                    os_shape != shape,
+                    ot_shape != shape,
+                ]
+            ).any(),
+            msg,
+        )
 
     @partial(jax.jit)
     def _potential(

--- a/src/galax/potential/_src/builtin/nfw.py
+++ b/src/galax/potential/_src/builtin/nfw.py
@@ -255,7 +255,7 @@ class LeeSutoTriaxialNFWPotential(AbstractSinglePotential):
         t = u.Quantity(0.0, "Myr")
         _ = eqx.error_if(
             t,
-            (self.a1(t) < self.a2(t)) or (self.a2(t) < self.a3(t)),
+            jnp.logical_or(self.a1(t) < self.a2(t), self.a2(t) < self.a3(t)),
             f"a1 {self.a1(t)} >= a2 {self.a2(t)} >= a3 {self.a3(t)} is required",
         )
 

--- a/tests/unit/potential/builtin/multipole/test_innermultipole.py
+++ b/tests/unit/potential/builtin/multipole/test_innermultipole.py
@@ -3,6 +3,7 @@
 from typing import Any
 from typing_extensions import override
 
+import equinox as eqx
 import pytest
 from jaxtyping import Array, Shaped
 from plum import convert
@@ -14,13 +15,18 @@ import galax._custom_types as gt
 import galax.potential as gp
 from ...test_core import AbstractSinglePotential_Test
 from ..test_common import ParameterMTotMixin, ParameterScaleRadiusMixin
-from .test_abstractmultipole import ParameterSlmMixin, ParameterTlmMixin
+from .test_abstractmultipole import (
+    MultipoleTestMixin,
+    ParameterSlmMixin,
+    ParameterTlmMixin,
+)
 from galax._interop.optional_deps import GSL_ENABLED, OptDeps
 
 ###############################################################################
 
 
 class TestMultipoleInnerPotential(
+    MultipoleTestMixin,
     AbstractSinglePotential_Test,
     # Parameters
     ParameterMTotMixin,
@@ -60,7 +66,8 @@ class TestMultipoleInnerPotential(
     ) -> None:
         """Test the `MultipoleInnerPotential.__check_init__` method."""
         fields_["Slm"] = fields_["Slm"][::2]  # make it the wrong shape
-        with pytest.raises(ValueError, match="Slm and Tlm must have the shape"):
+        match = "Slm and Tlm must have the shape"
+        with pytest.raises(eqx.EquinoxRuntimeError, match=match):
             pot_cls(**fields_)
 
     # ==========================================================================

--- a/tests/unit/potential/builtin/multipole/test_multipole.py
+++ b/tests/unit/potential/builtin/multipole/test_multipole.py
@@ -4,6 +4,7 @@ import re
 from typing import Any
 from typing_extensions import override
 
+import equinox as eqx
 import pytest
 from jaxtyping import Array, Shaped
 from plum import convert
@@ -16,7 +17,10 @@ import galax.potential as gp
 from ...io.test_gala import parametrize_test_method_gala
 from ...test_core import AbstractSinglePotential_Test
 from ..test_common import ParameterMTotMixin, ParameterScaleRadiusMixin
-from .test_abstractmultipole import ParameterAngularCoefficientsMixin
+from .test_abstractmultipole import (
+    MultipoleTestMixin,
+    ParameterAngularCoefficientsMixin,
+)
 
 ###############################################################################
 
@@ -211,6 +215,7 @@ class ParameterOTlmMixin(ParameterAngularCoefficientsMixin):
 
 
 class TestMultipolePotential(
+    MultipoleTestMixin,
     AbstractSinglePotential_Test,
     # Parameters
     ParameterMTotMixin,
@@ -257,7 +262,7 @@ class TestMultipolePotential(
         """Test the `MultipoleInnerPotential.__check_init__` method."""
         fields_["ISlm"] = fields_["ISlm"][::2]  # make it the wrong shape
         match = re.escape("I/OSlm and I/OTlm must have the shape")
-        with pytest.raises(ValueError, match=match):
+        with pytest.raises(eqx.EquinoxRuntimeError, match=match):
             pot_cls(**fields_)
 
     # ==========================================================================

--- a/tests/unit/potential/builtin/multipole/test_outermultipole.py
+++ b/tests/unit/potential/builtin/multipole/test_outermultipole.py
@@ -3,6 +3,7 @@
 from typing import Any
 from typing_extensions import override
 
+import equinox as eqx
 import pytest
 from jaxtyping import Array, Shaped
 from plum import convert
@@ -14,13 +15,18 @@ import galax._custom_types as gt
 import galax.potential as gp
 from ...test_core import AbstractSinglePotential_Test
 from ..test_common import ParameterMTotMixin, ParameterScaleRadiusMixin
-from .test_abstractmultipole import ParameterSlmMixin, ParameterTlmMixin
+from .test_abstractmultipole import (
+    MultipoleTestMixin,
+    ParameterSlmMixin,
+    ParameterTlmMixin,
+)
 from galax._interop.optional_deps import GSL_ENABLED, OptDeps
 
 ###############################################################################
 
 
 class TestMultipoleOuterPotential(
+    MultipoleTestMixin,
     AbstractSinglePotential_Test,
     # Parameters
     ParameterMTotMixin,
@@ -60,7 +66,8 @@ class TestMultipoleOuterPotential(
     ) -> None:
         """Test the `MultipoleInnerPotential.__check_init__` method."""
         fields_["Slm"] = fields_["Slm"][::2]  # make it the wrong shape
-        with pytest.raises(ValueError, match="Slm and Tlm must have the shape"):
+        match = "Slm and Tlm must have the shape"
+        with pytest.raises(eqx.EquinoxRuntimeError, match=match):
             pot_cls(**fields_)
 
     # ==========================================================================

--- a/tests/unit/potential/test_base.py
+++ b/tests/unit/potential/test_base.py
@@ -193,19 +193,6 @@ class AbstractPotential_Test(GalaIOMixin, metaclass=ABCMeta):
         assert orbits.shape == (2, len(ts))
         assert jnp.allclose(orbits.t, ts, atol=u.Quantity(1e-16, "Myr"))
 
-    # ---------------------------------
-    # Interaction with JAX
-
-    def test_jit_init(self, pot: gp.AbstractPotential, x: gt.QuSz3) -> None:
-        """Test that potentials can be created within a JITted function."""
-
-        @jax.jit
-        def init_potential_evaluate() -> None:
-            inner_pot = pot.__class__(**pot.parameters, units=pot.units)
-            inner_pot.potential(x, t=0)
-
-        init_potential_evaluate()
-
 
 ##############################################################################
 

--- a/tests/unit/potential/test_base.py
+++ b/tests/unit/potential/test_base.py
@@ -193,6 +193,19 @@ class AbstractPotential_Test(GalaIOMixin, metaclass=ABCMeta):
         assert orbits.shape == (2, len(ts))
         assert jnp.allclose(orbits.t, ts, atol=u.Quantity(1e-16, "Myr"))
 
+    # ---------------------------------
+    # Interaction with JAX
+
+    def test_jit_init(self, pot: gp.AbstractPotential, x: gt.QuSz3) -> None:
+        """Test that potentials can be created within a JITted function."""
+
+        @jax.jit
+        def init_potential_evaluate() -> None:
+            inner_pot = pot.__class__(**pot.parameters, units=pot.units)
+            inner_pot.potential(x, t=0)
+
+        init_potential_evaluate()
+
 
 ##############################################################################
 

--- a/tests/unit/potential/test_core.py
+++ b/tests/unit/potential/test_core.py
@@ -30,6 +30,19 @@ class AbstractSinglePotential_Test(AbstractPotential_Test, FieldUnitSystemMixin)
     def fields_(self, field_units: u.AbstractUnitSystem) -> dict[str, Any]:
         return {"units": field_units}
 
+    # ---------------------------------
+    # Interaction with JAX
+
+    def test_jit_init(self, pot: gp.AbstractPotential, x: gt.QuSz3) -> None:
+        """Test that potentials can be created within a JITted function."""
+
+        @jax.jit
+        def init_potential_evaluate() -> None:
+            inner_pot = pot.__class__(**pot.parameters, units=pot.units)
+            inner_pot.potential(x, t=0)
+
+        init_potential_evaluate()
+
 
 ###############################################################################
 


### PR DESCRIPTION
This is a bug that Katie and I stumbled on. Inside of a JITted function, we create a potential instance. We tried using the `LeeSutoNFWPotential` but get a `TracerBoolConversionError` - I think it's related to the Python `or` in the `__check_init
__`, so I switched that out for a `jnp.logical_or`. 

I also added a test to make sure all builtin potentials are safe from this and found a few other things to fix (commit coming).