### PR TITLE
Add blurb to README about uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ If you found this library to be useful in academic work, then please cite.
 
 We welcome contributions!
 
+Galax uses [`uv`](https://docs.astral.sh/uv) for development dependency
+management (make sure you have `uv` version >=0.4.27 installed). For example, to
+run the test suite, install the `test` group and run `pytest` with:
+
+```
+uv sync --group test
+uv run pytest src docs tests
+```
+
 ### Contributors
 
 See the


### PR DESCRIPTION
Eventually we should have some developer documentation, but I thought in the short term we could at least have a small note about using `uv` to run the tests (at least to remind me 😅).