### PR TITLE
Put upper bound on incompatible coordinax version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@
   dependencies = [
     "astropy>=7.0",
     "beartype>=0.19",
-    "coordinax>=0.20.1",
+    "coordinax>=0.20.1,<0.21",
     "dataclassish>=0.8.0",
     "diffrax>=0.6",
     "diffraxtra>=1.5.1",


### PR DESCRIPTION
This temporarily adds an upper bound to the coordinax version dependency because of the current incompatibility with coordinax v0.21.0.