### PR TITLE
Add dispatched function to plot all components of an orbit

### DIFF
--- a/src/galax/_interop/matplotlib/orbit.py
+++ b/src/galax/_interop/matplotlib/orbit.py
@@ -19,6 +19,8 @@ def _get_component(orbit: gd.Orbit, coord: str) -> AbstractQuantity:
         out = getattr(orbit.q, coord)
     elif hasattr(orbit.p, coord):
         out = getattr(orbit.p, coord)
+    elif hasattr(orbit, coord):  # allows for, e.g., orbit.t
+        out = getattr(orbit, coord)
     elif coord.startswith("d_"):
         out = getattr(orbit.p, coord[2:])
     else:

--- a/src/galax/_interop/matplotlib/orbit.py
+++ b/src/galax/_interop/matplotlib/orbit.py
@@ -40,11 +40,11 @@ class PlotFunctionCallable(Protocol):
 @dispatch
 def plot_components(
     orbit: gd.Orbit,
+    x: str,
+    y: str,
     backend: type[MatplotlibBackend] = MatplotlibBackend,  # noqa: ARG001
     /,
     *,
-    x: str,
-    y: str,
     plot_function: str | PlotFunctionCallable = "plot",
     vector_representation: Any = None,
     ax: Any | None = None,
@@ -91,7 +91,7 @@ def plot_components(
     axes: Any | None = None,
     subplots_kw: dict[str, Any] | None = None,
     **kwargs: Any,
-) -> Axes:
+) -> Any:  # TODO: type hint for array of axes is borked?
     if subplots_kw is None:
         subplots_kw = {}
 
@@ -112,9 +112,9 @@ def plot_components(
     for ax, xidx, yidx in zip(axes, xidxs, yidxs, strict=True):
         plot_components(
             orbit,
-            backend=backend,
-            x=components[xidx],
-            y=components[yidx],
+            components[xidx],
+            components[yidx],
+            backend,
             plot_function=plot_function,
             vector_representation=vector_representation,
             ax=ax,

--- a/src/galax/_interop/matplotlib/orbit.py
+++ b/src/galax/_interop/matplotlib/orbit.py
@@ -55,7 +55,7 @@ def plot_components(
 ) -> Axes | Any:
     if x is None and y is None:
         # Plot all components:
-        return plot_all_components(orbit, axes=ax, **kwargs)
+        return plot_all_components(orbit, **kwargs)
 
     if (x is None and y is not None) or (x is not None and y is None):
         msg = "Both x and y components must be specified, or neither."
@@ -107,11 +107,11 @@ def plot_all_components(
     # TODO: 5 is an arbitrary number - is there a way to get this from matplotlib?
     subplots_kw.setdefault("figsize", (len(components) * 5, 5))
     if axes is None:
-        _, axes = plt.subplots(1, len(components), **subplots_kw)
-    elif len(axes) != len(components):
+        _, axes = plt.subplots(1, len(xidxs), **subplots_kw)
+    elif len(axes) != len(xidxs):
         msg = (
             f"Number of matplotlib axes ({len(axes)}) does not match number of "
-            f"components to plot ({len(components)})"
+            f"pairwise components to plot ({len(xidxs)})"
         )
         raise ValueError(msg)
 

--- a/tests/integration/matplotlib/hashes.json
+++ b/tests/integration/matplotlib/hashes.json
@@ -5,6 +5,6 @@
   "integration.matplotlib.test_orbit.test_orbit_plot_time_color": "3a12252a7e2b676d8c3427b36b6d8c5753023e3a0b416b0d7433a9e7dcd91c92",
   "integration.matplotlib.test_potential.test_kepler_potential_contours": "f21ac32338c8120f0f8851f1fef3c516bc906bb21452539868361cf86833e561",
   "integration.matplotlib.test_potential.test_kernel_density_contours": "51f9e6ca266b063efdd9fd6914b09d689b9ff4be55554a5b0a981e54b972e8d3",
-  "integration.matplotlib.test_orbit.test_orbit_plot_all_components": "90292151d40b4ee9e8e965eed8b6c6fd9750e8f863ac45bdcced61be5df2a29f",
+  "integration.matplotlib.test_orbit.test_orbit_plot_all_components": "8195a0ed6cd92a3334151d2a3513fc3764f06e36b785bd046451d89a542f33f0",
   "integration.matplotlib.test_orbit.test_orbit_plot_time": "3f9856b4798abfb6b1a136eec33088d552368b05067eaa658cfe3c4f4c81dc27"
 }

--- a/tests/integration/matplotlib/hashes.json
+++ b/tests/integration/matplotlib/hashes.json
@@ -4,5 +4,7 @@
   "integration.matplotlib.test_orbit.test_orbit_plot_scatter": "e7f337382dada6558022a0888f2f741c90e74a6531ececa293e7754df273a4ee",
   "integration.matplotlib.test_orbit.test_orbit_plot_time_color": "3a12252a7e2b676d8c3427b36b6d8c5753023e3a0b416b0d7433a9e7dcd91c92",
   "integration.matplotlib.test_potential.test_kepler_potential_contours": "f21ac32338c8120f0f8851f1fef3c516bc906bb21452539868361cf86833e561",
-  "integration.matplotlib.test_potential.test_kernel_density_contours": "51f9e6ca266b063efdd9fd6914b09d689b9ff4be55554a5b0a981e54b972e8d3"
+  "integration.matplotlib.test_potential.test_kernel_density_contours": "51f9e6ca266b063efdd9fd6914b09d689b9ff4be55554a5b0a981e54b972e8d3",
+  "integration.matplotlib.test_orbit.test_orbit_plot_all_components": "90292151d40b4ee9e8e965eed8b6c6fd9750e8f863ac45bdcced61be5df2a29f",
+  "integration.matplotlib.test_orbit.test_orbit_plot_time": "3f9856b4798abfb6b1a136eec33088d552368b05067eaa658cfe3c4f4c81dc27"
 }

--- a/tests/integration/matplotlib/test_orbit.py
+++ b/tests/integration/matplotlib/test_orbit.py
@@ -70,6 +70,14 @@ def test_orbit_plot_scatter(orbit: gd.Orbit) -> Figure:
 
 
 @pytest.mark.mpl_image_compare(deterministic=True)
+def test_orbit_plot_time(orbit: gd.Orbit) -> Figure:
+    """Test plotting an orbit in a Kepler potential."""
+    ax = orbit.plot(x="t", y="y")
+
+    return ax.figure
+
+
+@pytest.mark.mpl_image_compare(deterministic=True)
 def test_orbit_plot_time_color(orbit: gd.Orbit) -> Figure:
     """Test plotting an orbit in a Kepler potential."""
     ax = orbit.plot(x="x", y="y", plot_function="scatter", c="orbit.t")

--- a/tests/integration/matplotlib/test_orbit.py
+++ b/tests/integration/matplotlib/test_orbit.py
@@ -40,6 +40,13 @@ def orbit(potential: gp.AbstractPotential, w0: gc.PhaseSpacePosition) -> gd.Orbi
 
 @pytest.mark.mpl_image_compare(deterministic=True)
 def test_orbit_plot(orbit: gd.Orbit) -> Figure:
+    """Test plotting all components of an orbit in a Kepler potential."""
+    ax = orbit.plot()
+    return ax.figure
+
+
+@pytest.mark.mpl_image_compare(deterministic=True)
+def test_orbit_plot(orbit: gd.Orbit) -> Figure:
     """Test plotting an orbit in a Kepler potential."""
     ax = orbit.plot(x="x", y="y")
 

--- a/tests/integration/matplotlib/test_orbit.py
+++ b/tests/integration/matplotlib/test_orbit.py
@@ -39,10 +39,10 @@ def orbit(potential: gp.AbstractPotential, w0: gc.PhaseSpacePosition) -> gd.Orbi
 
 
 @pytest.mark.mpl_image_compare(deterministic=True)
-def test_orbit_plot(orbit: gd.Orbit) -> Figure:
+def test_orbit_plot_all_components(orbit: gd.Orbit) -> Figure:
     """Test plotting all components of an orbit in a Kepler potential."""
-    ax = orbit.plot()
-    return ax.figure
+    axes = orbit.plot()
+    return axes[0].figure
 
 
 @pytest.mark.mpl_image_compare(deterministic=True)

--- a/tests/integration/matplotlib/test_orbit.py
+++ b/tests/integration/matplotlib/test_orbit.py
@@ -1,5 +1,6 @@
 """Test the `galax.dynamics.orbit` package contents."""
 
+import matplotlib.pyplot as plt
 import pytest
 from matplotlib.figure import Figure
 
@@ -85,7 +86,28 @@ def test_orbit_plot_time_color(orbit: gd.Orbit) -> Figure:
     return ax.figure
 
 
+##############################################################################
+# Expected failures
+
+
 def test_orbit_no_attribute(orbit: gd.Orbit) -> None:
     """Test failed plot."""
     with pytest.raises(AttributeError):
         orbit.plot(x="z", y="not_an_attribute")
+
+
+def test_orbit_only_one_component(orbit: gd.Orbit) -> None:
+    """Test failed plot."""
+    with pytest.raises(ValueError, match="Both x and y"):
+        orbit.plot(x="z")
+
+    with pytest.raises(ValueError, match="Both x and y"):
+        orbit.plot(y="z")
+
+
+def test_orbit_wrong_size_axes(orbit: gd.Orbit) -> None:
+    """Test failed plot."""
+    fig, axes = plt.subplots(1, 2)
+    with pytest.raises(ValueError, match="Number of matplotlib axes"):
+        orbit.plot(axes=axes)
+    plt.close(fig)


### PR DESCRIPTION
This adds a dispatch for `plot_components` when no components are specified to plot all pairs of components for an orbit.

I had to change the order of arguments to squeeze `x` and `y` into the positional arguments (to dispatch over). But alternatively I could make them `str | None = None` in a dispatched `plot_components()` outer function, and implement `_plot_components_single` and `_plot_components_all` to be called within. Thoughts?