### PR TITLE
🐛 fix(potential): finite gradient & hessian at r=0 for radial potentials

### DIFF
--- a/src/galax/potential/_src/builtin/burkert.py
+++ b/src/galax/potential/_src/builtin/burkert.py
@@ -184,7 +184,7 @@ def mass_enclosed(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
     """
     x = r / p["r_s"]
     factor = p["m"] / CONST_BURKER
-    return factor * (2 * jnp.log(1 + x) + jnp.log(1 + x**2) - 2 * jnp.atan(x))
+    return factor * (2 * jnp.log1p(x) + jnp.log1p(x**2) - 2 * jnp.atan(x))
 
 
 @ft.partial(jax.jit)
@@ -220,6 +220,6 @@ def potential(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
     return -prefactor * (
         jnp.pi
         - 2 * (1 + xinv) * jnp.atan(x)
-        + 2 * (1 + xinv) * jnp.log(1 + x)
-        - (1 - xinv) * jnp.log(1 + x**2)
+        + 2 * (1 + xinv) * jnp.log1p(x)
+        - (1 - xinv) * jnp.log1p(x**2)
     )

--- a/src/galax/potential/_src/builtin/hernquist.py
+++ b/src/galax/potential/_src/builtin/hernquist.py
@@ -19,7 +19,7 @@ from galax.potential._src.base import default_constants
 from galax.potential._src.base_single import AbstractSinglePotential
 from galax.potential._src.params.base import AbstractParameter
 from galax.potential._src.params.field import ParameterField
-from galax.potential._src.utils import r_spherical
+from galax.potential._src.utils import r_spherical, safe_sqrt
 
 
 @final
@@ -163,7 +163,7 @@ class TriaxialHernquistPotential(AbstractSinglePotential):
 
         u1 = self.units["dimensionless"]
         q1, q2 = self.q1(t, ustrip=u1), self.q2(t, ustrip=u1)
-        rprime = jnp.sqrt(
+        rprime = safe_sqrt(
             xyz[..., 0] ** 2 + (xyz[..., 1] / q1) ** 2 + (xyz[..., 2] / q2) ** 2
         )
 

--- a/src/galax/potential/_src/builtin/nfw/base.py
+++ b/src/galax/potential/_src/builtin/nfw/base.py
@@ -319,7 +319,7 @@ def mass_enclosed(p: gt.Params, r: gt.BBtSz0, /) -> gt.BtFloatSz0:
     """
     x = r / p["r_s"]
     m = p["m"]
-    return m * (jnp.log(1 + x) - x / (1 + x))
+    return m * (jnp.log1p(x) - x / (1 + x))
 
 
 @ft.partial(jax.jit)
@@ -334,4 +334,4 @@ def potential(p: gt.Params, r: gt.BBtSz0, /) -> gt.BtFloatSz0:
     r_s = p["r_s"]
     x = r / r_s
     phi0 = -p["G"] * p["m"] / r_s
-    return phi0 * jnp.log(1 + x) / x
+    return phi0 * jnp.log1p(x) / x

--- a/src/galax/potential/_src/builtin/nfw/generalized.py
+++ b/src/galax/potential/_src/builtin/nfw/generalized.py
@@ -87,9 +87,11 @@ class gNFWPotential(AbstractSinglePotential):
     >>> jnp.isclose(gnfw.potential(x, t), nfw.potential(x, t), atol=1e-8)
     Array(True, dtype=bool)
 
+    Both are finite at the origin, where $\\Phi(0) = -G m / r_s$:
+
     >>> x = jnp.array([0, 0, 0])
     >>> gnfw.potential(x, t), nfw.potential(x, t)
-    (Array(nan, dtype=float64), Array(nan, dtype=float64))
+    (Array(-4.49850215, dtype=float64), Array(-4.49850215, dtype=float64))
 
     The gNFW potential is a generalization of the NFW potential, so it can be
     used to model a wider range of profiles. For example, if we set $\gamma =
@@ -328,9 +330,11 @@ def potential(p: gt.Params, r: gt.BBtSz0, /) -> gt.BtFloatSz0:
     >>> jnp.isclose(gnfw.potential(x, t), nfw.potential(x, t), atol=1e-8)
     Array(True, dtype=bool)
 
+    Both are finite at the origin, where $\\Phi(0) = -G m / r_s$:
+
     >>> x = jnp.array([0, 0, 0])
     >>> gnfw.potential(x, t), nfw.potential(x, t)
-    (Array(nan, dtype=float64), Array(nan, dtype=float64))
+    (Array(-4.49850215, dtype=float64), Array(-4.49850215, dtype=float64))
 
     The gNFW potential is a generalization of the NFW potential, so it can be
     used to model a wider range of profiles. For example, if we set

--- a/src/galax/potential/_src/builtin/nfw/leesuto.py
+++ b/src/galax/potential/_src/builtin/nfw/leesuto.py
@@ -19,7 +19,7 @@ from galax.potential._src.base import default_constants
 from galax.potential._src.base_single import AbstractSinglePotential
 from galax.potential._src.params.base import AbstractParameter
 from galax.potential._src.params.field import ParameterField
-from galax.potential._src.utils import safe_sqrt
+from galax.potential._src.utils import safe_vector_norm
 
 LOG2: Final = jnp.log(jnp.asarray(2.0))
 
@@ -127,7 +127,7 @@ def potential(p: gt.Params, xyz: gt.BBtSz3, /) -> gt.BtFloatSz0:
     # https://github.com/adrn/gala/blob/2067009de41518a71c674d0252bc74a7b2d78a36/gala/potential/potential/builtin/builtin_potentials.c#L1472
 
     # Parse inputs
-    r = safe_sqrt(jnp.sum(jnp.square(xyz), axis=-1))
+    r = safe_vector_norm(xyz)
 
     v_c2 = p["G"] * p["m"] / p["r_s"]
 

--- a/src/galax/potential/_src/builtin/nfw/leesuto.py
+++ b/src/galax/potential/_src/builtin/nfw/leesuto.py
@@ -19,6 +19,7 @@ from galax.potential._src.base import default_constants
 from galax.potential._src.base_single import AbstractSinglePotential
 from galax.potential._src.params.base import AbstractParameter
 from galax.potential._src.params.field import ParameterField
+from galax.potential._src.utils import safe_sqrt
 
 LOG2: Final = jnp.log(jnp.asarray(2.0))
 
@@ -126,7 +127,7 @@ def potential(p: gt.Params, xyz: gt.BBtSz3, /) -> gt.BtFloatSz0:
     # https://github.com/adrn/gala/blob/2067009de41518a71c674d0252bc74a7b2d78a36/gala/potential/potential/builtin/builtin_potentials.c#L1472
 
     # Parse inputs
-    r = jnp.linalg.vector_norm(xyz, axis=-1)
+    r = safe_sqrt(jnp.sum(jnp.square(xyz), axis=-1))
 
     v_c2 = p["G"] * p["m"] / p["r_s"]
 
@@ -141,7 +142,7 @@ def potential(p: gt.Params, xyz: gt.BBtSz3, /) -> gt.BtFloatSz0:
     s = r / p["r_s"]
 
     # The functions F1, F2, and F3 and some useful quantities
-    log1pu = jnp.log(1 + s)
+    log1pu = jnp.log1p(s)
     u2 = s**2
     um3 = s ** (-3)
     costh2 = xyz[..., 2] ** 2 / r**2  # z^2 / r^2

--- a/src/galax/potential/_src/builtin/nfw/vogelsburger08.py
+++ b/src/galax/potential/_src/builtin/nfw/vogelsburger08.py
@@ -19,6 +19,7 @@ from galax.potential._src.base import default_constants
 from galax.potential._src.base_single import AbstractSinglePotential
 from galax.potential._src.params.base import AbstractParameter
 from galax.potential._src.params.field import ParameterField
+from galax.potential._src.utils import safe_sqrt
 
 
 @final
@@ -60,7 +61,7 @@ class Vogelsberger08TriaxialNFWPotential(AbstractSinglePotential):
         q1sq = self.q1(t, ustrip=self.units["dimensionless"]) ** 2
         q2sq = 3 - q1sq
         x, y, z = xyz[..., 0], xyz[..., 1], xyz[..., 2]
-        return jnp.sqrt(x**2 + y**2 / q1sq + z**2 / q2sq)
+        return safe_sqrt(x**2 + y**2 / q1sq + z**2 / q2sq)
 
     @ft.partial(jax.jit, inline=True)
     def _r_tilde(self, xyz: gt.BtSz3, t: gt.BBtSz0) -> gt.BtFloatSz0:
@@ -68,7 +69,7 @@ class Vogelsberger08TriaxialNFWPotential(AbstractSinglePotential):
         r_a = a_r * self.r_s(t, ustrip=self.units["length"])
 
         r_e = self._r_e(xyz, t)
-        r = jnp.linalg.vector_norm(xyz, axis=-1)
+        r = safe_sqrt(jnp.sum(jnp.square(xyz), axis=-1))
         return (r_a + r) * r_e / (r_a + r_e)
 
     @ft.partial(jax.jit)
@@ -82,4 +83,4 @@ class Vogelsberger08TriaxialNFWPotential(AbstractSinglePotential):
         r_s = self.r_s(t, ustrip=self.units["length"])
 
         r = self._r_tilde(xyz, t)
-        return -self.constants["G"].value * m * jnp.log(1.0 + r / r_s) / r
+        return -self.constants["G"].value * m * jnp.log1p(r / r_s) / r

--- a/src/galax/potential/_src/builtin/nfw/vogelsburger08.py
+++ b/src/galax/potential/_src/builtin/nfw/vogelsburger08.py
@@ -19,7 +19,7 @@ from galax.potential._src.base import default_constants
 from galax.potential._src.base_single import AbstractSinglePotential
 from galax.potential._src.params.base import AbstractParameter
 from galax.potential._src.params.field import ParameterField
-from galax.potential._src.utils import safe_sqrt
+from galax.potential._src.utils import safe_sqrt, safe_vector_norm
 
 
 @final
@@ -69,7 +69,7 @@ class Vogelsberger08TriaxialNFWPotential(AbstractSinglePotential):
         r_a = a_r * self.r_s(t, ustrip=self.units["length"])
 
         r_e = self._r_e(xyz, t)
-        r = safe_sqrt(jnp.sum(jnp.square(xyz), axis=-1))
+        r = safe_vector_norm(xyz)
         return (r_a + r) * r_e / (r_a + r_e)
 
     @ft.partial(jax.jit)

--- a/src/galax/potential/_src/utils.py
+++ b/src/galax/potential/_src/utils.py
@@ -75,15 +75,49 @@ def safe_sqrt(q2: gt.BBtFloatSz0, /) -> gt.BBtFloatSz0:
     return jnp.sqrt(q2 + tiny)
 
 
+@ft.partial(jax.jit, inline=True)
+def safe_vector_norm(x: gt.BBtSz3, /) -> gt.BBtFloatSz0:
+    """`jnp.linalg.vector_norm` over the last axis, differentiable at the origin.
+
+    Values match `jnp.linalg.vector_norm` to within a rounding ulp -- the
+    offset is a no-op at any meaningful magnitude, but XLA fuses
+    ``sum(square(x))`` differently from `vector_norm`'s scaled algorithm. The
+    derivative at the origin is finite rather than NaN. See `safe_sqrt`.
+
+    Unlike `vector_norm`, this overflows for ``|x| > ~1e154`` (float64), which
+    no physical position reaches.
+
+    Examples
+    --------
+    >>> import quaxed.numpy as jnp
+    >>> from galax.potential._src.utils import safe_vector_norm
+
+    >>> xyz = jnp.asarray([3.0, 4.0, 0.0])
+    >>> safe_vector_norm(xyz)
+    Array(5., dtype=float64)
+
+    At the origin the gradient is zero -- the value `jnp.linalg.vector_norm`
+    cannot give -- rather than NaN:
+
+    >>> import jax
+    >>> jax.grad(safe_vector_norm)(jnp.zeros(3))
+    Array([0., 0., 0.], dtype=float64)
+    >>> jax.grad(jnp.linalg.vector_norm)(jnp.zeros(3))
+    Array([nan, nan, nan], dtype=float64)
+
+    """
+    return safe_sqrt(jnp.sum(jnp.square(x), axis=-1))
+
+
 @ft.partial(jax.jit, inline=True, static_argnames=("unit",))
 def r_spherical(xyz: gt.BBtQorVSz3, unit: Any) -> gt.BBtFloatSz0:
     """Spherical radius.
 
-    Uses `safe_sqrt` so that the gradient and hessian of potentials written in
-    terms of ``r`` are finite at the origin rather than NaN.
+    Uses `safe_vector_norm` so that the gradient and hessian of potentials
+    written in terms of ``r`` are finite at the origin rather than NaN.
     """
     xyz = u.ustrip(AllowValue, unit, xyz)
-    r = safe_sqrt(jnp.sum(jnp.square(xyz), axis=-1))
+    r = safe_vector_norm(xyz)
     return r
 
 

--- a/src/galax/potential/_src/utils.py
+++ b/src/galax/potential/_src/utils.py
@@ -37,11 +37,53 @@ def parse_dtypes(dtype2: np.dtype, dtype1: Any, /) -> np.dtype | None:
 # ==============================================================================
 
 
+@ft.partial(jax.jit, inline=True)
+def safe_sqrt(q2: gt.BBtFloatSz0, /) -> gt.BBtFloatSz0:
+    """Square root that stays differentiable where its argument vanishes.
+
+    ``sqrt`` has an infinite derivative at 0, so a radius built as
+    ``sqrt(x**2 + y**2 + z**2)`` makes `jax.grad` and `jax.hessian` of every
+    potential defined in terms of it NaN at the origin. Offsetting by the
+    smallest normal float keeps the derivative finite. The offset is ~1e-308
+    (float64), so the value is unchanged for any physically meaningful
+    position.
+
+    The offset must be applied to the primal, not just the tangent: recovering
+    the correct Hessian of a cored profile at the origin needs ``Phi'(r) / r``
+    evaluated at a genuinely non-zero ``r``.
+
+    Examples
+    --------
+    >>> import quaxed.numpy as jnp
+    >>> from galax.potential._src.utils import safe_sqrt
+
+    The value matches `jnp.sqrt`:
+
+    >>> safe_sqrt(jnp.asarray(4.0))
+    Array(2., dtype=float64)
+
+    but the derivative at zero is finite rather than infinite:
+
+    >>> import jax
+    >>> jnp.isfinite(jax.grad(safe_sqrt)(jnp.asarray(0.0)))
+    Array(True, dtype=bool, weak_type=True)
+    >>> jax.grad(jnp.sqrt)(jnp.asarray(0.0))
+    Array(inf, dtype=float64...)
+
+    """
+    tiny = jnp.finfo(jnp.promote_types(q2.dtype, float)).tiny
+    return jnp.sqrt(q2 + tiny)
+
+
 @ft.partial(jax.jit, inline=True, static_argnames=("unit",))
 def r_spherical(xyz: gt.BBtQorVSz3, unit: Any) -> gt.BBtFloatSz0:
-    """Spherical radius."""
+    """Spherical radius.
+
+    Uses `safe_sqrt` so that the gradient and hessian of potentials written in
+    terms of ``r`` are finite at the origin rather than NaN.
+    """
     xyz = u.ustrip(AllowValue, unit, xyz)
-    r = jnp.linalg.vector_norm(xyz, axis=-1)
+    r = safe_sqrt(jnp.sum(jnp.square(xyz), axis=-1))
     return r
 
 

--- a/tests/unit/potential/test_origin.py
+++ b/tests/unit/potential/test_origin.py
@@ -1,0 +1,115 @@
+"""Tests for potential derivatives at exactly r=0.
+
+`jnp.sqrt` has an infinite derivative at zero, so a radius built as
+``sqrt(x**2 + y**2 + z**2)`` made `gradient` and `hessian` NaN at the origin for
+every potential defined in terms of ``r``. See `galax.potential._src.utils.safe_sqrt`.
+"""
+
+import jax
+import pytest
+
+import quaxed.numpy as jnp
+import unxt as u
+
+import galax.potential as gp
+from galax.potential._src.utils import safe_sqrt
+
+# Potentials that are regular at the origin, with the analytic value of
+# d^2Phi/dx^2 there (the Hessian is isotropic, so the diagonal suffices).
+M_TOT = u.Quantity(1e12, "Msun")
+R_S = u.Quantity(5.0, "kpc")
+
+REGULAR = [
+    # Plummer: Phi = -GM / sqrt(r^2 + b^2)  =>  d2Phi/dx2(0) = GM / b^3
+    (gp.PlummerPotential(m_tot=M_TOT, r_s=R_S, units="galactic"), 3),
+    # Isochrone: Phi = -GM / (b + sqrt(r^2 + b^2))  =>  d2Phi/dx2(0) = GM / (4 b^3)
+    (gp.IsochronePotential(m_tot=M_TOT, r_s=R_S, units="galactic"), 12),
+]
+
+# Cuspy but still expected to be non-NaN: the net force at the exact centre of a
+# spherically symmetric system is zero by symmetry.
+CUSPY = [
+    gp.HernquistPotential(m_tot=M_TOT, r_s=R_S, units="galactic"),
+    gp.TriaxialHernquistPotential(
+        m_tot=M_TOT, r_s=R_S, q1=1.0, q2=0.9, units="galactic"
+    ),
+    gp.LogarithmicPotential(v_c=u.Quantity(220, "km/s"), r_s=R_S, units="galactic"),
+    gp.StoneOstriker15Potential(
+        m_tot=M_TOT, r_h=u.Quantity(10.0, "kpc"), r_c=R_S, units="galactic"
+    ),
+]
+
+# Known remaining limitation, from a *second* and independent cause: these
+# profiles are written in a form whose r-derivative is itself 0/0 at r=0 (e.g.
+# NFW's d/dr[log1p(x)/x] = [x/(1+x) - log1p(x)]/x^2). Making the radius
+# differentiable does not help; the profile formula needs a small-x series.
+# Their potential *values* at the origin are correct.
+STILL_NAN_GRADIENT = [
+    gp.NFWPotential(m=M_TOT, r_s=R_S, units="galactic"),
+    gp.BurkertPotential(m=M_TOT, r_s=R_S, units="galactic"),
+]
+
+ORIGIN = jnp.zeros(3)
+
+
+def test_safe_sqrt_value_is_exact() -> None:
+    """`safe_sqrt` must not perturb the value of `jnp.sqrt`."""
+    x = jnp.asarray([1e-30, 1e-6, 1.0, 4.0, 1e30])
+    assert jnp.array_equal(safe_sqrt(x), jnp.sqrt(x))
+
+
+def test_safe_sqrt_derivative_is_finite_at_zero() -> None:
+    """...but its derivative at zero must be finite, unlike `jnp.sqrt`."""
+    assert jnp.isinf(jax.grad(jnp.sqrt)(jnp.asarray(0.0)))
+    assert jnp.isfinite(jax.grad(safe_sqrt)(jnp.asarray(0.0)))
+
+
+@pytest.mark.parametrize(("pot", "denom"), REGULAR, ids=lambda p: type(p).__name__)
+def test_regular_potential_hessian_at_origin(
+    pot: gp.AbstractPotential, denom: int
+) -> None:
+    """Cored potentials have the exact analytic gradient & Hessian at r=0."""
+    G = pot.constants["G"].value
+    m_tot = pot.m_tot(0.0, ustrip=pot.units["mass"])
+    r_s = pot.r_s(0.0, ustrip=pot.units["length"])
+
+    assert jnp.allclose(pot.gradient(ORIGIN, 0.0), jnp.zeros(3), atol=1e-12)
+    expected = G * m_tot / (denom / 3 * r_s**3)
+    assert jnp.allclose(pot.hessian(ORIGIN, 0.0), expected * jnp.eye(3), rtol=1e-8)
+
+
+@pytest.mark.parametrize("pot", CUSPY, ids=lambda p: type(p).__name__)
+def test_cuspy_potential_gradient_at_origin(pot: gp.AbstractPotential) -> None:
+    """Cuspy potentials give zero net force at the centre, not NaN."""
+    assert jnp.all(jnp.isfinite(pot.gradient(ORIGIN, 0.0)))
+    assert jnp.allclose(pot.gradient(ORIGIN, 0.0), jnp.zeros(3), atol=1e-12)
+
+
+def test_potential_value_matches_limit_at_origin() -> None:
+    """NFW's Phi = -G m log1p(r/r_s) / r has a removable singularity at r=0."""
+    pot = gp.NFWPotential(m=M_TOT, r_s=R_S, units="galactic")
+    G = pot.constants["G"].value
+    expected = -G * 1e12 / 5.0
+    assert jnp.allclose(pot.potential(ORIGIN, 0.0), expected, rtol=1e-8)
+
+
+@pytest.mark.parametrize(
+    "pot", [p for p, _ in REGULAR] + CUSPY, ids=lambda p: type(p).__name__
+)
+def test_gradient_is_continuous_into_the_origin(pot: gp.AbstractPotential) -> None:
+    """The value just off the origin stays finite, i.e. no NaN boundary layer."""
+    near = jnp.asarray([1e-12, 0.0, 0.0])
+    assert jnp.all(jnp.isfinite(pot.gradient(near, 0.0)))
+    assert jnp.isfinite(pot.potential(near, 0.0))
+
+
+@pytest.mark.parametrize("pot", STILL_NAN_GRADIENT, ids=lambda p: type(p).__name__)
+def test_profile_formula_singularity_is_a_separate_issue(
+    pot: gp.AbstractPotential,
+) -> None:
+    """Pin the known limitation so that fixing the profiles trips this test.
+
+    The potential value at the origin is correct; only the gradient is NaN.
+    """
+    assert jnp.isfinite(pot.potential(ORIGIN, 0.0))
+    assert jnp.all(jnp.isnan(pot.gradient(ORIGIN, 0.0)))

--- a/tests/unit/potential/test_origin.py
+++ b/tests/unit/potential/test_origin.py
@@ -6,13 +6,14 @@ every potential defined in terms of ``r``. See `galax.potential._src.utils.safe_
 """
 
 import jax
+import numpy as np
 import pytest
 
 import quaxed.numpy as jnp
 import unxt as u
 
 import galax.potential as gp
-from galax.potential._src.utils import safe_sqrt
+from galax.potential._src.utils import safe_sqrt, safe_vector_norm
 
 # Potentials that are regular at the origin, with the analytic value of
 # d^2Phi/dx^2 there (the Hessian is isotropic, so the diagonal suffices).
@@ -62,6 +63,26 @@ def test_safe_sqrt_derivative_is_finite_at_zero() -> None:
     """...but its derivative at zero must be finite, unlike `jnp.sqrt`."""
     assert jnp.isinf(jax.grad(jnp.sqrt)(jnp.asarray(0.0)))
     assert jnp.isfinite(jax.grad(safe_sqrt)(jnp.asarray(0.0)))
+
+
+def test_safe_vector_norm_matches_vector_norm_to_1ulp() -> None:
+    """`safe_vector_norm` must agree with `jnp.linalg.vector_norm`.
+
+    Agreement is to within a rounding ulp rather than bitwise: the offset
+    itself is a no-op at these magnitudes, but XLA fuses ``sum(square(x))``
+    differently from `vector_norm`'s scaled algorithm.
+    """
+    rng = np.random.default_rng(0)
+    n = 20_000
+    xyz = jnp.asarray(rng.normal(size=(n, 3)) * 10 ** rng.uniform(-6, 6, size=(n, 1)))
+    expect = jnp.linalg.vector_norm(xyz, axis=-1)
+    assert jnp.allclose(safe_vector_norm(xyz), expect, rtol=4e-16, atol=0.0)
+
+
+def test_safe_vector_norm_gradient_at_origin() -> None:
+    """Its gradient at the origin is zero, where `vector_norm` gives NaN."""
+    assert jnp.all(jnp.isnan(jax.grad(jnp.linalg.vector_norm)(ORIGIN)))
+    assert jnp.array_equal(jax.grad(safe_vector_norm)(ORIGIN), jnp.zeros(3))
 
 
 @pytest.mark.parametrize(("pot", "denom"), REGULAR, ids=lambda p: type(p).__name__)


### PR DESCRIPTION
`gradient` and `hessian` returned NaN at exactly `r = 0` for essentially every
radial potential. The cause is that a radius built as `sqrt(x² + y² + z²)` has an
infinite derivative where its argument vanishes, so the chain rule produces
`0 · inf = NaN` for any potential written in terms of `r` — `HernquistPotential`,
`PlummerPotential`, `NFWPotential`, `LogarithmicPotential`, and the rest.

## The fix

A single helper, `galax.potential._src.utils.safe_sqrt`, offsets the radicand by
the smallest normal float:

```python
tiny = jnp.finfo(jnp.promote_types(q2.dtype, float)).tiny
return jnp.sqrt(q2 + tiny)
```

A thin `safe_vector_norm` wraps `safe_sqrt(sum(square(x)))` so call sites read as
a norm. `r_spherical` uses it, covering the twelve modules that build a spherical
radius; the ellipsoidal radii in `TriaxialHernquistPotential`,
`Vogelsberger08TriaxialNFWPotential`, and `LeeSutoTriaxialNFWPotential` call
`safe_sqrt` directly, since their quadratic form is not a plain norm.

The offset is ~1e-308, a no-op at any meaningful magnitude. Values agree with
`jnp.linalg.vector_norm` **to within a rounding ulp** — not bitwise: under
`jax.jit`, XLA fuses `sum(square(x))` differently from `vector_norm`'s scaled
algorithm, and ~11% of sampled elements differ by 1 ulp (≤3e-16 relative).
`safe_vector_norm` also overflows above `|x| ~ 1e154`, which `vector_norm`'s
scaling avoids and no physical position reaches.

It has to be applied to the primal rather than only to the tangent. I tried the
usual `jnp.where` "double-where" and a `custom_jvp` that keeps the primal exact;
both make the gradient finite but silently zero *every* Hessian at the origin,
and the `custom_jvp` also reports zero force at the centre of a Kepler point
mass. Recovering the correct Hessian of a cored profile needs `Φ'(r)/r`
evaluated at a genuinely non-zero `r`.

## Second cause found along the way

Making the radius differentiable exposed a `log(1 + x)` underflow: at
`x ~ 1e-155`, `log(1 + x)` flushes to exactly `0`, so `NFWPotential` returned
`-0` at the origin instead of `-Gm/r_s`. Switched to `log1p` in the NFW, Burkert,
Lee–Suto, and Vogelsberger profiles — a genuine precision fix at small `r`
independently of this PR.

## Results at `r = 0`

| | before | after |
|---|---|---|
| `PlummerPotential`, `IsochronePotential` | NaN | exact analytic gradient **and** Hessian (`GM/b³`) |
| `HernquistPotential`, `TriaxialHernquistPotential`, `LogarithmicPotential`, `StoneOstriker15Potential`, `LM10Potential` | NaN | gradient `0` — the net force at the centre of a spherically symmetric system, by symmetry |
| `NFWPotential`, `BurkertPotential`, `MilkyWayPotential`, `MilkyWayPotential2022`, `gNFWPotential` | NaN value | correct value `-Gm/r_s` |

Cuspy profiles report a very large finite Hessian (~1e18) rather than NaN, which
reflects the genuine divergence of the tidal field at a `1/r` cusp.

## Known limitation, pinned by a test

`NFWPotential` and `BurkertPotential` still have a NaN **gradient** at the
origin, from a second and independent cause: their profile's `r`-derivative is
itself `0/0` there (`d/dr[log1p(x)/x] = [x/(1+x) − log1p(x)]/x²`). A
differentiable radius cannot help; those formulas need a small-`x` series. Their
*values* are now correct. `test_profile_formula_singularity_is_a_separate_issue`
pins this so that fixing the profiles trips the test.

Two genuinely singular potentials also change character: `KeplerPotential` and
`JaffePotential` diverge at `r = 0`, and their value there goes from `-inf` to a
large finite number. Kepler's gradient stays NaN. Happy to special-case these if
you'd rather they keep returning `-inf`.

## Tests

`tests/unit/potential/test_origin.py`, covering `safe_sqrt` value-exactness and
derivative finiteness, the exact analytic Hessian for cored profiles, zero
gradient for cuspy ones, and the known limitation above. Full suite passes; the
two `gNFWPotential` doctests that asserted `(nan, nan)` at the origin were
updated to the now-correct values.

## CI note

`tests/functional/test_mockstreamgenerator.py::test_second_deriv` fails on this
branch, but it **also fails identically on the base commit `d1a031bc`** — I ran
it in a separate worktree to check:

| | computed | reference | max rel. diff |
|---|---|---|---|
| base `d1a031bc` | -978142 | -978157 | 0.00098106 |
| this branch | -978137 | -978157 | 0.00101161 |

The committed `pytest-arraydiff` reference is stale by ~1e-3 on darwin/arm64.
This change moves the value by a further ~5e-6 relative: the 1-ulp norm
differences above, amplified through second-order autodiff of a chaotic
10,000-step integration. `test_first_deriv`, same mechanism and same
`rtol=1e-7`, passes. I have deliberately **not** regenerated the reference
file.

The `mypy` pre-commit hook also reports 50 pre-existing errors in 23 files, an
identical count with and without this change; none are in the files touched here.

Full suite otherwise: 6047 passed, 182 skipped, 14 xfailed.
