### PR TITLE
💚 ci: bump build-and-inspect-python-package to v3.0.1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: hynek/build-and-inspect-python-package@v3.0.1
 
   test-publish:
     needs: [dist]


### PR DESCRIPTION
`hatchling` now emits `Metadata-Version: 2.5`, but v2.18.0 of
`hynek/build-and-inspect-python-package` pins `twine==6.2.0`, which rejects it:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

v3.0.1 ships twine 7, which supports metadata 2.5.

Same fix as GalacticDynamics/unxt#867 and GalacticDynamics/coordinax#697.

## Not caused by any branch

`main` already builds a wheel with `Metadata-Version: 2.5` — I built one from a
pristine `main` worktree to check — so the next CD run on `main` would fail the
same way. It surfaced on #799 only because that is the first CD run since
hatchling changed.

## Why the exact tag rather than `@v3`

Unlike `v2`, upstream has no floating `v3` tag — only `v3.0.0` and `v3.0.1` — so
`@v3` would not resolve. `unxt` and `coordinax` SHA-pin their actions; galax pins
by floating major tag everywhere (`actions/checkout@v7`, `download-artifact@v8`),
so this stays a tag.

#799 is rebased on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
