### PR TITLE
🎨 style: spell empty __all__ as a tuple

### DIFF
--- a/src/galax/_custom_types.py
+++ b/src/galax/_custom_types.py
@@ -17,7 +17,7 @@ Notes
 
 """
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 from jaxtyping import Array, ArrayLike, Float, Int, Real, ScalarLike, Shaped
 from typing import Any, TypeAlias

--- a/src/galax/_interop/__init__.py
+++ b/src/galax/_interop/__init__.py
@@ -1,7 +1,7 @@
 """Interoperability."""
 # ruff:noqa: F401
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 from .optional_deps import OptDeps
 

--- a/src/galax/_interop/galax_interop_astropy/__init__.py
+++ b/src/galax/_interop/galax_interop_astropy/__init__.py
@@ -1,6 +1,6 @@
 """Compatibility with :mod:`astropy.coordinates`."""
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 from .coordinates import *
 from .dynamics import *

--- a/src/galax/_interop/galax_interop_astropy/coordinates.py
+++ b/src/galax/_interop/galax_interop_astropy/coordinates.py
@@ -1,6 +1,6 @@
 """Compatibility."""
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 from typing import Any
 

--- a/src/galax/_interop/galax_interop_astropy/dynamics.py
+++ b/src/galax/_interop/galax_interop_astropy/dynamics.py
@@ -1,6 +1,6 @@
 """Compatibility."""
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 from typing import Any
 

--- a/src/galax/_interop/galax_interop_astropy/potential.py
+++ b/src/galax/_interop/galax_interop_astropy/potential.py
@@ -1,6 +1,6 @@
 """Compatibility."""
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 from jaxtyping import Real
 from typing import Any

--- a/src/galax/_interop/galax_interop_gala/coordinates.py
+++ b/src/galax/_interop/galax_interop_gala/coordinates.py
@@ -1,6 +1,6 @@
 """Compatibility with :mod:`gala` coordinates."""
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 import warnings
 

--- a/src/galax/coordinates/_src/__init__.py
+++ b/src/galax/coordinates/_src/__init__.py
@@ -4,4 +4,4 @@ Private API.
 
 """
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()

--- a/src/galax/coordinates/_src/ops/__init__.py
+++ b/src/galax/coordinates/_src/ops/__init__.py
@@ -3,4 +3,4 @@
 E.g. a translation.
 """
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()

--- a/src/galax/coordinates/_src/pscs/register_primitives.py
+++ b/src/galax/coordinates/_src/pscs/register_primitives.py
@@ -1,6 +1,6 @@
 """Register primitives for PSPs."""
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 from dataclasses import replace
 

--- a/src/galax/coordinates/_src/pscs/register_vectorapi.py
+++ b/src/galax/coordinates/_src/pscs/register_vectorapi.py
@@ -1,6 +1,6 @@
 """Base classes for operators on coordinates and potentials."""
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 from dataclasses import replace
 

--- a/src/galax/coordinates/_src/psps/register_primitives.py
+++ b/src/galax/coordinates/_src/psps/register_primitives.py
@@ -1,6 +1,6 @@
 """Register primitives for PSPs."""
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 from dataclasses import replace
 

--- a/src/galax/coordinates/_src/psps/register_vectorapi.py
+++ b/src/galax/coordinates/_src/psps/register_vectorapi.py
@@ -1,6 +1,6 @@
 """Register PSPs with `coordinax`."""
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 from dataclasses import replace
 

--- a/src/galax/dynamics/_src/__init__.py
+++ b/src/galax/dynamics/_src/__init__.py
@@ -1,4 +1,4 @@
 """``galax`` dynamics."""
 # ruff:noqa: F401
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()

--- a/src/galax/dynamics/_src/cluster/register_funcs.py
+++ b/src/galax/dynamics/_src/cluster/register_funcs.py
@@ -1,6 +1,6 @@
 """Cluster functions."""
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 import functools as ft
 

--- a/src/galax/dynamics/_src/custom_types.py
+++ b/src/galax/dynamics/_src/custom_types.py
@@ -1,6 +1,6 @@
 """Type hints for `galax.dynamics`."""
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 from jaxtyping import Real
 from typing import TypeAlias

--- a/src/galax/dynamics/_src/examples/__init__.py
+++ b/src/galax/dynamics/_src/examples/__init__.py
@@ -1,3 +1,3 @@
 """System-specific dynamics."""
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()

--- a/src/galax/dynamics/_src/experimental/df.py
+++ b/src/galax/dynamics/_src/experimental/df.py
@@ -1,6 +1,6 @@
 """Experimental dynamics."""
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 import abc
 import functools as ft

--- a/src/galax/dynamics/_src/legacy/mockstream/_moving.py
+++ b/src/galax/dynamics/_src/legacy/mockstream/_moving.py
@@ -4,7 +4,7 @@ This class adds time-dependent translations to a potential.
 It is NOT careful about the implied changes to velocity, etc.
 """
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 
 from collections.abc import Callable

--- a/src/galax/dynamics/_src/orbit/register_dfx.py
+++ b/src/galax/dynamics/_src/orbit/register_dfx.py
@@ -4,7 +4,7 @@ This is private API.
 
 """
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 
 import diffrax as dfx

--- a/src/galax/potential/_src/__init__.py
+++ b/src/galax/potential/_src/__init__.py
@@ -1,6 +1,6 @@
 """``galax`` Potentials."""
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 
 # NOTE: this avoids a circular import

--- a/src/galax/potential/_src/plot.py
+++ b/src/galax/potential/_src/plot.py
@@ -5,7 +5,7 @@ BSD 3-Clause License. The original code can be found at
 https:://github.com/nstarman/bound-class. See the license in the LICENSE files.
 """
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 from typing import Any
 

--- a/src/galax/potential/_src/register_funcs.py
+++ b/src/galax/potential/_src/register_funcs.py
@@ -1,6 +1,6 @@
 """galax: Galactic Dynamix in Jax."""
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 import functools as ft
 

--- a/src/galax/potential/_src/utils.py
+++ b/src/galax/potential/_src/utils.py
@@ -1,6 +1,6 @@
 """galax: Galactic Dynamix in Jax."""
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 import functools as ft
 

--- a/src/galax/utils/_boundinstance.py
+++ b/src/galax/utils/_boundinstance.py
@@ -5,7 +5,7 @@ BSD 3-Clause License. The original code can be found at
 https:://github.com/nstarman/bound-class. See the license in the LICENSE files.
 """
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 import weakref
 from dataclasses import dataclass, replace

--- a/src/galax/utils/_jax.py
+++ b/src/galax/utils/_jax.py
@@ -1,6 +1,6 @@
 """galax: Galactic Dynamix in Jax."""
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 import functools as ft
 

--- a/src/galax/utils/_shape.py
+++ b/src/galax/utils/_shape.py
@@ -1,6 +1,6 @@
 """galax: Galactic Dynamix in Jax."""
 
-__all__: list[str] = []
+__all__: tuple[str, ...] = ()
 
 from jaxtyping import Array, Shaped
 from typing import Literal, TypeAlias, overload


### PR DESCRIPTION
Spell empty `__all__` as a tuple: `__all__: tuple[str, ...] = ()` rather than
`__all__: list[str] = []`. 27 modules, matching `coordinax` and `unxt`.

The convention already existed here — `src/galax/setup_package.py` was written this
way — it just wasn't applied anywhere else.

## Two things deliberately left alone

**Non-empty `__all__` stays a list.** Only the empty ones change.

**`dynamics/_src/legacy/mockstream/df/__init__.py` stays a list.** It starts empty but
accumulates:

```python
__all__: list[str] = []
__all__ += base.__all__
...
```

so it is an accumulator that ends up non-empty, not an empty `__all__`. Converting it
raises `TypeError: can only concatenate tuple (not "list") to tuple` and breaks
collection in three test files — its submodules' `__all__` are non-empty, hence lists.

## Checks

- `tests/smoke` + `tests/unit`: 1167 passed, 43 skipped, 14 xfailed
- `src` + `docs` doctests: 5833 passed
- full pre-commit incl. mypy: green

Split out of #799 so that PR stays confined to the namespace-package restructuring;
it will be rebased on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
