### PR TITLE
🎨 style: require `import astropy.coordinates as apyc`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -313,7 +313,12 @@ ignore = [
   "TID252", # Relative imports from parent modules are banned
 ]
 
+[tool.ruff.lint.flake8-import-conventions]
+# `from astropy.coordinates import X` is banned; import the module as `apyc`.
+banned-from = ["astropy.coordinates"]
+
 [tool.ruff.lint.flake8-import-conventions.extend-aliases]
+"astropy.coordinates" = "apyc"
 "coordinax" = "cx"
 "diffrax" = "dfx"
 "diffraxtra" = "dfxtra"

--- a/src/galax/_interop/galax_interop_astropy/coordinates.py
+++ b/src/galax/_interop/galax_interop_astropy/coordinates.py
@@ -25,13 +25,13 @@ def from_(
 
     Examples
     --------
-    >>> import astropy.coordinates as coord
+    >>> import astropy.coordinates as apyc
     >>> import astropy.units as u
     >>> import galax.coordinates as gc
 
-    >>> vec = coord.SphericalRepresentation(
+    >>> vec = apyc.SphericalRepresentation(
     ...     lon=10*u.deg, lat=34*u.deg, distance=3*u.kpc,
-    ...     differentials=coord.SphericalCosLatDifferential(
+    ...     differentials=apyc.SphericalCosLatDifferential(
     ...         d_lon_coslat=1*u.deg/u.Myr, d_lat=1*u.deg/u.Myr,
     ...         d_distance=1*u.kpc/u.Myr) )
     >>> vec
@@ -71,13 +71,13 @@ def from_(
 
     Examples
     --------
-    >>> import astropy.coordinates as coord
+    >>> import astropy.coordinates as apyc
     >>> import astropy.units as u
     >>> import galax.coordinates as gc
 
-    >>> vec = coord.SphericalRepresentation(
+    >>> vec = apyc.SphericalRepresentation(
     ...     lon=10*u.deg, lat=34*u.deg, distance=3*u.kpc,
-    ...     differentials=coord.SphericalCosLatDifferential(
+    ...     differentials=apyc.SphericalCosLatDifferential(
     ...         d_lon_coslat=1*u.deg/u.Myr, d_lat=1*u.deg/u.Myr,
     ...         d_distance=1*u.kpc/u.Myr) )
     >>> vec
@@ -118,13 +118,13 @@ def from_(
 
     Examples
     --------
-    >>> import astropy.coordinates as coord
+    >>> import astropy.coordinates as apyc
     >>> import astropy.units as u
     >>> import galax.coordinates as gc
 
-    >>> vec = coord.SphericalRepresentation(
+    >>> vec = apyc.SphericalRepresentation(
     ...     lon=10*u.deg, lat=34*u.deg, distance=3*u.kpc)
-    >>> dif = coord.SphericalCosLatDifferential(
+    >>> dif = apyc.SphericalCosLatDifferential(
     ...         d_lon_coslat=1*u.deg/u.Myr, d_lat=1*u.deg/u.Myr,
     ...         d_distance=1*u.kpc/u.Myr)
     >>> vec
@@ -163,13 +163,13 @@ def from_(
 
     Examples
     --------
-    >>> import astropy.coordinates as coord
+    >>> import astropy.coordinates as apyc
     >>> import astropy.units as u
     >>> import galax.coordinates as gc
 
-    >>> vec = coord.SphericalRepresentation(
+    >>> vec = apyc.SphericalRepresentation(
     ...     lon=10*u.deg, lat=34*u.deg, distance=3*u.kpc)
-    >>> dif = coord.SphericalCosLatDifferential(
+    >>> dif = apyc.SphericalCosLatDifferential(
     ...         d_lon_coslat=1*u.deg/u.Myr, d_lat=1*u.deg/u.Myr,
     ...         d_distance=1*u.kpc/u.Myr)
     >>> vec

--- a/src/galax/_interop/galax_interop_astropy/potential.py
+++ b/src/galax/_interop/galax_interop_astropy/potential.py
@@ -5,7 +5,7 @@ __all__: tuple[str, ...] = ()
 from jaxtyping import Real
 from typing import Any
 
-from astropy.coordinates import BaseRepresentation
+import astropy.coordinates as apyc
 from astropy.units import Quantity as APYQuantity
 from plum import convert, dispatch
 
@@ -34,7 +34,7 @@ def parse_to_xyz_t(
 @coord_dispatcher
 def parse_to_xyz_t(
     to_frame: cx.frames.AbstractReferenceFrame | None,
-    q: BaseRepresentation,
+    q: apyc.BaseRepresentation,
     t: Any,
     /,
     **kw: Any,

--- a/src/galax/_interop/galax_interop_gala/coordinates.py
+++ b/src/galax/_interop/galax_interop_gala/coordinates.py
@@ -6,9 +6,9 @@ import warnings
 
 from typing import Any
 
+import astropy.coordinates as apyc
 import gala.dynamics as galad
 import plum
-from astropy.coordinates import BaseDifferential, BaseRepresentation
 
 import galax.coordinates as gc
 
@@ -101,8 +101,8 @@ def galax_psp_to_gala_psp(obj: gc.PhaseSpacePosition, /) -> galad.PhaseSpacePosi
     warnings.warn("The frame is not preserved in the conversion!", stacklevel=2)
 
     return galad.PhaseSpacePosition(
-        pos=plum.convert(obj.q, BaseRepresentation),
-        vel=plum.convert(obj.p, BaseDifferential),
+        pos=plum.convert(obj.q, apyc.BaseRepresentation),
+        vel=plum.convert(obj.p, apyc.BaseDifferential),
     )
 
 
@@ -145,6 +145,6 @@ def galax_psp_to_gala_psp(obj: gc.PhaseSpaceCoordinate, /) -> galad.PhaseSpacePo
     )
 
     return galad.PhaseSpacePosition(
-        pos=plum.convert(obj.q, BaseRepresentation),
-        vel=plum.convert(obj.p, BaseDifferential),
+        pos=plum.convert(obj.q, apyc.BaseRepresentation),
+        vel=plum.convert(obj.p, apyc.BaseDifferential),
     )


### PR DESCRIPTION
Import `astropy.coordinates` under the `apyc` alias rather than pulling names out of
it, matching how the codebase already treats other third-party namespaces
(`coordinax as cx`, `unxt as u`, …).

## Enforced, not just conventional

Two ruff rules, so the shape can't drift back:

| Rule | Effect |
| --- | --- |
| `extend-aliases = {"astropy.coordinates" = "apyc"}` | any other alias is `ICN001` |
| `banned-from = ["astropy.coordinates"]` | `from astropy.coordinates import X` is `ICN003` |

I checked both actually fire by running ruff over throwaway files in each shape,
rather than assuming the config took:

```
_probe1.py:1:1: ICN003 Members of `astropy.coordinates` should not be imported explicitly
_probe2.py:1:31: ICN001 `astropy.coordinates` should be imported as `apyc`
```

## What changed

- `_interop/galax_interop_astropy/coordinates.py` — doctests used `as coord`. The
  module already imported `apyc` at the top, so this was inconsistent within one file.
- `_interop/galax_interop_astropy/potential.py` — `from astropy.coordinates import
  BaseRepresentation`
- `_interop/galax_interop_gala/coordinates.py` — `from astropy.coordinates import
  BaseDifferential, BaseRepresentation`

## Checks

- `src/galax/_interop` + `tests/smoke`: 938 passed
- `src` + `docs` doctests: 5833 passed
- full pre-commit incl. mypy: green
- test-merges cleanly with #802

Split out of #799 so that PR stays confined to the namespace-package restructuring;
it will be rebased on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
