### PR TITLE
♻️ refactor: per-subpackage setup_package; move cond_reverse to potential

### DIFF
--- a/src/galax/__init__.py
+++ b/src/galax/__init__.py
@@ -11,7 +11,7 @@ __all__ = [
     "_custom_types",
 ]
 
-from . import _custom_types, setup_package as setup_package
+from . import _custom_types
 
 # isort: split
 from . import coordinates, dynamics, potential, utils

--- a/src/galax/coordinates/__init__.py
+++ b/src/galax/coordinates/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
     "PhaseSpaceObjectInterpolant",
 ]
 
-from galax.setup_package import install_import_hook
+from .setup_package import install_import_hook
 
 with install_import_hook("galax.coordinates"):
     from . import frames, ops

--- a/src/galax/coordinates/setup_package.py
+++ b/src/galax/coordinates/setup_package.py
@@ -1,0 +1,57 @@
+"""`galax.coordinates` package setup.
+
+Copyright (c) 2023 galax maintainers. All rights reserved.
+"""
+
+__all__: tuple[str, ...] = ()
+
+import contextlib
+import os
+
+from collections.abc import Sequence
+from jaxtyping import install_import_hook as _install_import_hook
+from typing import Any, Final, Literal
+
+_RUNTIME_TYPECHECKER: str | None | Literal[False]
+match os.getenv("GALAX_ENABLE_RUNTIME_TYPECHECKING", "False"):
+    case "False":
+        _RUNTIME_TYPECHECKER = False
+    case "None":
+        _RUNTIME_TYPECHECKER = None
+    case str() as _name:
+        _RUNTIME_TYPECHECKER = _name
+
+RUNTIME_TYPECHECKER: Final[str | None | Literal[False]] = _RUNTIME_TYPECHECKER
+"""Runtime type checking variable "GALAX_ENABLE_RUNTIME_TYPECHECKING".
+
+Set to "False" to disable runtime typechecking (default).
+Set to "None" to only enable typechecking for `@jaxtyped`-decorated functions.
+Set to "beartype.beartype" to enable runtime typechecking.
+
+See https://docs.kidger.site/jaxtyping/api/runtime-type-checking for more
+information on options.
+
+"""
+
+
+def install_import_hook(
+    modules: str | Sequence[str], /
+) -> contextlib.AbstractContextManager[Any, None]:
+    """Install the jaxtyping import hook for the given modules.
+
+    Parameters
+    ----------
+    modules
+        Module name or sequence of module names to install the import hook for.
+
+    Returns
+    -------
+    contextlib.AbstractContextManager
+        Context manager that installs the import hook on entry and removes it on exit.
+
+    """
+    return (
+        _install_import_hook(modules, RUNTIME_TYPECHECKER)
+        if RUNTIME_TYPECHECKER is not False
+        else contextlib.nullcontext()
+    )

--- a/src/galax/dynamics/__init__.py
+++ b/src/galax/dynamics/__init__.py
@@ -43,7 +43,7 @@ __all__ = [
 ]
 
 
-from galax.setup_package import install_import_hook
+from .setup_package import install_import_hook
 
 with install_import_hook("galax.dynamics"):
     from diffraxtra import DiffEqSolver

--- a/src/galax/dynamics/_src/legacy/mockstream/mockstream_generator.py
+++ b/src/galax/dynamics/_src/legacy/mockstream/mockstream_generator.py
@@ -24,8 +24,8 @@ from galax.dynamics._src.legacy.integrator import Integrator
 from galax.dynamics._src.mockstream.arm import MockStreamArm
 from galax.dynamics._src.mockstream.core import MockStream
 from galax.dynamics._src.orbit import Orbit
-from galax.dynamics._src.utils import cond_reverse
 from galax.potential import AbstractPotential
+from galax.potential._src.utils import cond_reverse
 
 Carry: TypeAlias = tuple[gt.IntSz0, gt.SzN, gt.SzN]
 

--- a/src/galax/dynamics/_src/utils.py
+++ b/src/galax/dynamics/_src/utils.py
@@ -7,18 +7,15 @@ This is private API.
 __all__ = [
     "parse_saveat",
     "parse_to_t_y",
-    "cond_reverse",
 ]
 
 from dataclasses import replace
 
-from jaxtyping import Array, ArrayLike, Bool
-from typing import Any, TypeAlias, TypeVar, cast
+from jaxtyping import ArrayLike
+from typing import Any, TypeAlias
 
 import diffrax as dfx
 import equinox as eqx
-import jax
-import optype as op
 from plum import convert, dispatch
 
 import coordinax.frames as cxf
@@ -537,19 +534,3 @@ def parse_to_t_y(
 
 
 #####################################################################
-
-
-T_co = TypeVar("T_co", covariant=True)
-
-
-def _identity[T](x: T) -> T:
-    return x
-
-
-def _reverse[T](x: op.CanGetitem[Any, T]) -> T:
-    return x[::-1]
-
-
-def cond_reverse[T](pred: Bool[Array, ""], x: T) -> T:
-    """Reverse `x` if `pred` is True."""
-    return cast("T", jax.lax.cond(pred, _reverse, _identity, x))

--- a/src/galax/dynamics/cluster.py
+++ b/src/galax/dynamics/cluster.py
@@ -23,7 +23,7 @@ __all__ = [
     "relaxation_time",
 ]
 
-from galax.setup_package import install_import_hook
+from .setup_package import install_import_hook
 
 with install_import_hook("galax.dynamics.fields"):
     from ._src.cluster import (

--- a/src/galax/dynamics/examples.py
+++ b/src/galax/dynamics/examples.py
@@ -14,7 +14,7 @@ __all__ = [
     "radial_velocity_dispersion_helper",
 ]
 
-from galax.setup_package import install_import_hook
+from .setup_package import install_import_hook
 
 with install_import_hook("galax.dynamics.examples"):
     from ._src.examples.mw_lmc import (

--- a/src/galax/dynamics/fields.py
+++ b/src/galax/dynamics/fields.py
@@ -7,7 +7,7 @@ __all__ = [
     "NBodyField",
 ]
 
-from galax.setup_package import install_import_hook
+from .setup_package import install_import_hook
 
 with install_import_hook("galax.dynamics.fields"):
     from ._src.fields import AbstractField

--- a/src/galax/dynamics/integrate.py
+++ b/src/galax/dynamics/integrate.py
@@ -8,7 +8,7 @@ __all__ = [
     "InterpolatedPhaseSpaceCoordinate",
 ]
 
-from galax.setup_package import install_import_hook
+from .setup_package import install_import_hook
 
 with install_import_hook("galax.dynamics.integrate"):
     from ._src.legacy import (

--- a/src/galax/dynamics/mockstream.py
+++ b/src/galax/dynamics/mockstream.py
@@ -12,7 +12,7 @@ __all__ = [
     "ConstantMassProtenitor",
 ]
 
-from galax.setup_package import install_import_hook
+from .setup_package import install_import_hook
 
 with install_import_hook("galax.dynamics.dynamics"):
     from ._src.legacy.mockstream import MockStreamGenerator

--- a/src/galax/dynamics/orbit.py
+++ b/src/galax/dynamics/orbit.py
@@ -9,7 +9,7 @@ __all__ = [
     "PhaseSpaceInterpolation",
 ]
 
-from galax.setup_package import install_import_hook
+from .setup_package import install_import_hook
 
 with install_import_hook("galax.dynamics.solve"):
     from ._src.orbit import Orbit, OrbitSolver, PhaseSpaceInterpolation, compute_orbit

--- a/src/galax/dynamics/plot.py
+++ b/src/galax/dynamics/plot.py
@@ -4,7 +4,7 @@ __all__ = [
     "plot_components",
 ]
 
-from galax.setup_package import install_import_hook
+from .setup_package import install_import_hook
 
 with install_import_hook("galax.dynamics.plot"):
     from ._src.orbit import plot_components

--- a/src/galax/dynamics/setup_package.py
+++ b/src/galax/dynamics/setup_package.py
@@ -1,0 +1,57 @@
+"""`galax.dynamics` package setup.
+
+Copyright (c) 2023 galax maintainers. All rights reserved.
+"""
+
+__all__: tuple[str, ...] = ()
+
+import contextlib
+import os
+
+from collections.abc import Sequence
+from jaxtyping import install_import_hook as _install_import_hook
+from typing import Any, Final, Literal
+
+_RUNTIME_TYPECHECKER: str | None | Literal[False]
+match os.getenv("GALAX_ENABLE_RUNTIME_TYPECHECKING", "False"):
+    case "False":
+        _RUNTIME_TYPECHECKER = False
+    case "None":
+        _RUNTIME_TYPECHECKER = None
+    case str() as _name:
+        _RUNTIME_TYPECHECKER = _name
+
+RUNTIME_TYPECHECKER: Final[str | None | Literal[False]] = _RUNTIME_TYPECHECKER
+"""Runtime type checking variable "GALAX_ENABLE_RUNTIME_TYPECHECKING".
+
+Set to "False" to disable runtime typechecking (default).
+Set to "None" to only enable typechecking for `@jaxtyped`-decorated functions.
+Set to "beartype.beartype" to enable runtime typechecking.
+
+See https://docs.kidger.site/jaxtyping/api/runtime-type-checking for more
+information on options.
+
+"""
+
+
+def install_import_hook(
+    modules: str | Sequence[str], /
+) -> contextlib.AbstractContextManager[Any, None]:
+    """Install the jaxtyping import hook for the given modules.
+
+    Parameters
+    ----------
+    modules
+        Module name or sequence of module names to install the import hook for.
+
+    Returns
+    -------
+    contextlib.AbstractContextManager
+        Context manager that installs the import hook on entry and removes it on exit.
+
+    """
+    return (
+        _install_import_hook(modules, RUNTIME_TYPECHECKER)
+        if RUNTIME_TYPECHECKER is not False
+        else contextlib.nullcontext()
+    )

--- a/src/galax/potential/__init__.py
+++ b/src/galax/potential/__init__.py
@@ -69,7 +69,7 @@ __all__ = [
     "d2potential_dr2",
 ]
 
-from galax.setup_package import install_import_hook
+from .setup_package import install_import_hook
 
 with install_import_hook("galax.potential"):
     from . import io, params, plot

--- a/src/galax/potential/_src/utils.py
+++ b/src/galax/potential/_src/utils.py
@@ -4,11 +4,13 @@ __all__: tuple[str, ...] = ()
 
 import functools as ft
 
-from typing import Any, TypeAlias
+from jaxtyping import Array, Bool
+from typing import Any, TypeAlias, cast
 
 import equinox as eqx
 import jax
 import numpy as np
+import optype as op
 from jax.dtypes import canonicalize_dtype
 from plum import Dispatcher, convert
 
@@ -578,3 +580,22 @@ def parse_to_xyz_t(
     return parse_to_xyz_t(
         None, wt.q, jnp.asarray(wt.t, dtype=dtype), dtype=dtype, ustrip=ustrip
     )
+
+
+# ============================================================================
+# Moved here from `galax.dynamics._src.utils`: `potential` is the lower
+# subpackage of the two that use it, so keeping it in `dynamics` meant
+# `potential` importing upward.
+
+
+def _identity[T](x: T) -> T:
+    return x
+
+
+def _reverse[T](x: op.CanGetitem[Any, T]) -> T:
+    return x[::-1]
+
+
+def cond_reverse[T](pred: Bool[Array, ""], x: T) -> T:
+    """Reverse `x` if `pred` is True."""
+    return cast("T", jax.lax.cond(pred, _reverse, _identity, x))

--- a/src/galax/potential/_src/xfm/translate.py
+++ b/src/galax/potential/_src/xfm/translate.py
@@ -19,10 +19,10 @@ from unxt.quantity import AllowValue
 
 import galax._custom_types as gt
 from .base import AbstractTransformedPotential
-from galax.dynamics._src.utils import cond_reverse
 from galax.potential._src.base import AbstractPotential
 from galax.potential._src.params.base import AbstractParameter
 from galax.potential._src.params.field import ParameterField
+from galax.potential._src.utils import cond_reverse
 
 
 @final

--- a/src/galax/potential/setup_package.py
+++ b/src/galax/potential/setup_package.py
@@ -1,4 +1,4 @@
-"""Galax package setup.
+"""`galax.potential` package setup.
 
 Copyright (c) 2023 galax maintainers. All rights reserved.
 """


### PR DESCRIPTION
Two independent steps toward letting `coordinates`, `potential` and `dynamics` stand
on their own. Neither depends on the namespace-package work; both are split out of
#799 so that PR stays confined to the restructuring itself.

## 1. Each subpackage gets its own `setup_package`

`coordinax` and `unxt` each ship a byte-identical `setup_package.py` differing only in
the env-var name, so duplicating it is the established convention across these
packages rather than a workaround. All three copies read
`GALAX_ENABLE_RUNTIME_TYPECHECKING`, so behaviour is unchanged.

This removes the last 10 cross-subpackage imports of a shared `galax` module.

`galax.setup_package` is deleted with no shim — it was never in `galax.__all__` and
has no references in tests or docs.

## 2. `cond_reverse` moves to `galax.potential`

It's a generic jax helper with one consumer in `potential` and one in `dynamics`, but
it lived in `galax.dynamics._src.utils`, so `potential/_src/xfm/translate.py` imported
it **upward** at module level — the only module-level `potential` → `dynamics` import
in the codebase. Moving it reverses the direction; `dynamics` now imports it downward,
as it already does for `coord_dispatcher` and `speed_of_light` from that same module.

`T_co` goes with it: defined beside these helpers and never used.

## Checks

- `src` + `docs` + `tests/smoke` + `tests/unit`: 7000 passed, 43 skipped, 14 xfailed
- full pre-commit incl. mypy: green

#799 will be rebased on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
