### PR TITLE
config: add quax to the mypy pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,6 +83,7 @@ repos:
           - dataclassish
           - optype
           - plum-dispatch>=2.5.7
+          - quax
 
   - repo: https://github.com/codespell-project/codespell
     rev: "v2.3.0"

--- a/src/galax/_interop/galax_interop_gala/potential.py
+++ b/src/galax/_interop/galax_interop_gala/potential.py
@@ -297,7 +297,7 @@ if OptDeps.GALA.installed and (Version("1.8.2") <= OptDeps.GALA):
         )
         return _apply_xop(_get_xop(gala), pot)
 
-    @dispatch
+    @dispatch  # type: ignore[misc]
     def galax_to_gala(pot: gp.BurkertPotential, /) -> galap.BurkertPotential:
         """Convert a `galax.potential.BurkertPotential` to a `gala.potential.BurkertPotential`.
 
@@ -1207,6 +1207,7 @@ def gala_to_galax(
         or params["q3"] != 1
         or params["phi"] != 0
     ):
+        pot: gp.LogarithmicPotential | gp.LMJ09LogarithmicPotential
         pot = gp.LMJ09LogarithmicPotential(
             v_c=params["v_c"],
             r_s=params["r_h"],

--- a/src/galax/_interop/galax_interop_galpy/potential.py
+++ b/src/galax/_interop/galax_interop_galpy/potential.py
@@ -101,15 +101,13 @@ def convert_potential(
 # Helper functions
 
 
-def _error_if_not_all_constant_parameters(
-    pot: gp.AbstractPotential,
-) -> gp.AbstractPotential:
+def _error_if_not_all_constant_parameters[PT: gp.AbstractPotential](pot: PT) -> PT:
     """Check if all parameters are constant."""
     is_time_dep = any(
         not isinstance(getattr(pot, name), gp.params.ConstantParameter)
         for name in pot.parameters
     )
-    pot: gp.AbstractPotential = eqx.error_if(
+    pot = eqx.error_if(
         pot, is_time_dep, "Gala does not support time-dependent parameters."
     )
     return pot

--- a/src/galax/coordinates/_src/base.py
+++ b/src/galax/coordinates/_src/base.py
@@ -423,7 +423,9 @@ class AbstractPhaseSpaceObject(cx.frames.AbstractCoordinate):  # type: ignore[mi
         """
         usys = u.unitsystem(units)
         q, p = self._qp(units=usys)
-        return jnp.concat((q.ustrip(usys["length"]), p.ustrip(usys["speed"])), axis=-1)
+        qarr, parr = q.ustrip(usys["length"]), p.ustrip(usys["speed"])
+        _result = jnp.concat((qarr, parr), axis=-1)
+        return _result  # type: ignore[no-any-return]
 
     # ==========================================================================
     # Dynamical quantities

--- a/src/galax/coordinates/_src/pscs/base.py
+++ b/src/galax/coordinates/_src/pscs/base.py
@@ -174,7 +174,7 @@ class AbstractPhaseSpaceCoordinate(AbstractPhaseSpaceObject):
         q = jnp.broadcast_to(convert(cart.q, FastQ), (*batch, comps.q))
         p = jnp.broadcast_to(convert(cart.p, FastQ), (*batch, comps.p))
         t = jnp.broadcast_to(self.t.ustrip(usys["time"])[..., None], (*batch, comps.t))
-        return jnp.concat((t, q.value, p.value), axis=-1)
+        return jnp.concat((t, q.value, p.value), axis=-1)  # type: ignore[no-any-return]
 
     # ==========================================================================
     # Dynamical quantities

--- a/src/galax/coordinates/_src/pscs/composite.py
+++ b/src/galax/coordinates/_src/pscs/composite.py
@@ -187,6 +187,6 @@ class CompositePhaseSpaceCoordinate(AbstractCompositePhaseSpaceCoordinate):
         ]
 
     @property
-    def frame(self) -> cxf.AbstractReferenceFrame:
+    def frame(self) -> cxf.AbstractReferenceFrame:  # type: ignore[override]
         """The reference frame."""
         return self._frame

--- a/src/galax/coordinates/_src/pscs/register_primitives.py
+++ b/src/galax/coordinates/_src/pscs/register_primitives.py
@@ -12,7 +12,7 @@ import quaxed.numpy as jnp
 from .base import AbstractPhaseSpaceCoordinate
 
 
-@register(jax.lax.add_p)  # type: ignore[misc]
+@register(jax.lax.add_p)
 def add_wts(
     wt1: AbstractPhaseSpaceCoordinate, wt2: AbstractPhaseSpaceCoordinate, /
 ) -> AbstractPhaseSpaceCoordinate:

--- a/src/galax/coordinates/_src/psps/register_primitives.py
+++ b/src/galax/coordinates/_src/psps/register_primitives.py
@@ -10,7 +10,7 @@ from quax import register
 from .core import PhaseSpacePosition
 
 
-@register(jax.lax.add_p)  # type: ignore[misc]
+@register(jax.lax.add_p)
 def add_psps(
     psp1: PhaseSpacePosition, psp2: PhaseSpacePosition, /
 ) -> PhaseSpacePosition:

--- a/src/galax/coordinates/_src/shape.py
+++ b/src/galax/coordinates/_src/shape.py
@@ -6,11 +6,11 @@
 
 __all__: tuple[str, ...] = ()
 
-from collections.abc import Callable
 from jaxtyping import Array, Shaped
-from typing import Any, Literal, TypeAlias, cast, overload
+from typing import Literal, TypeAlias, overload
 
 import quax
+from quax import quaxify
 
 import coordinax as cx
 import quaxed.numpy as jnp
@@ -19,16 +19,6 @@ import galax._custom_types as gt
 
 AnyScalar: TypeAlias = Shaped[Array, ""]
 ArrayAnyShape: TypeAlias = Shaped[Array | quax.ArrayValue, "..."]
-
-
-def quaxify[**P, R](fn: Callable[P, R], *, filter_spec: Any = True) -> Callable[P, R]:
-    """Wrap a function with `quax.quaxify`, preserving its signature.
-
-    `quax.quaxify` is untyped, so decorating with it directly makes the
-    decorated function untyped too. The `cast` keeps type checkers seeing the
-    original signature.
-    """
-    return cast("Callable[P, R]", quax.quaxify(fn, filter_spec=filter_spec))
 
 
 def vector_batched_shape(obj: cx.vecs.AbstractVector, /) -> tuple[gt.Shape, int]:

--- a/src/galax/dynamics/_src/cluster/dmdt.py
+++ b/src/galax/dynamics/_src/cluster/dmdt.py
@@ -250,7 +250,8 @@ class ConstantMassRate(AbstractMassRateField):
         **kwargs: Any,  # noqa: ARG002
     ) -> Shaped[Array, "{M}"]:
         unit = self.units["mass"] / self.units["time"]
-        return u.ustrip(AllowValue, unit, self.dm_dt) * jnp.ones_like(M)
+        _result = u.ustrip(AllowValue, unit, self.dm_dt) * jnp.ones_like(M)
+        return _result  # type: ignore[no-any-return]
 
 
 ######################################################
@@ -342,4 +343,5 @@ class Baumgardt1998MassLossRate(AbstractMassRateField):
         dmdt = (
             -args["xi0"] * jnp.sqrt(1.0 + (args["alpha"] * r_ratio) ** 3) * Mq / t_relax
         )
-        return u.ustrip(usys["mass"] / usys["time"], dmdt)
+        _result = u.ustrip(usys["mass"] / usys["time"], dmdt)
+        return _result  # type: ignore[no-any-return]

--- a/src/galax/dynamics/_src/cluster/events.py
+++ b/src/galax/dynamics/_src/cluster/events.py
@@ -13,7 +13,7 @@ import unxt as u
 from unxt.quantity import AllowValue
 
 
-class MassBelowThreshold(eqx.Module):  # type: ignore[misc]
+class MassBelowThreshold(eqx.Module):
     """Event to stop integration when the mass falls below a threshold.
 
     Instances can be used as the ``cond_fn`` argument of `diffrax.Event`. Since
@@ -88,4 +88,5 @@ class MassBelowThreshold(eqx.Module):  # type: ignore[misc]
 
         """
         mu = args["units"]["mass"]
-        return u.ustrip(AllowValue, mu, y) - self.threshold.ustrip(mu)
+        _result = u.ustrip(AllowValue, mu, y) - self.threshold.ustrip(mu)
+        return _result  # type: ignore[no-any-return]

--- a/src/galax/dynamics/_src/cluster/sample.py
+++ b/src/galax/dynamics/_src/cluster/sample.py
@@ -22,7 +22,7 @@ import unxt as u
 from .dmdt import AbstractMassRateField
 
 
-class ReleaseTimeSampler(eqx.Module):  # type: ignore[misc]
+class ReleaseTimeSampler(eqx.Module):
     """Release time sampler.
 
     This requires a dense mass history solution.

--- a/src/galax/dynamics/_src/cluster/solver.py
+++ b/src/galax/dynamics/_src/cluster/solver.py
@@ -182,7 +182,7 @@ default_saveat = dfx.SaveAt(t1=True)
 
 
 @MassSolver.solve.dispatch  # type: ignore[misc,union-attr]
-@eqx.filter_jit  # type: ignore[misc]
+@eqx.filter_jit
 def solve(
     self: MassSolver,
     field: AbstractMassRateField | MassVectorField,

--- a/src/galax/dynamics/_src/examples/mw_lmc.py
+++ b/src/galax/dynamics/_src/examples/mw_lmc.py
@@ -89,7 +89,7 @@ def radial_velocity_dispersion_helper(  # TODO: better name
     integral = trapezoid(integrand, x=r_grid)
 
     sigma2 = jnp.power(r, -2 * beta) / innermost_density * integral
-    return jnp.sqrt(sigma2)
+    return jnp.sqrt(sigma2)  # type: ignore[no-any-return]
 
 
 @final
@@ -181,11 +181,13 @@ class RigidMWandLMCField(AbstractField):
         """Mass of the LMC."""
         xyz = jnp.array([100.0, 0, 0])
         t = jnp.array(0.0)
-        return gp.spherical_mass_enclosed(self.lmc_pot, xyz, t)
+        return gp.spherical_mass_enclosed(self.lmc_pot, xyz, t)  # type: ignore[return-value]
 
     @override  # specify the signature of the `__call__` method.
     @dispatch.abstract
-    def __call__(self, *_: Any, **kw: Any) -> tuple[Any, Any]:
+    def __call__(  # type: ignore[override]
+        self, *_: Any, **kw: Any
+    ) -> tuple[Any, Any]:
         """Evaluate the field at a given coordinate."""
         raise NotImplementedError  # pragma: no cover
 
@@ -284,7 +286,7 @@ def _sigma_fn(_: gt.Sz3, /) -> gt.Sz0:
     Maps (Array[float, (3)]) -> Array[float, ()].
 
     """
-    return u.Q(130, "km/s").ustrip("kpc/Myr")
+    return u.Q(130, "km/s").ustrip("kpc/Myr")  # type: ignore[no-any-return]
 
 
 t_interp = u.Q(jnp.linspace(0, -14, 10_000), "Gyr")

--- a/src/galax/dynamics/_src/examples/uniform_acceleration.py
+++ b/src/galax/dynamics/_src/examples/uniform_acceleration.py
@@ -73,7 +73,8 @@ class UniformAcceleration(gp.AbstractSinglePotential):
             t = u.ustrip(AllowValue, self.units["time"], t)
 
         grad = jax.jacfwd(self.velocity_func)(t)
-        return u.ustrip(AllowValue, self.units["acceleration"], grad)
+        _result = u.ustrip(AllowValue, self.units["acceleration"], grad)
+        return _result  # type: ignore[no-any-return]
 
     @ft.partial(jax.jit)
     def _hessian(
@@ -83,4 +84,4 @@ class UniformAcceleration(gp.AbstractSinglePotential):
         xyz = u.ustrip(AllowValue, self.units["length"], xyz)
         t = u.ustrip(AllowValue, self.units["time"], t)
         hess_op = jax.jacfwd(self._gradient, argnums=0)
-        return hess_op(xyz, t)
+        return hess_op(xyz, t)  # type: ignore[no-any-return]

--- a/src/galax/dynamics/_src/experimental/integrate.py
+++ b/src/galax/dynamics/_src/experimental/integrate.py
@@ -139,7 +139,7 @@ def parse_t0_t1_saveat(
             t0=False, t1=False, ts=ts if not dense else None, dense=dense, steps=False
         )
 
-    return t0, t1, saver
+    return t0, t1, saver  # type: ignore[return-value]
 
 
 # =============================================================================

--- a/src/galax/dynamics/_src/experimental/stream.py
+++ b/src/galax/dynamics/_src/experimental/stream.py
@@ -224,11 +224,13 @@ class StreamSimulator:
         # Scan over the release times/xs/vs/ms to generate the stream particle's
         # initial conditions.
         _, all_states = jax.lax.scan(
-            scan_fn, init_carry, (release_times, prog_xs, prog_vs, Msat)
+            scan_fn,  # type: ignore[arg-type]
+            init_carry,
+            (release_times, prog_xs, prog_vs, Msat),
         )
         return StreamICs(
             release_times,
-            prog_mass=Msat,
+            prog_mass=Msat,  # type: ignore[arg-type]
             qp_lead=all_states[0:2],
             qp_trail=all_states[2:4],
         )

--- a/src/galax/dynamics/_src/fields.py
+++ b/src/galax/dynamics/_src/fields.py
@@ -17,7 +17,7 @@ import diffraxtra as dfxtra
 import unxt as u
 
 
-class AbstractField(eqx.Module):  # type: ignore[misc]
+class AbstractField(eqx.Module):
     """Abstract base class for fields.
 
     Methods

--- a/src/galax/dynamics/_src/legacy/integrator.py
+++ b/src/galax/dynamics/_src/legacy/integrator.py
@@ -40,7 +40,7 @@ default_stepsize_controller = dfx.PIDController(rtol=1e-7, atol=1e-7)
 
 
 @final
-class Integrator(eqx.Module):  # type: ignore[misc]
+class Integrator(eqx.Module):
     """Integrator using :func:`diffrax.diffeqsolve`.
 
     This integrator uses the :func:`diffrax.diffeqsolve` function to integrate

--- a/src/galax/dynamics/_src/legacy/mockstream/df/base.py
+++ b/src/galax/dynamics/_src/legacy/mockstream/df/base.py
@@ -25,7 +25,7 @@ from galax.dynamics._src.orbit import Orbit
 Carry: TypeAlias = tuple[gt.QuSz3, gt.QuSz3, gt.QuSz3, gt.QuSz3]
 
 
-class AbstractStreamDF(eqx.Module):  # type: ignore[misc]
+class AbstractStreamDF(eqx.Module):
     """Abstract base class of Stream Distribution Functions."""
 
     @ft.partial(jax.jit)

--- a/src/galax/dynamics/_src/legacy/mockstream/df/progenitor.py
+++ b/src/galax/dynamics/_src/legacy/mockstream/df/progenitor.py
@@ -27,7 +27,7 @@ class ProgenitorMassCallable(Protocol):
         ...
 
 
-class ConstantMassProtenitor(eqx.Module):  # type: ignore[misc]
+class ConstantMassProtenitor(eqx.Module):
     """Progenitor mass callable that returns a constant mass.
 
     Parameters

--- a/src/galax/dynamics/_src/legacy/mockstream/mockstream_generator.py
+++ b/src/galax/dynamics/_src/legacy/mockstream/mockstream_generator.py
@@ -31,7 +31,7 @@ Carry: TypeAlias = tuple[gt.IntSz0, gt.SzN, gt.SzN]
 
 
 @final
-class MockStreamGenerator(eqx.Module):  # type: ignore[misc]
+class MockStreamGenerator(eqx.Module):
     """Generate a mock stellar stream in the specified external potential."""
 
     df: AbstractStreamDF
@@ -104,7 +104,7 @@ class MockStreamGenerator(eqx.Module):  # type: ignore[misc]
 
             def integ_ics(ics: gt.Sz6) -> gt.SzN:
                 # TODO: only return the final state
-                return evaluate_orbit(
+                return evaluate_orbit(  # type: ignore[no-any-return]
                     self.potential, ics, tstep, integrator=self.stream_integrator
                 ).w(units=self.units)[-1]
 
@@ -117,7 +117,11 @@ class MockStreamGenerator(eqx.Module):  # type: ignore[misc]
 
         carry_init = (0, w0_lead[0, :], w0_trail[0, :])
         pt_ids = jnp.arange(len(w0_lead))
-        lead_arm_w, trail_arm_w = jax.lax.scan(one_pt_intg, carry_init, pt_ids)[1]
+        lead_arm_w, trail_arm_w = jax.lax.scan(
+            one_pt_intg,  # type: ignore[arg-type]
+            carry_init,
+            pt_ids,
+        )[1]
 
         return lead_arm_w, trail_arm_w
 

--- a/src/galax/dynamics/_src/mockstream/core.py
+++ b/src/galax/dynamics/_src/mockstream/core.py
@@ -79,6 +79,6 @@ class MockStream(gc.AbstractCompositePhaseSpaceCoordinate):
         ]
 
     @property
-    def frame(self) -> cx.frames.AbstractReferenceFrame:
+    def frame(self) -> cx.frames.AbstractReferenceFrame:  # type: ignore[override]
         """The reference frame of the phase-space position."""
         return self._frame

--- a/src/galax/dynamics/_src/orbit/field_base.py
+++ b/src/galax/dynamics/_src/orbit/field_base.py
@@ -27,7 +27,9 @@ class AbstractOrbitField(AbstractField):
 
     @override  # specify the signature of the `__call__` method.
     @dispatch.abstract
-    def __call__(self, *_: Any, **kw: Any) -> tuple[Any, Any]:
+    def __call__(  # type: ignore[override]
+        self, *_: Any, **kw: Any
+    ) -> tuple[Any, Any]:
         raise NotImplementedError  # pragma: no cover
 
     @override

--- a/src/galax/dynamics/_src/orbit/field_hamiltonian.py
+++ b/src/galax/dynamics/_src/orbit/field_hamiltonian.py
@@ -229,7 +229,7 @@ class HamiltonianField(AbstractOrbitField):
     #: Potential.
     potential: gp.AbstractPotential
 
-    @property
+    @property  # type: ignore[misc]
     def units(self) -> u.AbstractUnitSystem:
         return self.potential.units
 
@@ -237,15 +237,16 @@ class HamiltonianField(AbstractOrbitField):
     # Symplectic integration terms
     # TODO: enable full gamut of inputs
 
-    @jax.jit  # type: ignore[misc]
+    @jax.jit
     def dx_dt(self, t: Any, v_xyz: gdt.BBtParr, args: Any, /) -> gdt.BBtParr:  # noqa: ARG002
         """Call with time, position quantity arrays."""
         return v_xyz
 
-    @jax.jit  # type: ignore[misc]
+    @jax.jit
     def dv_dt(self, t: gt.BBtSz0, xyz: gdt.BBtQarr, _: Any, /) -> gdt.BtAarr:
         """Call with time, velocity quantity arrays."""
-        return -self.potential._gradient(xyz, t)  # noqa: SLF001
+        grad = self.potential._gradient(xyz, t)  # noqa: SLF001
+        return -grad  # type: ignore[no-any-return]
 
 
 # ===============================================

--- a/src/galax/dynamics/_src/orbit/field_nbody.py
+++ b/src/galax/dynamics/_src/orbit/field_nbody.py
@@ -67,7 +67,7 @@ class NBodyField(AbstractOrbitField):
         default=gp.NullPotential(units="galactic")
     )
 
-    @property
+    @property  # type: ignore[misc]
     def units(self) -> u.AbstractUnitSystem:
         return self.external_potential.units
 
@@ -75,9 +75,10 @@ class NBodyField(AbstractOrbitField):
     def _G(self) -> gt.Sz0:
         us = self.units
         unit = us["length"] ** 3 / (us["mass"] * us["time"] ** 2)
-        return self.external_potential.constants["G"].ustrip(unit)
+        _result = self.external_potential.constants["G"].ustrip(unit)
+        return _result  # type: ignore[no-any-return]
 
-    @dispatch.abstract
+    @dispatch.abstract  # type: ignore[override]
     def __call__(
         self, t: Any, qp: tuple[Any, Any], args: tuple[Any, ...], /
     ) -> tuple[Any, Any]:
@@ -85,7 +86,7 @@ class NBodyField(AbstractOrbitField):
 
 
 @NBodyField.__call__.dispatch  # type: ignore[misc,union-attr]
-@jax.jit  # type: ignore[misc]
+@jax.jit
 def __call__(
     self: "NBodyField",
     t: gt.LikeSz0,
@@ -104,12 +105,12 @@ def __call__(
     diffs = x[:, None, :] - x[None, :, :]  # (N, N, 3)
 
     # Compute softened squared distances.
-    eps = self.eps.ustrip(units["length"])
+    eps = u.ustrip(AllowValue, units["length"], self.eps)
     soft_d2s = jnp.sum(diffs**2, axis=-1)[:, :, None] + eps**2  # (N, N, 1)
     soft_d3s = soft_d2s * jnp.sqrt(soft_d2s)  # (N, N, 1)
 
     # Compute pairwise forces.
-    ms = self.masses.ustrip(units["mass"])  # (N,)
+    ms = u.ustrip(AllowValue, units["mass"], self.masses)  # (N,)
     m2s = ms[:, None, None] * ms[None, :, None]  # (N, N, 1)
     forces = self._G * m2s / soft_d3s * diffs  # (N, N, 3)
 

--- a/src/galax/dynamics/_src/orbit/interp.py
+++ b/src/galax/dynamics/_src/orbit/interp.py
@@ -32,13 +32,14 @@ import galax.coordinates as gc
 def within_bounds(
     t: Real[Array, "N"], t_lower: Real[Array, ""], t_upper: Real[Array, ""]
 ) -> Bool[Array, "N"]:
-    return jnp.logical_and(jnp.greater_equal(t, t_lower), jnp.less_equal(t, t_upper))
+    _result = jnp.logical_and(jnp.greater_equal(t, t_lower), jnp.less_equal(t, t_upper))
+    return _result  # type: ignore[no-any-return]
 
 
 # TODO: move this to galax.coordinates?
 # TODO: address mypy complaints about subclassing
 # AbstractVectorizedDenseInterpolation
-class PhaseSpaceInterpolation(eqx.Module):  # type: ignore[misc]
+class PhaseSpaceInterpolation(eqx.Module):
     """Evaluate phase-space interpolations."""
 
     #: The vectorized interpolation object.
@@ -49,7 +50,7 @@ class PhaseSpaceInterpolation(eqx.Module):  # type: ignore[misc]
     #: The unit system for the interpolation.
     units: u.AbstractUnitSystem = eqx.field(static=True, converter=u.unitsystem)
 
-    @eqx.filter_jit  # type: ignore[misc]
+    @eqx.filter_jit
     def evaluate(self, ts: Any) -> gc.PhaseSpaceCoordinate:
         usys = self.units
         t = FastQ.from_(ts, usys["time"])
@@ -98,7 +99,7 @@ class PhaseSpaceInterpolation(eqx.Module):  # type: ignore[misc]
         return cast(int, self.interp.batch_ndim)
 
     def __call__(self, *args: Any, **kwds: Any) -> gc.PhaseSpaceCoordinate:
-        return cast(gc.PhaseSpaceCoordinate, self.evaluate(*args, **kwds))
+        return self.evaluate(*args, **kwds)
 
     @property
     def t0(self) -> BatchedRealScalar:
@@ -118,7 +119,7 @@ class PhaseSpaceInterpolation(eqx.Module):  # type: ignore[misc]
     @property
     def ts_size(self) -> Int[Array, "..."]:  # TODO: shape
         """The number of times in the interpolation."""
-        return self.interp.ts_size
+        return self.interp.ts_size  # type: ignore[no-any-return]
 
     @property
     def infos(self) -> VecDenseInfos:

--- a/src/galax/dynamics/_src/solver.py
+++ b/src/galax/dynamics/_src/solver.py
@@ -37,7 +37,7 @@ DfxRealScalarLike: TypeAlias = Real[int | float | Array | np.ndarray[Any, Any], 
 # SolveState
 
 
-class SolveState(eqx.Module):  # type: ignore[misc]
+class SolveState(eqx.Module):
     """State of the solver.
 
     This is used as the return value for `galax.dynamics.AbstractSolver.init`
@@ -255,13 +255,13 @@ def _parse_t0_t1(
         return t0, t1
 
     def t0_t1_are_different() -> tuple[gt.Sz0, gt.Sz0]:
-        return t0, t1
+        return t0, t1  # type: ignore[return-value]
 
     t0, t1 = jax.lax.cond(t0 != t1, t0_t1_are_different, t0_t1_are_same)
-    return t0, t1
+    return t0, t1  # type: ignore[return-value]
 
 
-@ft.partial(eqx.filter_jit)
+@eqx.filter_jit
 def integrate_field(
     field: AbstractField,
     y0: PyTree[Array],

--- a/src/galax/potential/_src/base.py
+++ b/src/galax/potential/_src/base.py
@@ -40,7 +40,7 @@ DimT = u.dimension("time")
 ##############################################################################
 
 
-class AbstractPotential(eqx.Module, metaclass=ModuleMeta):  # type: ignore[misc]
+class AbstractPotential(eqx.Module, metaclass=ModuleMeta):
     """Abstract Potential Class."""
 
     parameters: ClassVar = ParametersAttribute(MappingProxyType({}))
@@ -176,7 +176,7 @@ class AbstractPotential(eqx.Module, metaclass=ModuleMeta):  # type: ignore[misc]
         xyz = u.ustrip(AllowValue, self.units[DimL], xyz)
         t = u.ustrip(AllowValue, self.units[DimT], t)
         grad_op = jax.grad(self._potential)
-        return grad_op(xyz, t)
+        return grad_op(xyz, t)  # type: ignore[no-any-return]
 
     def gradient(self, *args: Any, **kwargs: Any) -> Any:
         """Compute the gradient of the potential at the given position(s).
@@ -197,7 +197,7 @@ class AbstractPotential(eqx.Module, metaclass=ModuleMeta):  # type: ignore[misc]
         xyz = u.ustrip(AllowValue, self.units[DimL], xyz)
         t = u.ustrip(AllowValue, self.units[DimT], t)
         hess_op = jax.hessian(self._potential, argnums=0)
-        return jnp.trace(hess_op(xyz, t))
+        return jnp.trace(hess_op(xyz, t))  # type: ignore[no-any-return]
 
     def laplacian(self, *args: Any, **kwargs: Any) -> u.Quantity["1/s^2"] | Array:
         """Compute the laplacian of the potential at the given position(s).
@@ -214,7 +214,8 @@ class AbstractPotential(eqx.Module, metaclass=ModuleMeta):  # type: ignore[misc]
         """See ``density``."""
         # Note: trace(jacobian(gradient)) is faster than trace(hessian(energy))
         laplacian = self._laplacian(q, t)
-        return laplacian / (4 * jnp.pi * self.constants["G"].value)
+        _result = laplacian / (4 * jnp.pi * self.constants["G"].value)
+        return _result  # type: ignore[no-any-return]
 
     def density(self, *args: Any, **kwargs: Any) -> gt.BBtFloatSz0 | gt.BBtFloatQuSz0:
         """Compute the density at the given position(s).
@@ -235,7 +236,7 @@ class AbstractPotential(eqx.Module, metaclass=ModuleMeta):  # type: ignore[misc]
         xyz = u.ustrip(AllowValue, self.units[DimL], xyz)
         t = u.ustrip(AllowValue, self.units[DimT], t)
         hess_op = jax.hessian(self._potential)
-        return hess_op(xyz, t)
+        return hess_op(xyz, t)  # type: ignore[no-any-return]
 
     def hessian(self, *args: Any, **kwargs: Any) -> gt.BBtQuSz33 | gt.BBtSz33:
         """Compute the hessian of the potential at the given position(s).

--- a/src/galax/potential/_src/base_multi.py
+++ b/src/galax/potential/_src/base_multi.py
@@ -40,7 +40,7 @@ class AbstractCompositePotential(AbstractPotential):
     def _potential(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BBtSz0:
         xyz = u.ustrip(AllowValue, self.units["length"], xyz)
         t = u.ustrip(AllowValue, self.units["time"], t)
-        return jnp.sum(
+        return jnp.sum(  # type: ignore[no-any-return]
             jnp.array([p._potential(xyz, t) for p in self.values()]),  # noqa: SLF001
             axis=0,
         )
@@ -49,7 +49,7 @@ class AbstractCompositePotential(AbstractPotential):
     def _gradient(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BBtSz3:
         xyz = u.ustrip(AllowValue, self.units["length"], xyz)
         t = u.ustrip(AllowValue, self.units["time"], t)
-        return jnp.sum(
+        return jnp.sum(  # type: ignore[no-any-return]
             jnp.array([p._gradient(xyz, t) for p in self.values()]),  # noqa: SLF001
             axis=0,
         )
@@ -58,7 +58,7 @@ class AbstractCompositePotential(AbstractPotential):
     def _laplacian(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BBtSz0:
         xyz = u.ustrip(AllowValue, self.units["length"], xyz)
         t = u.ustrip(AllowValue, self.units["time"], t)
-        return jnp.sum(
+        return jnp.sum(  # type: ignore[no-any-return]
             jnp.array([p._laplacian(xyz, t) for p in self.values()]),  # noqa: SLF001
             axis=0,
         )
@@ -67,7 +67,7 @@ class AbstractCompositePotential(AbstractPotential):
     def _density(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BBtSz0:
         xyz = u.ustrip(AllowValue, self.units["length"], xyz)
         t = u.ustrip(AllowValue, self.units["time"], t)
-        return jnp.sum(
+        return jnp.sum(  # type: ignore[no-any-return]
             jnp.array([p._density(xyz, t) for p in self.values()]),  # noqa: SLF001
             axis=0,
         )
@@ -76,7 +76,7 @@ class AbstractCompositePotential(AbstractPotential):
     def _hessian(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BBtSz33:
         xyz = u.ustrip(AllowValue, self.units["length"], xyz)
         t = u.ustrip(AllowValue, self.units["time"], t)
-        return jnp.sum(
+        return jnp.sum(  # type: ignore[no-any-return]
             jnp.array([p._hessian(xyz, t) for p in self.values()]),  # noqa: SLF001
             axis=0,
         )
@@ -112,7 +112,7 @@ class AbstractCompositePotential(AbstractPotential):
     # Mapping Protocol
 
     def __getitem__(self, key: str) -> AbstractPotential:
-        return cast("AbstractPotential", self._data[key])
+        return self._data[key]
 
     def keys(self) -> KeysView[str]:
         return cast("KeysView[str]", self._data.keys())
@@ -294,7 +294,7 @@ class AbstractPreCompositedPotential(AbstractCompositePotential):
             setattr(self, k, pot)
 
     @property
-    def _data(self) -> ImmutableMap[str, AbstractPotential]:
+    def _data(self) -> ImmutableMap[str, AbstractPotential]:  # type: ignore[override]
         """Return the parameters as an ImmutableMap."""
         return ImmutableMap({k: getattr(self, k) for k in self._keys})
 

--- a/src/galax/potential/_src/builtin/burkert.py
+++ b/src/galax/potential/_src/builtin/burkert.py
@@ -73,7 +73,7 @@ class BurkertPotential(AbstractSinglePotential):
             "m": self.m(t, ustrip=self.units["mass"]),
             "r_s": self.r_s(t, ustrip=self.units["length"]),
         }
-        return potential(params, r)
+        return potential(params, r)  # type: ignore[no-any-return]
 
     @ft.partial(jax.jit)
     def _density(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BtFloatSz0:
@@ -85,7 +85,7 @@ class BurkertPotential(AbstractSinglePotential):
             "m": self.m(t, ustrip=self.units["mass"]),
             "r_s": self.r_s(t, ustrip=self.units["length"]),
         }
-        return density(params, r)
+        return density(params, r)  # type: ignore[no-any-return]
 
     @ft.partial(jax.jit)
     def _mass(self, xyz: gt.BBtQuSz3, /, t: gt.BtQuSz0 | gt.QuSz0) -> gt.BtFloatQuSz0:
@@ -156,7 +156,7 @@ class BurkertPotential(AbstractSinglePotential):
 @ft.partial(jax.jit)
 def rho0(m: gt.QuSz0, r_s: gt.QuSz0, /) -> gt.Sz0:
     r"""Central density of the potential."""
-    return m / (CONST_BURKER * jnp.pi * r_s**3)
+    return m / (CONST_BURKER * jnp.pi * r_s**3)  # type: ignore[no-any-return]
 
 
 @ft.partial(jax.jit)
@@ -169,7 +169,8 @@ def density(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
     where $m$ is the characteristic mass and $r_s$ is the scale radius.
     """
     factor = p["m"] / (jnp.pi * CONST_BURKER)
-    return factor / ((r + p["r_s"]) * (r**2 + p["r_s"] ** 2))
+    _result = factor / ((r + p["r_s"]) * (r**2 + p["r_s"] ** 2))
+    return _result  # type: ignore[no-any-return]
 
 
 @ft.partial(jax.jit)
@@ -185,7 +186,8 @@ def mass_enclosed(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
     """
     x = r / p["r_s"]
     factor = p["m"] / CONST_BURKER
-    return factor * (2 * jnp.log1p(x) + jnp.log1p(x**2) - 2 * jnp.atan(x))
+    _result = factor * (2 * jnp.log1p(x) + jnp.log1p(x**2) - 2 * jnp.atan(x))
+    return _result  # type: ignore[no-any-return]
 
 
 @ft.partial(jax.jit)
@@ -218,7 +220,7 @@ def potential(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
     x = r / r_s
     xinv = 1 / x
     prefactor = p["G"] * p["m"] / (r_s * CONST_BURKER)
-    return -prefactor * (
+    return -prefactor * (  # type: ignore[no-any-return]
         jnp.pi
         - 2 * (1 + xinv) * jnp.atan(x)
         + 2 * (1 + xinv) * jnp.log1p(x)

--- a/src/galax/potential/_src/builtin/example.py
+++ b/src/galax/potential/_src/builtin/example.py
@@ -81,7 +81,8 @@ class HarmonicOscillatorPotential(AbstractSinglePotential):
         # \Phi(\mathbf{q}, t) = \frac{1}{2} |\omega(t) \cdot \mathbf{q}|^2
         omega = self.omega(t, ustrip=self.units["frequency"])
 
-        return 0.5 * jnp.sum(jnp.square(jnp.atleast_1d(omega) * xyz), axis=-1)
+        _result = 0.5 * jnp.sum(jnp.square(jnp.atleast_1d(omega) * xyz), axis=-1)
+        return _result  # type: ignore[no-any-return]
 
     @ft.partial(jax.jit)
     def _density(self, _: gt.BBtQorVSz3, t: gt.BtQuSz0 | gt.BtSz0, /) -> gt.BBtFloatSz0:
@@ -94,7 +95,7 @@ class HarmonicOscillatorPotential(AbstractSinglePotential):
         # TODO: fix this - not valid for arbitrary ndim
         # \rho(\mathbf{q}, t) = \frac{1}{4 \pi G} \sum_i^N \omega_i^2 / N
         denom = 4 * jnp.pi * self.constants["G"].value
-        return jnp.sum(omega**2, axis=-1) / denom
+        return jnp.sum(omega**2, axis=-1) / denom  # type: ignore[no-any-return]
 
 
 # -------------------------------------------------------------------
@@ -171,4 +172,5 @@ class HenonHeilesPotential(AbstractSinglePotential):
 
         x2, y = xyz[..., 0] ** 2, xyz[..., 1]
         R2 = x2 + y**2
-        return (R2 / 2 + coeff * (x2 * y - y**3 / 3.0)) / ts2
+        _result = (R2 / 2 + coeff * (x2 * y - y**3 / 3.0)) / ts2
+        return _result  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/hernquist.py
+++ b/src/galax/potential/_src/builtin/hernquist.py
@@ -51,7 +51,7 @@ class HernquistPotential(AbstractSinglePotential):
             "m_tot": self.m_tot(t, ustrip=self.units["mass"]),
             "r_s": self.r_s(t, ustrip=self.units["length"]),
         }
-        return potential(params, r)
+        return potential(params, r)  # type: ignore[no-any-return]
 
     @ft.partial(jax.jit)
     def _density(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BtFloatSz0:
@@ -62,7 +62,7 @@ class HernquistPotential(AbstractSinglePotential):
             "m_tot": self.m_tot(t, ustrip=self.units["mass"]),
             "r_s": self.r_s(t, ustrip=self.units["length"]),
         }
-        return density(params, r)
+        return density(params, r)  # type: ignore[no-any-return]
 
 
 # ============================================
@@ -73,7 +73,7 @@ def density(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
     r"""Density profile for the Kepler potential."""
     s = r / p["r_s"]
     rho0 = p["m_tot"] / (2 * jnp.pi * p["r_s"] ** 3)
-    return rho0 / (s * (1 + s) ** 3)
+    return rho0 / (s * (1 + s) ** 3)  # type: ignore[no-any-return]
 
 
 @ft.partial(jax.jit)
@@ -173,4 +173,4 @@ class TriaxialHernquistPotential(AbstractSinglePotential):
             "m_tot": self.m_tot(t, ustrip=self.units["mass"]),
             "r_s": self.r_s(t, ustrip=self.units["length"]),
         }
-        return potential(params, rprime)
+        return potential(params, rprime)  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/isochrone.py
+++ b/src/galax/potential/_src/builtin/isochrone.py
@@ -70,7 +70,7 @@ class IsochronePotential(AbstractSinglePotential):
             "m_tot": self.m_tot(t, ustrip=self.units["mass"]),
             "r_s": self.r_s(t, ustrip=self.units["length"]),
         }
-        return potential(params, r)
+        return potential(params, r)  # type: ignore[no-any-return]
 
 
 # ===================================================================
@@ -86,4 +86,5 @@ def potential(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
 
     """
     r_s = p["r_s"]
-    return -p["G"] * p["m_tot"] / (r_s + jnp.sqrt(r**2 + r_s**2))
+    _result = -p["G"] * p["m_tot"] / (r_s + jnp.sqrt(r**2 + r_s**2))
+    return _result  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/jaffe.py
+++ b/src/galax/potential/_src/builtin/jaffe.py
@@ -41,7 +41,7 @@ class JaffePotential(AbstractSinglePotential):
             "m_tot": self.m_tot(t, ustrip=self.units["mass"]),
             "r_s": self.r_s(t, ustrip=self.units["length"]),
         }
-        return potential(params, r)
+        return potential(params, r)  # type: ignore[no-any-return]
 
 
 # ===================================================================
@@ -56,4 +56,5 @@ def potential(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
     $$
 
     """
-    return -p["G"] * p["m_tot"] / p["r_s"] * jnp.log(1 + p["r_s"] / r)
+    _result = -p["G"] * p["m_tot"] / p["r_s"] * jnp.log(1 + p["r_s"] / r)
+    return _result  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/kepler.py
+++ b/src/galax/potential/_src/builtin/kepler.py
@@ -61,7 +61,7 @@ class KeplerPotential(AbstractSinglePotential):
             "G": self.constants["G"].value,
             "m_tot": self.m_tot(t, ustrip=self.units["mass"]),
         }
-        return potential(params, r)
+        return potential(params, r)  # type: ignore[no-any-return]
 
     @ft.partial(jax.jit)
     def _density(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BtFloatSz0:
@@ -70,7 +70,7 @@ class KeplerPotential(AbstractSinglePotential):
         t = u.Q.from_(t, self.units["time"])
 
         params = {"m_tot": self.m_tot(t, ustrip=self.units["mass"])}
-        return density(params, r)
+        return density(params, r)  # type: ignore[no-any-return]
 
 
 # ============================================
@@ -100,7 +100,7 @@ def potential(p: gt.Params, r: gt.Sz0, /) -> gt.Sz0:
     from the center of the potential.
 
     """
-    return point_mass_potential(p["G"], p["m_tot"], r)
+    return point_mass_potential(p["G"], p["m_tot"], r)  # type: ignore[no-any-return]
 
 
 @ft.partial(jax.jit)
@@ -118,4 +118,5 @@ def density(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
         jnp.greater(r, jnp.zeros_like(r)),
         jnp.equal(p["m_tot"], jnp.zeros_like(p["m_tot"])),
     )
-    return qlax.select(pred, jnp.zeros_like(r), jnp.full_like(r, fill_value=jnp.inf))
+    _result = qlax.select(pred, jnp.zeros_like(r), jnp.full_like(r, fill_value=jnp.inf))
+    return _result  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/kuzmin.py
+++ b/src/galax/potential/_src/builtin/kuzmin.py
@@ -65,7 +65,7 @@ class KuzminPotential(AbstractSinglePotential):
             "m_tot": self.m_tot(t, ustrip=self.units["mass"]),
             "r_s": self.r_s(t, ustrip=self.units["length"]),
         }
-        return potential(params, xyz)
+        return potential(params, xyz)  # type: ignore[no-any-return]
 
 
 # ====================================================================
@@ -81,4 +81,5 @@ def potential(p: gt.Params, xyz: gt.BBtSz3) -> gt.BBtSz0:
     """
     R2 = xyz[..., 0] ** 2 + xyz[..., 1] ** 2
     z = xyz[..., 2]
-    return -p["G"] * p["m_tot"] / jnp.sqrt(R2 + (jnp.abs(z) + p["r_s"]) ** 2)
+    _result = -p["G"] * p["m_tot"] / jnp.sqrt(R2 + (jnp.abs(z) + p["r_s"]) ** 2)
+    return _result  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/logarithmic.py
+++ b/src/galax/potential/_src/builtin/logarithmic.py
@@ -50,7 +50,7 @@ class LogarithmicPotential(AbstractSinglePotential):
         r_s = self.r_s(t, ustrip=self.units["length"])
         v_c = self.v_c(t, ustrip=self.units["speed"])
 
-        return 0.5 * v_c**2 * jnp.log(r_s**2 + r**2)
+        return 0.5 * v_c**2 * jnp.log(r_s**2 + r**2)  # type: ignore[no-any-return]
 
 
 @final
@@ -105,4 +105,4 @@ class LMJ09LogarithmicPotential(AbstractSinglePotential):
         r2 = (x / q1) ** 2 + (y / q2) ** 2 + (xyz[..., 2] / q3) ** 2
 
         # Potential energy
-        return 0.5 * v_c**2 * jnp.log(r_s**2 + r2)
+        return 0.5 * v_c**2 * jnp.log(r_s**2 + r2)  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/longmurali.py
+++ b/src/galax/potential/_src/builtin/longmurali.py
@@ -64,7 +64,7 @@ class LongMuraliBarPotential(AbstractSinglePotential):
             "c": self.c(t, ustrip=ul),
             "alpha": self.alpha(t, ustrip=self.units["angle"]),
         }
-        return potential(params, xyz)
+        return potential(params, xyz)  # type: ignore[no-any-return]
 
 
 # ===================================================================
@@ -85,4 +85,5 @@ def potential(p: gt.Params, xyz: gt.Sz3, /) -> gt.Sz0:
     T_minus = jnp.sqrt((a - xp) ** 2 + yz2)
 
     GM_R = p["G"] * p["m_tot"] / (2.0 * a)
-    return GM_R * jnp.log((xp - a + T_minus) / (xp + a + T_plus))
+    _result = GM_R * jnp.log((xp - a + T_minus) / (xp + a + T_plus))
+    return _result  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/miyamotonagai.py
+++ b/src/galax/potential/_src/builtin/miyamotonagai.py
@@ -63,7 +63,7 @@ class MiyamotoNagaiPotential(AbstractSinglePotential):
             "a": self.a(t, ustrip=ul),
             "b": self.b(t, ustrip=ul),
         }
-        return potential(p, xyz)
+        return potential(p, xyz)  # type: ignore[no-any-return]
 
 
 # ===================================================================
@@ -75,4 +75,4 @@ def potential(p: gt.Params, xyz: gt.Sz3) -> gt.Sz0:
     """Miyamoto-Nagai potential function."""
     R2 = xyz[..., 0] ** 2 + xyz[..., 1] ** 2
     zp2 = (jnp.sqrt(xyz[..., 2] ** 2 + p["b"] ** 2) + p["a"]) ** 2
-    return -p["G"] * p["m_tot"] / jnp.sqrt(R2 + zp2)
+    return -p["G"] * p["m_tot"] / jnp.sqrt(R2 + zp2)  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/mn3.py
+++ b/src/galax/potential/_src/builtin/mn3.py
@@ -124,7 +124,7 @@ class AbstractMN3Potential(AbstractSinglePotential):
         t = u.ustrip(AllowValue, self.units["time"], t)
         # TODO: swap to use mn.potential when have an easy way to construct
         # paarams dict.
-        return jnp.sum(
+        return jnp.sum(  # type: ignore[no-any-return]
             jnp.asarray([mn._potential(xyz, t) for mn in self._get_mn_components(t)]),  # noqa: SLF001
             axis=0,
         )
@@ -135,7 +135,7 @@ class AbstractMN3Potential(AbstractSinglePotential):
         densities = jnp.asarray(
             [mn._density(xyz, t) for mn in self._get_mn_components(t)]  # noqa: SLF001
         )
-        return jnp.sum(densities, axis=0)
+        return jnp.sum(densities, axis=0)  # type: ignore[no-any-return]
 
 
 @final
@@ -160,7 +160,7 @@ class MN3ExponentialPotential(AbstractMN3Potential):
 
     @property
     def _b_coeffs(self) -> Array:
-        return MN3_B_COEFFS_EXP
+        return MN3_B_COEFFS_EXP  # type: ignore[no-any-return]
 
 
 @final
@@ -184,4 +184,4 @@ class MN3Sech2Potential(AbstractMN3Potential):
 
     @property
     def _b_coeffs(self) -> Array:
-        return MN3_B_COEFFS_SECH2
+        return MN3_B_COEFFS_SECH2  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/monari2016.py
+++ b/src/galax/potential/_src/builtin/monari2016.py
@@ -104,7 +104,7 @@ class MonariEtAl2016BarPotential(AbstractSinglePotential):
             "phi_b": self.phi_b(t, ustrip=self.units["angle"]),
             "Omega": self.Omega(t, ustrip=self.units["frequency"]),
         }
-        return potential(params, xyz, t)
+        return potential(params, xyz, t)  # type: ignore[no-any-return]
 
 
 @ft.partial(jax.jit)
@@ -117,7 +117,7 @@ def U_of_r(s: gt.Sz0, /) -> gt.Sz0:
         return s**3 - 2.0
 
     pred = s >= 1
-    return jax.lax.cond(pred, gtr_func, less_func, s)
+    return jax.lax.cond(pred, gtr_func, less_func, s)  # type: ignore[no-any-return]
 
 
 # ===================================================================
@@ -134,4 +134,5 @@ def potential(p: gt.Params, xyz: gt.Sz3, t: gt.Sz0, /) -> gt.Sz0:
     phi = jnp.arctan2(xyz[1], xyz[0])
     gamma_b = 2 * (phi - p["phi_b"] - p["Omega"] * t)  # M+2016 eq.2
 
-    return prefactor * u_of_r * (R2 / r2) * jnp.cos(gamma_b)  # M+2016 eq.1
+    energy = prefactor * u_of_r * (R2 / r2) * jnp.cos(gamma_b)  # M+2016 eq.1
+    return energy  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/multipole.py
+++ b/src/galax/potential/_src/builtin/multipole.py
@@ -98,13 +98,15 @@ class MultipoleInnerPotential(AbstractMultipolePotential):
         # TODO: vectorize compute_Ylm over l, m, then don't need a vmap?
         def summand(l: int, m: int) -> Float[Array, "*batch"]:
             cPlm, sPlm = compute_Ylm(l, m, theta, phi, l_max=l_max)
-            return jnp.pow(s, l) * (Slm[l, m] * cPlm + Tlm[l, m] * sPlm)
+            _result = jnp.pow(s, l) * (Slm[l, m] * cPlm + Tlm[l, m] * sPlm)
+            return _result  # type: ignore[no-any-return]
 
         summation = jnp.sum(jax.vmap(summand, in_axes=(0, 0))(ls, ms), axis=0)
         if is_scalar:
             summation = summation[0]
 
-        return self.constants["G"].value * m_tot / r_s * summation
+        _result = self.constants["G"].value * m_tot / r_s * summation
+        return _result  # type: ignore[no-any-return]
 
 
 @final
@@ -164,13 +166,15 @@ class MultipoleOuterPotential(AbstractMultipolePotential):
         # TODO: vectorize compute_Ylm over l, m, then don't need a vmap?
         def summand(l: int, m: int) -> Float[Array, "*batch"]:
             cPlm, sPlm = compute_Ylm(l, m, theta, phi, l_max=l_max)
-            return jnp.pow(s, -(l + 1)) * (Slm[l, m] * cPlm + Tlm[l, m] * sPlm)
+            _result = jnp.pow(s, -(l + 1)) * (Slm[l, m] * cPlm + Tlm[l, m] * sPlm)
+            return _result  # type: ignore[no-any-return]
 
         summation = jnp.sum(jax.vmap(summand, in_axes=(0, 0))(ls, ms), axis=0)
         if is_scalar:
             summation = summation[0]
 
-        return self.constants["G"].value * m_tot / r_s * summation
+        _result = self.constants["G"].value * m_tot / r_s * summation
+        return _result  # type: ignore[no-any-return]
 
 
 @final
@@ -243,13 +247,14 @@ class MultipolePotential(AbstractMultipolePotential):
             cPlm, sPlm = compute_Ylm(l, m, theta, phi, l_max=l_max)
             inner = jnp.pow(s, l) * (ISlm[l, m] * cPlm + ITlm[l, m] * sPlm)
             outer = jnp.pow(s, -l - 1) * (OSlm[l, m] * cPlm + OTlm[l, m] * sPlm)
-            return inner + outer
+            return inner + outer  # type: ignore[no-any-return]
 
         summation = jnp.sum(jax.vmap(summand, in_axes=(0, 0))(ls, ms), axis=0)
         if is_scalar:
             summation = summation[0]
 
-        return self.constants["G"].value * m_tot / r_s * summation
+        _result = self.constants["G"].value * m_tot / r_s * summation
+        return _result  # type: ignore[no-any-return]
 
 
 # ===== Helper functions =====

--- a/src/galax/potential/_src/builtin/nfw/base.py
+++ b/src/galax/potential/_src/builtin/nfw/base.py
@@ -97,7 +97,7 @@ class NFWPotential(AbstractSinglePotential):
             "m": self.m(t, ustrip=self.units["mass"]),
             "r_s": self.r_s(t, ustrip=self.units["length"]),
         }
-        return potential(params, r)
+        return potential(params, r)  # type: ignore[no-any-return]
 
     @ft.partial(jax.jit)
     def _density(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BtFloatSz0:
@@ -118,7 +118,7 @@ class NFWPotential(AbstractSinglePotential):
             "m": self.m(t, ustrip=self.units["mass"]),
             "r_s": self.r_s(t, ustrip=self.units["length"]),
         }
-        return density(params, r)
+        return density(params, r)  # type: ignore[no-any-return]
 
     @ft.partial(jax.jit)
     def _mass_enclosed(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BtFloatSz0:
@@ -149,7 +149,7 @@ class NFWPotential(AbstractSinglePotential):
             "m": self.m(t, ustrip=self.units["mass"]),
             "r_s": self.r_s(t, ustrip=self.units["length"]),
         }
-        return mass_enclosed(params, r)
+        return mass_enclosed(params, r)  # type: ignore[no-any-return]
 
     # ===========================================
     # Constructors
@@ -263,7 +263,7 @@ def rho0_of_m(p: gt.Params, /) -> gt.Sz0:
     Array(0., dtype=float64, weak_type=True)
 
     """
-    return p["m"] / (4 * jnp.pi * p["r_s"] ** 3)
+    return p["m"] / (4 * jnp.pi * p["r_s"] ** 3)  # type: ignore[no-any-return]
 
 
 @ft.partial(jax.jit)
@@ -284,7 +284,7 @@ def m_of_rho0(p: gt.Params, /) -> gt.Sz0:
     Array(0., dtype=float64, weak_type=True)
 
     """
-    return 4 * jnp.pi * p["rho0"] * p["r_s"] ** 3
+    return 4 * jnp.pi * p["rho0"] * p["r_s"] ** 3  # type: ignore[no-any-return]
 
 
 # -----------------------------------------------
@@ -320,7 +320,7 @@ def mass_enclosed(p: gt.Params, r: gt.BBtSz0, /) -> gt.BtFloatSz0:
     """
     x = r / p["r_s"]
     m = p["m"]
-    return m * (jnp.log1p(x) - x / (1 + x))
+    return m * (jnp.log1p(x) - x / (1 + x))  # type: ignore[no-any-return]
 
 
 @ft.partial(jax.jit)
@@ -335,4 +335,4 @@ def potential(p: gt.Params, r: gt.BBtSz0, /) -> gt.BtFloatSz0:
     r_s = p["r_s"]
     x = r / r_s
     phi0 = -p["G"] * p["m"] / r_s
-    return phi0 * jnp.log1p(x) / x
+    return phi0 * jnp.log1p(x) / x  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/nfw/generalized.py
+++ b/src/galax/potential/_src/builtin/nfw/generalized.py
@@ -138,7 +138,7 @@ class gNFWPotential(AbstractSinglePotential):
             "r_s": self.r_s(t, ustrip=self.units["length"]),
             "gamma": self.gamma(t, ustrip=self.units["dimensionless"]),
         }
-        return density(params, r)
+        return density(params, r)  # type: ignore[no-any-return]
 
     @ft.partial(jax.jit)
     def _potential(  # TODO: inputs w/ units
@@ -153,7 +153,7 @@ class gNFWPotential(AbstractSinglePotential):
             "r_s": self.r_s(t, ustrip=self.units["length"]),
             "gamma": self.gamma(t, ustrip=self.units["dimensionless"]),
         }
-        return potential(params, r)
+        return potential(params, r)  # type: ignore[no-any-return]
 
     @vectorize_method(signature="(3),()->(3)")
     @ft.partial(jax.jit)
@@ -168,7 +168,7 @@ class gNFWPotential(AbstractSinglePotential):
             "r_s": self.r_s(t_, ustrip=self.units["length"]),
             "gamma": self.gamma(t_, ustrip=self.units["dimensionless"]),
         }
-        return gradient(params, xyz)
+        return gradient(params, xyz)  # type: ignore[no-any-return]
 
 
 # ===================================================================
@@ -281,7 +281,7 @@ def Bz_from_hyp2f1(a: gt.FloatSz0, b: gt.FloatSz0, z: gt.BBtFloatSz0) -> gt.BBtF
     Array(0.69312316, dtype=float64)
 
     """
-    return (z**a / a) * hyp2f1(a, 1 - b, a + 1, z)
+    return (z**a / a) * hyp2f1(a, 1 - b, a + 1, z)  # type: ignore[no-any-return]
 
 
 @ft.partial(jax.jit)
@@ -302,7 +302,8 @@ def mass_enclosed(p: gt.Params, r: gt.BBtSz0, /) -> gt.BtFloatSz0:
     """
     x = r / p["r_s"]
     z = x / (1 + x)
-    return p["m"] * Bz_from_hyp2f1(3.0 - p["gamma"], 0.0, z)
+    _result = p["m"] * Bz_from_hyp2f1(3.0 - p["gamma"], 0.0, z)
+    return _result  # type: ignore[no-any-return]
 
 
 # -----------------------------------------------
@@ -361,7 +362,7 @@ def potential(p: gt.Params, r: gt.BBtSz0, /) -> gt.BtFloatSz0:
     z2 = 1 / (1 + r / rs)
     outer = (p["m"] / rs) * Bz_from_hyp2f1(1.0, 2.0 - p["gamma"], z2)
 
-    return -p["G"] * (inner + outer)
+    return -p["G"] * (inner + outer)  # type: ignore[no-any-return]
 
 
 @ft.partial(jax.jit)
@@ -393,4 +394,4 @@ def gradient(p: gt.Params, xyz: gt.BBtSz3, /) -> gt.BBtSz3:
     r_mag = jnp.linalg.norm(xyz, axis=-1, keepdims=True)
     mass_enc = mass_enclosed(p, r_mag)
     grad_mag = p["G"] * mass_enc / (r_mag**2)
-    return grad_mag * (xyz / r_mag)
+    return grad_mag * (xyz / r_mag)  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/nfw/leesuto.py
+++ b/src/galax/potential/_src/builtin/nfw/leesuto.py
@@ -115,7 +115,7 @@ class LeeSutoTriaxialNFWPotential(AbstractSinglePotential):
             "a2": self.a2(t, ustrip=ul),
             "a3": self.a3(t, ustrip=ul),
         }
-        return potential(params, xyz)
+        return potential(params, xyz)  # type: ignore[no-any-return]
 
 
 # =============================================================

--- a/src/galax/potential/_src/builtin/nfw/triaxial.py
+++ b/src/galax/potential/_src/builtin/nfw/triaxial.py
@@ -26,7 +26,7 @@ from galax.potential._src.params.base import AbstractParameter
 from galax.potential._src.params.field import ParameterField
 
 
-class GaussLegendreIntegrator(eqx.Module):  # type: ignore[misc]
+class GaussLegendreIntegrator(eqx.Module):
     """Gauss-Legendre quadrature integrator."""
 
     x: Shaped[Array, "O"]
@@ -227,13 +227,13 @@ class TriaxialNFWPotential(AbstractSinglePotential):
         def integrand(s: Float[Array, "N"]) -> Float[Array, "N *batch"]:
             s2 = s.reshape(s.shape + (1,) * batchdims) ** 2
             denom = jnp.sqrt(((q1sq - 1) * s2 + 1) * ((q2sq - 1) * s2 + 1))
-            return delta_psi_factor(s2) / denom
+            return delta_psi_factor(s2) / denom  # type: ignore[no-any-return]
 
         # TODO: option to do integrate.quad
         integral = self._integrator(integrand)
 
         out = (-2.0 * jnp.pi * self.constants["G"] * rho0 * r_s**2 * q1 * q2) * integral
-        return out.ustrip(self.units["specific energy"])
+        return out.ustrip(self.units["specific energy"])  # type: ignore[no-any-return]
 
     # ==========================================================================
 
@@ -253,4 +253,4 @@ class TriaxialNFWPotential(AbstractSinglePotential):
         xi = jnp.sqrt(self._ellipsoid_surface(xyz[None], q1sq, q2sq, s2)[0]) / r_s
 
         dens = rho0 / xi / (1.0 + xi) ** 2
-        return dens.ustrip(self.units["mass density"])
+        return dens.ustrip(self.units["mass density"])  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/nfw/truncated.py
+++ b/src/galax/potential/_src/builtin/nfw/truncated.py
@@ -160,7 +160,7 @@ class HardCutoffNFWPotential(AbstractSinglePotential):
             "r_s": self.r_s(t, ustrip=self.units["length"]),
             "r_t": self.r_t(t, ustrip=self.units["length"]),
         }
-        return mass_enclosed(params, r)
+        return mass_enclosed(params, r)  # type: ignore[no-any-return]
 
     @ft.partial(jax.jit)
     def _potential(  # TODO: inputs w/ units
@@ -175,7 +175,7 @@ class HardCutoffNFWPotential(AbstractSinglePotential):
             "r_s": self.r_s(t, ustrip=self.units["length"]),
             "r_t": self.r_t(t, ustrip=self.units["length"]),
         }
-        return potential(params, r)
+        return potential(params, r)  # type: ignore[no-any-return]
 
     @ft.partial(jax.jit)
     def _density(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BtFloatSz0:
@@ -231,7 +231,7 @@ class HardCutoffNFWPotential(AbstractSinglePotential):
             "r_s": self.r_s(t, ustrip=self.units["length"]),
             "r_t": self.r_t(t, ustrip=self.units["length"]),
         }
-        return density(params, r)
+        return density(params, r)  # type: ignore[no-any-return]
 
 
 # ===================================================================
@@ -280,7 +280,8 @@ def mass_enclosed(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
 
     """
     r_t = p["r_t"]
-    return nfw_mass_enclosed(p, jnp.where(r <= r_t, r, r_t))
+    _result = nfw_mass_enclosed(p, jnp.where(r <= r_t, r, r_t))
+    return _result  # type: ignore[no-any-return]
 
 
 # -------------------------------------------------------------------
@@ -295,7 +296,7 @@ def _inner_potential(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
     """
     nfw = nfw_potential(p, r)
     constant = p["G"] * p["m"] / (p["r_s"] + p["r_t"])
-    return nfw + constant
+    return nfw + constant  # type: ignore[no-any-return]
 
 
 @ft.partial(jax.jit)
@@ -309,7 +310,7 @@ def _outer_potential(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
     enclosed within the truncation radius $r_t$.
     """
     m_tot = nfw_mass_enclosed(p, p["r_t"])
-    return kepler.point_mass_potential(p["G"], m_tot, r)
+    return kepler.point_mass_potential(p["G"], m_tot, r)  # type: ignore[no-any-return]
 
 
 @ft.partial(jax.jit)
@@ -333,4 +334,5 @@ def potential(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
       r_s$
 
     """
-    return jnp.where(r <= p["r_t"], _inner_potential(p, r), _outer_potential(p, r))
+    _result = jnp.where(r <= p["r_t"], _inner_potential(p, r), _outer_potential(p, r))
+    return _result  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/nfw/vogelsburger08.py
+++ b/src/galax/potential/_src/builtin/nfw/vogelsburger08.py
@@ -62,7 +62,8 @@ class Vogelsberger08TriaxialNFWPotential(AbstractSinglePotential):
         q1sq = self.q1(t, ustrip=self.units["dimensionless"]) ** 2
         q2sq = 3 - q1sq
         x, y, z = xyz[..., 0], xyz[..., 1], xyz[..., 2]
-        return safe_sqrt(x**2 + y**2 / q1sq + z**2 / q2sq)
+        _result = safe_sqrt(x**2 + y**2 / q1sq + z**2 / q2sq)
+        return _result  # type: ignore[no-any-return]
 
     @ft.partial(jax.jit, inline=True)
     def _r_tilde(self, xyz: gt.BtSz3, t: gt.BBtSz0) -> gt.BtFloatSz0:
@@ -71,7 +72,7 @@ class Vogelsberger08TriaxialNFWPotential(AbstractSinglePotential):
 
         r_e = self._r_e(xyz, t)
         r = safe_vector_norm(xyz)
-        return (r_a + r) * r_e / (r_a + r_e)
+        return (r_a + r) * r_e / (r_a + r_e)  # type: ignore[no-any-return]
 
     @ft.partial(jax.jit)
     def _potential(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BBtSz0:
@@ -84,4 +85,5 @@ class Vogelsberger08TriaxialNFWPotential(AbstractSinglePotential):
         r_s = self.r_s(t, ustrip=self.units["length"])
 
         r = self._r_tilde(xyz, t)
-        return -self.constants["G"].value * m * jnp.log1p(r / r_s) / r
+        _result = -self.constants["G"].value * m * jnp.log1p(r / r_s) / r
+        return _result  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/null.py
+++ b/src/galax/potential/_src/builtin/null.py
@@ -51,24 +51,26 @@ class NullPotential(AbstractSinglePotential):
 
     @ft.partial(jax.jit, inline=True)
     def _potential(self, q: gt.BBtQorVSz3, _: Any, /) -> gt.BBtSz0:
-        return jnp.zeros(q.shape[:-1], dtype=q.dtype)
+        return jnp.zeros(q.shape[:-1], dtype=q.dtype)  # type: ignore[no-any-return]
 
     @ft.partial(jax.jit, inline=True)
     def _gradient(self, q: gt.BBtQorVSz3, /, _: gt.BBtQorVSz0) -> gt.BBtSz3:
         """See ``gradient``."""
-        return jnp.zeros(q.shape[:-1] + (3,), dtype=q.dtype)
+        _result = jnp.zeros(q.shape[:-1] + (3,), dtype=q.dtype)
+        return _result  # type: ignore[no-any-return]
 
     @ft.partial(jax.jit, inline=True)
     def _laplacian(self, xyz: gt.BBtQorVSz3, /, _: gt.BBtQorVSz0) -> gt.BBtFloatSz0:
         """See ``laplacian``."""
-        return jnp.zeros(xyz.shape[:-1], dtype=xyz.dtype)
+        return jnp.zeros(xyz.shape[:-1], dtype=xyz.dtype)  # type: ignore[no-any-return]
 
     @ft.partial(jax.jit, inline=True)
     def _density(self, xyz: gt.BBtQorVSz3, _: gt.BBtQorVSz0, /) -> gt.BBtFloatSz0:
         """See ``density``."""
-        return jnp.zeros(xyz.shape[:-1], dtype=xyz.dtype)
+        return jnp.zeros(xyz.shape[:-1], dtype=xyz.dtype)  # type: ignore[no-any-return]
 
     @ft.partial(jax.jit, inline=True)
     def _hessian(self, q: gt.BBtQorVSz3, _: gt.BBtQorVSz0, /) -> gt.BBtSz33:
         """See ``hessian``."""
-        return jnp.zeros(q.shape[:-1] + (3, 3), dtype=q.dtype)
+        _result = jnp.zeros(q.shape[:-1] + (3, 3), dtype=q.dtype)
+        return _result  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/plummer.py
+++ b/src/galax/potential/_src/builtin/plummer.py
@@ -72,7 +72,7 @@ class PlummerPotential(AbstractSinglePotential):
             "m_tot": self.m_tot(t, ustrip=self.units["mass"]),
             "r_s": self.r_s(t, ustrip=ul),
         }
-        return density(params, r)
+        return density(params, r)  # type: ignore[no-any-return]
 
     @ft.partial(jax.jit)
     def _potential(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BBtSz0:
@@ -86,7 +86,7 @@ class PlummerPotential(AbstractSinglePotential):
             "m_tot": self.m_tot(t, ustrip=self.units["mass"]),
             "r_s": self.r_s(t, ustrip=ul),
         }
-        return potential(params, r)
+        return potential(params, r)  # type: ignore[no-any-return]
 
 
 # ===================================================================
@@ -105,7 +105,7 @@ def density(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
 
     """
     rho0 = 3 * p["m_tot"] / (4 * jnp.pi * p["r_s"] ** 3)
-    return rho0 / jnp.power(1 + (r / p["r_s"]) ** 2, 2.5)
+    return rho0 / jnp.power(1 + (r / p["r_s"]) ** 2, 2.5)  # type: ignore[no-any-return]
 
 
 @ft.partial(jax.jit)
@@ -115,7 +115,8 @@ def mass_enclosed(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
     $$ M(<r) = \frac{M_{tot} r^3}{(r^2 + r_s^2)^{3/2}} $$
 
     """
-    return p["m_tot"] * r**3 / jnp.power(r**2 + p["r_s"] ** 2, 1.5)
+    _result = p["m_tot"] * r**3 / jnp.power(r**2 + p["r_s"] ** 2, 1.5)
+    return _result  # type: ignore[no-any-return]
 
 
 @ft.partial(jax.jit)
@@ -128,4 +129,5 @@ def potential(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
     $r_s$ is the scale length.
 
     """
-    return -p["G"] * p["m_tot"] / jnp.sqrt(r**2 + p["r_s"] ** 2)
+    _result = -p["G"] * p["m_tot"] / jnp.sqrt(r**2 + p["r_s"] ** 2)
+    return _result  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/powerlawcutoff.py
+++ b/src/galax/potential/_src/builtin/powerlawcutoff.py
@@ -29,7 +29,7 @@ from galax.potential._src.utils import r_spherical
 
 @ft.partial(jax.jit)
 def _safe_gamma_inc(a: gt.SzN, x: gt.SzN) -> gt.SzN:
-    return jsp.gammainc(a, x) * jsp.gamma(a)
+    return jsp.gammainc(a, x) * jsp.gamma(a)  # type: ignore[no-any-return]
 
 
 @final
@@ -79,7 +79,7 @@ class PowerLawCutoffPotential(AbstractSinglePotential):
             "alpha": self.alpha(t, ustrip=self.units["dimensionless"]),
             "r_c": self.r_c(t, ustrip=ul),
         }
-        return potential(params, r)
+        return potential(params, r)  # type: ignore[no-any-return]
 
 
 # ===================================================================
@@ -114,4 +114,4 @@ def potential(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
         lambda: 0.0,
     )
 
-    return term1 + term2 - phi_infinity
+    return term1 + term2 - phi_infinity  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/satoh.py
+++ b/src/galax/potential/_src/builtin/satoh.py
@@ -54,7 +54,7 @@ class SatohPotential(AbstractSinglePotential):
             "a": self.a(t, ustrip=self.units["length"]),
             "b": self.b(t, ustrip=self.units["length"]),
         }
-        return potential(params, xyz)
+        return potential(params, xyz)  # type: ignore[no-any-return]
 
 
 # ===================================================================
@@ -66,4 +66,4 @@ def potential(p: gt.Params, xyz: gt.Sz3, /) -> gt.Sz0:
     R2 = xyz[..., 0] ** 2 + xyz[..., 1] ** 2
     z = xyz[..., 2]
     term = R2 + z**2 + p["a"] * (p["a"] + 2 * jnp.sqrt(z**2 + p["b"] ** 2))
-    return -p["G"] * p["m_tot"] / jnp.sqrt(term)
+    return -p["G"] * p["m_tot"] / jnp.sqrt(term)  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/stoneostriker15.py
+++ b/src/galax/potential/_src/builtin/stoneostriker15.py
@@ -70,7 +70,7 @@ class StoneOstriker15Potential(AbstractSinglePotential):
             "r_h": self.r_h(t, ustrip=ul),
             "r_c": self.r_c(t, ustrip=ul),
         }
-        return density(params, r)
+        return density(params, r)  # type: ignore[no-any-return]
 
     @ft.partial(jax.jit)
     def _potential(self, xyz: gt.BBtQuSz3, t: gt.BBtQuSz0, /) -> gt.BtSz0:
@@ -85,7 +85,7 @@ class StoneOstriker15Potential(AbstractSinglePotential):
             "r_h": self.r_h(t, ustrip=ul),
             "r_c": self.r_c(t, ustrip=ul),
         }
-        return potential(params, r)
+        return potential(params, r)  # type: ignore[no-any-return]
 
 
 # ===================================================================
@@ -102,7 +102,7 @@ def rhoc_of_mtot(p: gt.Params, /) -> gt.FloatSz0:
     """
     r_c, r_h = p["r_c"], p["r_h"]
     rho_c = p["m_tot"] * (r_h + r_c) / (2 * jnp.pi**2 * r_c**2 * r_h**2)
-    return rho_c
+    return rho_c  # type: ignore[no-any-return]
 
 
 @ft.partial(jax.jit)
@@ -119,7 +119,7 @@ def density(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
     rho_c = rhoc_of_mtot(p)
     core_term = 1 + (r / p["r_c"]) ** 2
     halo_term = 1 + (r / p["r_h"]) ** 2
-    return rho_c / (core_term * halo_term)
+    return rho_c / (core_term * halo_term)  # type: ignore[no-any-return]
 
 
 @ft.partial(jax.jit)
@@ -134,7 +134,7 @@ def mass_enclosed(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
     r_c, r_h = p["r_c"], p["r_h"]
     A = 2 * p["m_tot"] / (jnp.pi * (r_h - r_c))
     atan_term = r_h * jnp.atan2(r, r_h) - r_c * jnp.atan2(r, r_c)
-    return A * atan_term
+    return A * atan_term  # type: ignore[no-any-return]
 
 
 @ft.partial(jax.jit)
@@ -144,4 +144,4 @@ def potential(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
     A = -2 * p["G"] * p["m_tot"] / (jnp.pi * (r_h - r_c))
     atan_term = (r_h * jnp.atan2(r, r_h) - r_c * jnp.atan2(r, r_c)) / r
     log_term = 0.5 * jnp.log((r**2 + r_h**2) / (r**2 + r_c**2))
-    return A * (atan_term + log_term)
+    return A * (atan_term + log_term)  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/params/base.py
+++ b/src/galax/potential/_src/params/base.py
@@ -43,7 +43,7 @@ class ParameterCallable(Protocol):
 # -------------------------------------------
 
 
-class AbstractParameter(eqx.Module):  # type: ignore[misc]
+class AbstractParameter(eqx.Module):
     """Abstract base class for Parameters on a Potential.
 
     Parameters are time-dependent quantities that are used to define a

--- a/src/galax/potential/_src/params/constant.py
+++ b/src/galax/potential/_src/params/constant.py
@@ -100,7 +100,7 @@ class ConstantParameter(AbstractParameter, ArrayValue, quax_blocks.NumpyMathMixi
         ShapedArray(float64[], weak_type=True)
 
         """
-        return self.value.aval()
+        return self.value.aval()  # type: ignore[no-any-return]
 
     def materialise(self) -> NoReturn:
         """Return the dtype and shape info.
@@ -170,7 +170,7 @@ class ConstantParameter(AbstractParameter, ArrayValue, quax_blocks.NumpyMathMixi
 # add_p
 
 
-@register(jax.lax.add_p)  # type: ignore[misc]
+@register(jax.lax.add_p)
 def add_p_constantparams(
     x: ConstantParameter, y: ConstantParameter, /
 ) -> ConstantParameter:
@@ -195,7 +195,7 @@ def add_p_constantparam_scalar(
 # sub_p
 
 
-@register(jax.lax.sub_p)  # type: ignore[misc]
+@register(jax.lax.sub_p)
 def sub_p_constantparams(
     x: ConstantParameter, y: ConstantParameter, /
 ) -> ConstantParameter:
@@ -220,14 +220,14 @@ def sub_p_constantparam_scalar(
 # mul_p
 
 
-@register(jax.lax.mul_p)  # type: ignore[misc]
+@register(jax.lax.mul_p)
 def mul_p_obj_constantparam(
     x: ConstantParameter, y: u.AbstractQuantity | ArrayLike, /
 ) -> u.AbstractQuantity:
     return x.value * y
 
 
-@register(jax.lax.mul_p)  # type: ignore[misc]
+@register(jax.lax.mul_p)
 def mul_p_constantparam_obj(
     x: u.AbstractQuantity | ArrayLike, y: ConstantParameter, /
 ) -> u.AbstractQuantity:

--- a/src/galax/potential/_src/register_funcs.py
+++ b/src/galax/potential/_src/register_funcs.py
@@ -366,13 +366,15 @@ def tidal_tensor(
 
     """
     J = api.hessian(pot, *args, **kwargs)  # (*batch, 3, 3)
-    batch_shape, arr_shape = batched_shape(J, expect_ndim=2)  # (*batch), (3, 3)
+    batch_shape, arr_shape = batched_shape(  # type: ignore[call-overload]
+        J, expect_ndim=2
+    )  # (*batch), (3, 3)
     traced = (
-        expand_batch_dims(jnp.eye(3), ndim=len(batch_shape))
+        expand_batch_dims(jnp.eye(3), ndim=len(batch_shape))  # type: ignore[operator]
         * expand_arr_dims(jnp.trace(J, axis1=-2, axis2=-1), ndim=len(arr_shape))
         / 3
     )
-    return J - traced
+    return J - traced  # type: ignore[operator]
 
 
 # =============================================================================

--- a/src/galax/potential/_src/shape.py
+++ b/src/galax/potential/_src/shape.py
@@ -6,9 +6,11 @@ here rather than in `coordinates` alongside `batched_shape`.
 
 __all__: tuple[str, ...] = ()
 
+from quax import quaxify
+
 import quaxed.numpy as jnp
 
-from galax.coordinates._src.shape import ArrayAnyShape, quaxify
+from galax.coordinates._src.shape import ArrayAnyShape
 
 
 @quaxify
@@ -44,7 +46,7 @@ def expand_batch_dims(arr: ArrayAnyShape, /, ndim: int) -> ArrayAnyShape:
     >>> expand_batch_dims(jnp.array([0, 1]), ndim=1).shape
     (1, 2)
     """
-    return jnp.expand_dims(arr, axis=tuple(range(ndim)))
+    return jnp.expand_dims(arr, axis=tuple(range(ndim)))  # type: ignore[no-any-return]
 
 
 @quaxify
@@ -81,4 +83,5 @@ def expand_arr_dims(arr: ArrayAnyShape, /, ndim: int) -> ArrayAnyShape:
     (2, 1)
     """
     nbatch = len(arr.shape)
-    return jnp.expand_dims(arr, axis=tuple(nbatch + i for i in range(ndim)))
+    _result = jnp.expand_dims(arr, axis=tuple(nbatch + i for i in range(ndim)))
+    return _result  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/utils.py
+++ b/src/galax/potential/_src/utils.py
@@ -75,7 +75,7 @@ def safe_sqrt(q2: gt.BBtFloatSz0, /) -> gt.BBtFloatSz0:
 
     """
     tiny = jnp.finfo(jnp.promote_types(q2.dtype, float)).tiny
-    return jnp.sqrt(q2 + tiny)
+    return jnp.sqrt(q2 + tiny)  # type: ignore[no-any-return]
 
 
 @ft.partial(jax.jit, inline=True)
@@ -109,7 +109,7 @@ def safe_vector_norm(x: gt.BBtSz3, /) -> gt.BBtFloatSz0:
     Array([nan, nan, nan], dtype=float64)
 
     """
-    return safe_sqrt(jnp.sum(jnp.square(x), axis=-1))
+    return safe_sqrt(jnp.sum(jnp.square(x), axis=-1))  # type: ignore[no-any-return]
 
 
 @ft.partial(jax.jit, inline=True, static_argnames=("unit",))
@@ -121,7 +121,7 @@ def r_spherical(xyz: gt.BBtQorVSz3, unit: Any) -> gt.BBtFloatSz0:
     """
     xyz = u.ustrip(AllowValue, unit, xyz)
     r = safe_vector_norm(xyz)
-    return r
+    return r  # type: ignore[no-any-return]
 
 
 # ==============================================================================

--- a/src/galax/potential/_src/xfm/xop.py
+++ b/src/galax/potential/_src/xfm/xop.py
@@ -249,4 +249,4 @@ def simplify_op(pot: TransformedPotential, /) -> TransformedPotential:
     )
 
     """
-    return replace(pot, xop=cxo.simplify_op(pot.xop))
+    return replace(pot, xop=cxo.simplify_op(pot.xop))  # type: ignore[call-arg]

--- a/src/galax/utils/dataclasses.py
+++ b/src/galax/utils/dataclasses.py
@@ -100,7 +100,7 @@ def _add_converter_init_to_class[T](cls: type[T], /) -> type[T]:
 
 # TODO: upstream this to Equinox
 # TODO: Equinox doesn't seem to respect the conversion of the default value anymore.
-class ModuleMeta(_ModuleMeta):  # type: ignore[misc]
+class ModuleMeta(_ModuleMeta):
     """Equinox-compatible module metaclass.
 
     This metaclass extends Equinox's :class:`equinox._module._ModuleMeta` to


### PR DESCRIPTION
## Summary

Followup to a review comment on #805/#796: `quaxify` is wrapped in `galax.utils._jax`/`galax.coordinates._src.shape` with an explicit `cast`, because `quax` is deliberately excluded from the mypy pre-commit hook's isolated environment (only `dataclassish`, `optype`, and `plum-dispatch` are installed there, to keep it fast). Without `quax` resolvable, decorating with `quax.quaxify` directly makes the decorated function untyped — so the cast isn't a workaround for `quax`'s own typing, it's a workaround for this hook's minimal environment.

This PR adds `quax` (only `quax` — not `quaxed`/`unxt`/`coordinax`/`jax`, which would pull in the whole JAX stack and defeat the point of the minimal hook) to `additional_dependencies`, and removes the now-genuinely-redundant `quaxify` wrapper.

Doing so lets mypy follow real types through every `quax`-touched call chain for the first time, which surfaced **191 pre-existing errors across 60 files** that were previously masked. Breakdown:

- **`no-any-return`** (bulk of it) — from `jax`'s own functions (`jax.jit`, `jax.grad`, `jax.lax.scan`, `.min()`/`.max()`) being untyped under this project's `ignore_missing_imports` policy for `jax.*`. Fixed with `# type: ignore[no-any-return]`, matching the one existing precedent in this codebase (`coordinates/_src/base.py`).
- **redundant casts** that predated `quax` being resolvable — removed, including the `quaxify` wrapper itself.
- **`override`/`misc`** from equinox's `AbstractVar`/`AbstractClassVar` + property-override pattern, and plum's multiple-dispatch redefinitions — ignored with the matching error code, consistent with how this codebase already handles the same pattern elsewhere.
- **two real fixes**, not just suppressions:
  - `_error_if_not_all_constant_parameters` in the galpy interop is now generic (`[PT: gp.AbstractPotential](pot: PT) -> PT`) so it preserves the caller's specific potential subtype instead of widening every caller to `AbstractPotential`.
  - `NBodyField`'s force calculation called `self.eps.ustrip(...)` / `self.masses.ustrip(...)` as **method calls**, but both fields are typed `Quantity | Array` — a bare `Array` has no `.ustrip` method, so this would crash at runtime for that case. Switched to the polymorphic `u.ustrip(AllowValue, ...)` free function already used two lines above for the same purpose.
- `integrate_field`'s `@ft.partial(eqx.filter_jit)` decorator had zero bound arguments, making it a no-op wrapper that also breaks mypy's ability to see `eqx.filter_jit`'s `ParamSpec`-preserving signature through `functools.partial`. Simplified to bare `@eqx.filter_jit`, matching the pattern already used elsewhere in this codebase.

## Verification

- `pre-commit run --all-files` (the actual hook config, not a local approximation) is clean.
- Full test suite: 1080 passed, 170 skipped, 14 xfailed — no new failures. (One pre-existing failure, `test_mockstreamgenerator.py::test_second_deriv`, was confirmed to already fail identically on unmodified `main`; unrelated to this change, deselected for the full-suite verification run.)
- Doctests on every touched file: 2076 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)