### PR TITLE
💚 ci: stop the longdouble warning aborting the benchmark run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,4 +169,13 @@ jobs:
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: "instrumentation"
-          run: uv run pytest tests/benchmark --codspeed
+          # Instrumentation mode runs under Valgrind, whose x87 emulation gives
+          # `numpy.longdouble` a bit signature numpy does not recognise, so
+          # importing `numpy.ma` warns. `filterwarnings = ["error"]` turns that
+          # into an exception during session start, aborting the whole run with
+          # an INTERNALERROR before a single benchmark is collected. The warning
+          # says nothing about galax, so ignore it here rather than repo-wide,
+          # where it would still flag a genuinely broken numpy build.
+          run:
+            uv run pytest tests/benchmark --codspeed -W
+            "ignore:Signature:UserWarning"


### PR DESCRIPTION
`Run Benchmarks` has failed on **every push to `main` since 2025-11-17** (last green: `ead23784`, 2025-11-01). It is the *only* failing job, so `main` has been red for nine months on this alone.

It never appears on a PR — the job is gated on `github.event_name == 'push' && github.ref == 'refs/heads/main'`, so it shows as `skipping` everywhere else. That is why nothing caught it.

## Root cause

CodSpeed's `mode: "instrumentation"` runs the process under Valgrind (the job log shows it installing `/tmp/valgrind-codspeed.deb`). Valgrind's x87 emulation gives `numpy.longdouble` a bit signature numpy does not recognise, so `numpy/_core/getlimits.py::_get_machar` warns:

```
UserWarning: Signature b'\x00\xd0\xcc\xcc\xcc\xcc\xcc\xcc\xfb\xbf\x00\x00\x00\x00\x00\x00'
for <class 'numpy.longdouble'> does not match any known type: falling back to
type probe function. This warnings indicates broken support for the dtype!
```

`filterwarnings = ["error"]` turns that into an exception, and it fires during session start rather than inside a test:

```
pytest_sessionstart
  -> terminal.py: pytest_report_header
     -> pytest_mpl/plugin.py:133  import matplotlib
        -> matplotlib rcParams validation -> validate_color -> to_rgba
           -> np.ma.masked  (lazy import of numpy.ma)
              -> numpy/ma/core.py:209  info = np.finfo(sctype)
                 -> UserWarning  ==>  raised as error
```

pytest cannot attribute a session-start exception to any test, so it aborts with `INTERNALERROR` and CodSpeed reports `exit code: 3`. **Zero benchmarks are collected.**

Two details worth noting:

- `pytest-mpl` is in the environment even though the job runs `uv sync --group test`, because uv's default `dev` group pulls in `test-all` → `test-mpl`.
- Removing `pytest-mpl` would *not* fix this. It is merely the first thing to import `numpy.ma`; any later import would re-trigger it. The fatal link in the chain is the warning being an error, not who imports matplotlib.

## Fix

Ignore that one warning for the benchmark run only:

```
uv run pytest tests/benchmark --codspeed -W "ignore:Signature:UserWarning"
```

Scoped to the workflow rather than added to `pyproject.toml`'s `filterwarnings`, because outside Valgrind this warning is worth seeing — it means a genuinely broken numpy build. `-W` filters take precedence over ini ones, so this overrides `error` for this message alone.

## Verification

I could not run Valgrind on macOS/arm64, so I reproduced the *mechanism* instead — a `pytest_report_header` emitting this exact warning under `filterwarnings = ["error"]`:

- **without the flag** — same `INTERNALERROR` at `pytest_sessionstart`, matching CI;
- **with the flag** — session starts, tests pass;
- **control** — an unrelated `UserWarning` still fails the run, so strictness is preserved.

The real proof is this job going green on the next push to `main`, since it cannot run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
