### PR TITLE
✅ test(benchmark): drop the unsupported warmup marker kwarg

### DIFF
--- a/tests/benchmark/test_experimental.py
+++ b/tests/benchmark/test_experimental.py
@@ -211,7 +211,7 @@ funcs_id_and_args: list[tuple[Func, ID, JITOpts, *tuple[Arguments, ...]]] = [
     ("func", "argobj"),
     **process_pytest_paramatrization(process_func, funcs_id_and_args),
 )
-@pytest.mark.benchmark(group="quaxed", max_time=1.0, warmup=False)
+@pytest.mark.benchmark(group="quaxed", max_time=1.0)
 def test_jit_compile(func, argobj):
     """Test the speed of jitting a function."""
     _ = func.lower(*argobj.args, **argobj.kwargs).compile()
@@ -224,7 +224,6 @@ def test_jit_compile(func, argobj):
 @pytest.mark.benchmark(
     group="galax.dynamics",
     max_time=1.0,  # NOTE: max_time is ignored
-    warmup=True,
 )
 def test_execute(func, argobj):
     """Test the speed of calling the function."""


### PR DESCRIPTION
Last thing standing between `main` and green.

## Why

With the session-start abort fixed in #808, the benchmark suite gets far enough to collect — and then every one of its 28 cases fails:

```
ValueError: Unknown kwargs passed to benchmark marker: warmup
```

`warmup` is a **pytest-benchmark** kwarg. `pytest-codspeed`'s marker accepts only `group`, `min_time`, `max_time` and `max_rounds`, and since 4.x it raises on anything else rather than ignoring it. Both markers in `tests/benchmark/test_experimental.py` carried it, so the run ends `0 benchmarked` — this path has never produced benchmark data.

This was always there; the `INTERNALERROR` in #808 just aborted the session before collection could reach it. Fixing the first blocker uncovered the second.

## Scope

Dropping the kwarg **changes nothing about what is measured**. pytest-codspeed never honoured it, so `test_execute` has always timed compilation along with execution despite asking for `warmup=True`. Making that measurement genuinely warm needs an explicit call in the test body — a separate question from getting the suite running, and worth deciding on its own merits once there is data to compare against.

## Verification

Ran the suite locally both ways, which reproduces CI exactly:

| | result |
|---|---|
| before | `0 benchmarked`, `ValueError: Unknown kwargs ... warmup` |
| after | **28 benchmarked, 28 passed** |

CI's failing run reported `28 failed` / `0 benchmarked` from this single cause, so this should turn the job green and produce the first CodSpeed data the project has had through this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
