### PR TITLE
💥 boom: drop `PhaseSpaceInterpolation.y0_shape`

### DIFF
--- a/src/galax/dynamics/_src/orbit/interp.py
+++ b/src/galax/dynamics/_src/orbit/interp.py
@@ -89,11 +89,6 @@ class PhaseSpaceInterpolation(eqx.Module):
         return cast(gt.Shape, self.interp.batch_shape)
 
     @property
-    def y0_shape(self) -> gt.Shape:
-        """Return the shape of the initial value."""
-        return cast(gt.Shape, self.interp.y0_shape)
-
-    @property
     def batch_ndim(self) -> int:
         """Return the number of batch dimensions."""
         return cast(int, self.interp.batch_ndim)


### PR DESCRIPTION
`y0_shape` was removed from `diffraxtra.VectorizedDenseInterpolation` in
GalacticDynamics/diffraxtra#44 — it was computed in `__init__`, stored as a
field, and read by nothing.

This property forwarded it, to mirror the
`AbstractVectorizedDenseInterpolation` API:

```python
@property
def y0_shape(self) -> gt.Shape:
    """Return the shape of the initial value."""
    return cast(gt.Shape, self.interp.y0_shape)
```

It will raise `AttributeError` once diffraxtra 1.6 releases. Nothing in galax
calls it — those were its only two occurrences in the repository, the `def` line
and its own `return`.

## Scope check

Grepped the full repo for anything else #44 breaks:

- `y0_shape` — only this property, now gone; no references in `.py`, `.md`, or
  `.ipynb`.
- The two doctests showing `interpolation=VectorizedDenseInterpolation( ... )`
  elide the contents, so the changed `repr` does not affect them.
- `VectorizedDenseInterpolation.from_` is used as a single-argument converter,
  not with the removed third positional.

So this is the only change needed.

## Compatibility

No `diffraxtra` floor bump. Removing dead code works against both 1.5.x and 1.6,
so this can land independently of the diffraxtra release rather than being
gated on it. `scalar_interpolation`, `batch_shape` and `batch_ndim` are
untouched.

## Verification

`ruff check` on the modified file goes from 5 errors to 4 — the removal clears
one and introduces none; the remaining 4 are pre-existing. I have not run
galax's full test suite locally.

BREAKING CHANGE: `PhaseSpaceInterpolation.y0_shape` is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
