### PR TITLE
🔧 config: drop unused mypy type-ignore comments

### DIFF
--- a/src/galax/dynamics/_src/cluster/solver.py
+++ b/src/galax/dynamics/_src/cluster/solver.py
@@ -129,7 +129,7 @@ class MassSolver(AbstractSolver):
 # Init Dispatches
 
 
-@MassSolver.init.dispatch  # type: ignore[misc,union-attr]
+@MassSolver.init.dispatch
 def init(
     self: MassSolver,
     field: AbstractMassRateField,
@@ -148,7 +148,7 @@ def init(
 # Run Dispatches
 
 
-@MassSolver.run.dispatch  # type: ignore[misc,union-attr]
+@MassSolver.run.dispatch
 def run(
     self: MassSolver,
     field: AbstractMassRateField,
@@ -181,7 +181,7 @@ def run(
 default_saveat = dfx.SaveAt(t1=True)
 
 
-@MassSolver.solve.dispatch  # type: ignore[misc,union-attr]
+@MassSolver.solve.dispatch
 @eqx.filter_jit
 def solve(
     self: MassSolver,

--- a/src/galax/dynamics/_src/examples/mw_lmc.py
+++ b/src/galax/dynamics/_src/examples/mw_lmc.py
@@ -192,7 +192,7 @@ class RigidMWandLMCField(AbstractField):
         raise NotImplementedError  # pragma: no cover
 
     @override
-    @AbstractField.parse_inputs.dispatch  # type: ignore[misc,union-attr]
+    @AbstractField.parse_inputs.dispatch
     def parse_inputs(  # type: ignore[override]
         self: "RigidMWandLMCField",
         t0: gt.LikeSz0 | gt.QuSz0,

--- a/src/galax/dynamics/_src/orbit/field_base.py
+++ b/src/galax/dynamics/_src/orbit/field_base.py
@@ -33,7 +33,7 @@ class AbstractOrbitField(AbstractField):
         raise NotImplementedError  # pragma: no cover
 
     @override
-    @AbstractField.parse_inputs.dispatch  # type: ignore[misc,override,union-attr]
+    @AbstractField.parse_inputs.dispatch  # type: ignore[override]
     def parse_inputs(
         self: "AbstractOrbitField", *args: Any, ustrip: bool = True, **kwargs: Any
     ) -> tuple[Array, PyTree[Array]]:

--- a/src/galax/dynamics/_src/orbit/field_hamiltonian.py
+++ b/src/galax/dynamics/_src/orbit/field_hamiltonian.py
@@ -253,7 +253,7 @@ class HamiltonianField(AbstractOrbitField):
 # Terms dispatches
 
 
-@AbstractOrbitField.terms.dispatch  # type: ignore[misc,union-attr]
+@AbstractOrbitField.terms.dispatch
 def terms(
     self: HamiltonianField,
     _: dfx.SemiImplicitEuler,

--- a/src/galax/dynamics/_src/orbit/field_nbody.py
+++ b/src/galax/dynamics/_src/orbit/field_nbody.py
@@ -85,7 +85,7 @@ class NBodyField(AbstractOrbitField):
         raise NotImplementedError  # pragma: no cover
 
 
-@NBodyField.__call__.dispatch  # type: ignore[misc,union-attr]
+@NBodyField.__call__.dispatch
 @jax.jit
 def __call__(
     self: "NBodyField",

--- a/src/galax/dynamics/_src/orbit/solver.py
+++ b/src/galax/dynamics/_src/orbit/solver.py
@@ -771,7 +771,7 @@ def run(
 # TODO: check if this is any faster than the `init-run` pattern.
 
 
-@OrbitSolver.solve.dispatch(precedence=1)  # type: ignore[misc,union-attr]
+@OrbitSolver.solve.dispatch(precedence=1)  # type: ignore[misc]
 @ft.partial(eqx.filter_jit)
 def solve(
     self: OrbitSolver,
@@ -803,7 +803,7 @@ def solve(
     return soln
 
 
-scalar_solver = OrbitSolver.solve.invoke(  # type: ignore[union-attr]
+scalar_solver = OrbitSolver.solve.invoke(
     OrbitSolver,
     AbstractOrbitField,
     tuple[gdt.BBtQarr, gdt.BBtParr],

--- a/src/galax/dynamics/_src/solver.py
+++ b/src/galax/dynamics/_src/solver.py
@@ -426,7 +426,7 @@ def integrate_field(
         else solver
     )
     # Parse t0, y0. Important for Quantities
-    _, y0 = field.parse_inputs(ts[0], y0, ustrip=True)  # type: ignore[misc]
+    _, y0 = field.parse_inputs(ts[0], y0, ustrip=True)
 
     # Make SaveAt
     u_t = field.units["time"]


### PR DESCRIPTION
## Summary

Fixes the failing `Format` CI job on `main` ([run 34140329892](https://github.com/GalacticDynamics/galax/actions/runs/34140329892/job/101800642798)).

`plum-dispatch`'s current release now types `.dispatch`/`.invoke` correctly, so several `# type: ignore[misc, union-attr]` comments on dispatch decorators are now stale and trip mypy's `warn_unused_ignores` (part of `strict = true`). This removes the now-unused ignore codes, narrowing (rather than deleting) a couple where one code in the list is still legitimately needed:

- `solver.py`, `field_nbody.py`, `field_hamiltonian.py`, `mw_lmc.py`, `cluster/solver.py` (×3): ignore comment entirely unused → removed.
- `orbit/field_base.py:36`: `[misc,override,union-attr]` → only `override` still needed → narrowed to `[override]`.
- `orbit/solver.py:774`: `[misc,union-attr]` → only `misc` still needed → narrowed to `[misc]`.
- `orbit/solver.py:806`: `[union-attr]` entirely unused → removed.

No behavior changes — mypy-only annotation cleanup.

## Test plan

- [x] `pre-commit run --all-files` passes locally (fresh `mirrors-mypy` environment, matching CI's cache-miss build)
- [x] Verified each edit against mypy's own unused-ignore diagnostics (confirmed via a local repro that mypy reports only the specific unused error codes when a comment lists multiple codes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)