### PR TITLE
build(deps): drop tfp-nightly from gNFWPotential's core dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ dependencies = [
   "plum>=2.9.0; python_version >= '3.14'",
   "quax>=0.4.3",
   "quaxed>=0.10.5",
-  "tfp-nightly[jax]>=0.26.0.dev20260601",
   "typing-extensions>=4.13.2",
   "unxt>=1.11.2,<2",
   "wadler_lindig>=0.1.7",
@@ -133,6 +132,12 @@ test = [
   "pytest>=8.3",
   "sybil>=9.0.0",
   "pytest-env>=1.1.5",
+  # Cross-validates `gNFWPotential`'s native hyp2f1 series against
+  # tensorflow_probability's implementation; not a runtime dependency. The
+  # lower bound is kept close to the present: tfp-nightly publishes daily
+  # dev-only builds (no stable releases), so a loose bound leaves resolvers
+  # hundreds of pre-release candidates to backtrack through.
+  "tfp-nightly[jax]>=0.26.0.dev20260601",
 ]
 test-mpl = ["pytest-mpl>=0.17.0"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,11 +132,12 @@ test = [
   "pytest>=8.3",
   "sybil>=9.0.0",
   "pytest-env>=1.1.5",
-  # Cross-validates `gNFWPotential`'s native hyp2f1 series against
-  # tensorflow_probability's implementation; not a runtime dependency. The
-  # lower bound is kept close to the present: tfp-nightly publishes daily
-  # dev-only builds (no stable releases), so a loose bound leaves resolvers
-  # hundreds of pre-release candidates to backtrack through.
+  # Exercises `gNFWPotential`'s tfp-backed hyp2f1 code path in CI; not a
+  # runtime dependency (it's imported lazily, only when that potential is
+  # actually used). The lower bound is kept close to the present:
+  # tfp-nightly publishes daily dev-only builds (no stable releases), so a
+  # loose bound leaves resolvers hundreds of pre-release candidates to
+  # backtrack through.
   "tfp-nightly[jax]>=0.26.0.dev20260601",
 ]
 test-mpl = ["pytest-mpl>=0.17.0"]

--- a/src/galax/potential/_src/builtin/nfw/generalized.py
+++ b/src/galax/potential/_src/builtin/nfw/generalized.py
@@ -7,12 +7,12 @@ __all__ = [
 import functools as ft
 from dataclasses import KW_ONLY
 
-from typing import final
+from collections.abc import Callable
+from typing import Any, final
 
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-import tensorflow_probability.substrates.jax as tfp
 
 import unxt as u
 from unxt.quantity import AllowValue
@@ -230,7 +230,25 @@ def density(p: gt.Params, r: gt.BBtSz0, /) -> gt.BtFloatSz0:
 
 # -----------------------------------------------
 
-hyp2f1 = tfp.math.hypergeometric.hyp2f1_small_argument
+
+@ft.lru_cache(maxsize=1)
+def _hyp2f1_small_argument() -> Callable[..., Any]:
+    """Lazily import the ``tensorflow_probability`` hyp2f1 implementation.
+
+    ``tfp-nightly`` is no longer a core dependency: it only ever publishes
+    pre-release builds, which makes it a heavy, resolver-unfriendly
+    dependency to force on everyone just for this one potential class.
+    """
+    try:
+        import tensorflow_probability.substrates.jax as tfp
+    except ImportError as e:
+        msg = (
+            "`gNFWPotential` requires `tensorflow_probability` for its "
+            "hypergeometric-function implementation. Install it with "
+            "`pip install tensorflow_probability` (or `tfp-nightly[jax]`)."
+        )
+        raise ImportError(msg) from e
+    return tfp.math.hypergeometric.hyp2f1_small_argument  # type: ignore[no-any-return]
 
 
 @ft.partial(jax.jit)
@@ -281,7 +299,7 @@ def Bz_from_hyp2f1(a: gt.FloatSz0, b: gt.FloatSz0, z: gt.BBtFloatSz0) -> gt.BBtF
     Array(0.69312316, dtype=float64)
 
     """
-    return (z**a / a) * hyp2f1(a, 1 - b, a + 1, z)  # type: ignore[no-any-return]
+    return (z**a / a) * _hyp2f1_small_argument()(a, 1 - b, a + 1, z)  # type: ignore[no-any-return]
 
 
 @ft.partial(jax.jit)

--- a/src/galax/potential/_src/builtin/nfw/generalized.py
+++ b/src/galax/potential/_src/builtin/nfw/generalized.py
@@ -245,7 +245,7 @@ def _hyp2f1_small_argument() -> Callable[..., Any]:
         msg = (
             "`gNFWPotential` requires `tensorflow_probability` for its "
             "hypergeometric-function implementation. Install it with "
-            "`pip install tensorflow_probability` (or `tfp-nightly[jax]`)."
+            "`pip install tensorflow-probability[jax]` (or `tfp-nightly[jax]`)."
         )
         raise ImportError(msg) from e
     return tfp.math.hypergeometric.hyp2f1_small_argument  # type: ignore[no-any-return]

--- a/uv.lock
+++ b/uv.lock
@@ -854,7 +854,6 @@ dependencies = [
     { name = "plum" },
     { name = "quax" },
     { name = "quaxed" },
-    { name = "tfp-nightly", extra = ["jax"] },
     { name = "typing-extensions" },
     { name = "unxt" },
     { name = "wadler-lindig" },
@@ -910,6 +909,7 @@ dev = [
     { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-copybutton" },
     { name = "sybil" },
+    { name = "tfp-nightly", extra = ["jax"] },
     { name = "uv" },
 ]
 docs = [
@@ -928,6 +928,7 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "sybil" },
+    { name = "tfp-nightly", extra = ["jax"] },
 ]
 test-all = [
     { name = "nox" },
@@ -939,6 +940,7 @@ test-all = [
     { name = "pytest-env" },
     { name = "pytest-mpl" },
     { name = "sybil" },
+    { name = "tfp-nightly", extra = ["jax"] },
 ]
 test-mpl = [
     { name = "pytest-mpl" },
@@ -982,7 +984,6 @@ requires-dist = [
     { name = "plum", marker = "python_full_version >= '3.14'", specifier = ">=2.9.0" },
     { name = "quax", specifier = ">=0.4.3" },
     { name = "quaxed", specifier = ">=0.10.5" },
-    { name = "tfp-nightly", extras = ["jax"], specifier = ">=0.26.0.dev20260601" },
     { name = "typing-extensions", specifier = ">=4.13.2" },
     { name = "unxt", specifier = ">=1.11.2,<2" },
     { name = "wadler-lindig", specifier = ">=0.1.7" },
@@ -1009,6 +1010,7 @@ dev = [
     { name = "sphinx-autodoc-typehints", specifier = ">=2.5" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sybil", specifier = ">=9.0.0" },
+    { name = "tfp-nightly", extras = ["jax"], specifier = ">=0.26.0.dev20260601" },
     { name = "uv", specifier = ">=0.6.4" },
 ]
 docs = [
@@ -1027,6 +1029,7 @@ test = [
     { name = "pytest-cov", specifier = ">=5" },
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "sybil", specifier = ">=9.0.0" },
+    { name = "tfp-nightly", extras = ["jax"], specifier = ">=0.26.0.dev20260601" },
 ]
 test-all = [
     { name = "nox", specifier = ">=2024.10.9" },
@@ -1038,6 +1041,7 @@ test-all = [
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-mpl", specifier = ">=0.17.0" },
     { name = "sybil", specifier = ">=9.0.0" },
+    { name = "tfp-nightly", extras = ["jax"], specifier = ">=0.26.0.dev20260601" },
 ]
 test-mpl = [{ name = "pytest-mpl", specifier = ">=0.17.0" }]
 


### PR DESCRIPTION
## Summary

`tfp-nightly` is used for exactly one thing: the `hyp2f1` implementation backing `gNFWPotential`'s incomplete-beta-function math (`Bz_from_hyp2f1` in `galax/potential/_src/builtin/nfw/generalized.py`). Because it was a hard core dependency, it was imported at module scope — meaning **every** `import galax` (or `import galax.potential`) pulled it in, regardless of whether the caller ever touches `gNFWPotential`.

`tfp-nightly` only ever publishes dev/pre-release builds, so being an unconditional dependency means every galax user pays the resolver cost of a package with 600+ pre-release-only candidates on PyPI (see xggs-dev/potamides#95, #815).

## Changes

- Remove `tfp-nightly[jax]` from core `dependencies`. Lazily import it inside `Bz_from_hyp2f1` instead of at module scope.
- Keep it in the `test` dependency group so CI can still exercise/cross-validate `gNFWPotential`.

**Update:** an earlier version of this PR added a `gnfw` extra (`pip install galax[gnfw]`) so users could still opt into `tfp-nightly` for `gNFWPotential`. That turned out to be actively harmful rather than just unnecessary — see #818, which found that `tfp.hyp2f1_small_argument` (a) returns `NaN` for `gNFWPotential`'s exact call pattern once `z >= 0.9` (#817), and (b) implements its gradient via `jax.custom_vjp`, which can **never** be forward-differentiated, meaning `gNFWPotential.hessian()`/`.tidal_tensor()` has been unconditionally broken (any `r`, any `gamma`) as long as it depends on `tfp` at all (#820). Since #818 replaces the usage entirely with a native implementation, keeping a `tfp` fallback path around would just reintroduce #820 whenever `tfp-nightly` happens to be installed — so the extra is dropped rather than kept as an option.

## Context

Part 2 of a 3-PR sequence (see #815 for part 1, #818 for part 3):
1. #815 — tighten the version pin (quick mitigation, already up).
2. **This PR** — remove `tfp-nightly` from the core install.
3. #818 — replace the usage entirely with a native implementation (also fixes #817 and #820).

## Test plan

- [x] `uv lock` resolves cleanly
- [x] `import galax.potential` works with `tensorflow_probability` absent
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)