### PR TITLE
perf(test): parallelize the test suite with pytest-xdist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         run: >-
           uv run pytest src docs tests/unit tests/functional -ra --cov
           --cov-report=xml --cov-report=term --durations=20 --arraydiff -m"not
-          slow"
+          slow" -n logical --dist=loadfile
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v7.0.0
@@ -129,7 +129,7 @@ jobs:
           uv run pytest tests/integration src docs tests/unit tests/functional
           -ra --durations=20 --cov --cov-report=xml --cov-report=term
           --arraydiff -m"not slow" --mpl --mpl-hash-library=hashes.json
-          --mpl-deterministic
+          --mpl-deterministic -n logical --dist=loadfile
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v7.0.0

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,6 +14,12 @@ nox.options.sessions = ["lint", "tests", "doctests"]
 nox.options.default_venv_backend = "uv|virtualenv"
 
 
+def _xdist_args(posargs: list[str]) -> list[str]:
+    """`-n logical --dist=loadfile`, unless `--pdb`/`--trace` want a serial run."""
+    debugging = any(arg == "--trace" or arg.startswith("--pdb") for arg in posargs)
+    return [] if debugging else ["-n", "logical", "--dist=loadfile"]
+
+
 @nox.session
 def lint(session: nox.Session) -> None:
     """Run the linter."""
@@ -41,7 +47,7 @@ def tests(session: nox.Session) -> None:
     """Run the unit and regular tests."""
     session.install("-e", ".[test]")
     os.environ["GALAX_ENABLE_RUNTIME_TYPECHECKS"] = "1"  # TODO: set in a better way
-    session.run("pytest", *session.posargs)
+    session.run("pytest", *_xdist_args(session.posargs), *session.posargs)
 
 
 @nox.session
@@ -49,7 +55,7 @@ def tests_all(session: nox.Session) -> None:
     """Run the unit and regular tests."""
     session.install("-e", ".[test-all]")
     os.environ["GALAX_ENABLE_RUNTIME_TYPECHECKS"] = "1"  # TODO: set in a better way
-    session.run("pytest", *session.posargs)
+    session.run("pytest", *_xdist_args(session.posargs), *session.posargs)
 
 
 @nox.session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ test = [
   # loose bound leaves resolvers hundreds of pre-release candidates to
   # backtrack through.
   "tfp-nightly[jax]>=0.26.0.dev20260601",
+  "pytest-xdist>=3.6.1",
 ]
 test-mpl = ["pytest-mpl>=0.17.0"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -734,6 +734,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -905,6 +914,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-mpl" },
+    { name = "pytest-xdist" },
     { name = "sphinx" },
     { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-copybutton" },
@@ -927,6 +937,7 @@ test = [
     { name = "pytest-codspeed" },
     { name = "pytest-cov" },
     { name = "pytest-env" },
+    { name = "pytest-xdist" },
     { name = "sybil" },
     { name = "tfp-nightly", extra = ["jax"] },
 ]
@@ -939,6 +950,7 @@ test-all = [
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-mpl" },
+    { name = "pytest-xdist" },
     { name = "sybil" },
     { name = "tfp-nightly", extra = ["jax"] },
 ]
@@ -1006,6 +1018,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=5" },
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-mpl", specifier = ">=0.17.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "sphinx", specifier = ">=8.1" },
     { name = "sphinx-autodoc-typehints", specifier = ">=2.5" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
@@ -1028,6 +1041,7 @@ test = [
     { name = "pytest-codspeed", specifier = ">=3.2.0" },
     { name = "pytest-cov", specifier = ">=5" },
     { name = "pytest-env", specifier = ">=1.1.5" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "sybil", specifier = ">=9.0.0" },
     { name = "tfp-nightly", extras = ["jax"], specifier = ">=0.26.0.dev20260601" },
 ]
@@ -1040,6 +1054,7 @@ test-all = [
     { name = "pytest-cov", specifier = ">=5" },
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-mpl", specifier = ">=0.17.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "sybil", specifier = ">=9.0.0" },
     { name = "tfp-nightly", extras = ["jax"], specifier = ">=0.26.0.dev20260601" },
 ]
@@ -2183,6 +2198,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9c/40/ba3caed7a54a6a5fe035ecc62dbb473f6f41ecade2ea3e0474f7e8e65c5c/pytest_mpl-0.18.0.tar.gz", hash = "sha256:04c949ea1278a38ca3d8d675871f6c5a0958bfedfaf4fd8bfd4e25e5861759a7", size = 880354, upload-time = "2025-11-15T13:54:52.69Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/01/f9128b75808840fc070042c57168c800da57d2d80b97071dc6f07c793d58/pytest_mpl-0.18.0-py3-none-any.whl", hash = "sha256:e474b7676957c521104dbe351df937da5e582231cd34daeb43b9d1ecc048e5c0", size = 28063, upload-time = "2025-11-15T13:54:51.147Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Run the test suite in parallel by default via `pytest-xdist`, using `--dist=loadfile` to keep each file's Sybil doctests on a single worker (matches the setup in `coordinax` and `unxt`).
- Apply `-n logical --dist=loadfile` to both CI test jobs (`checks`, `check_interop`) and the `tests`/`tests_all` nox sessions.
- Auto-disable xdist in nox when `--pdb`/`--trace` is passed, so interactive debugging still works without remembering `-n0`.

## Test plan
- [x] `uv sync --group test` resolves cleanly with `pytest-xdist` added
- [x] `uv run pytest tests/smoke -n logical --dist=loadfile` passes
- [x] `uv run pytest docs -n logical --dist=loadfile --arraydiff` passes (Sybil doctests survive parallelization)
- [x] Verified the nox `_xdist_args` helper disables xdist for `--pdb`/`--trace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)