### PR TITLE
🔧 config: add CI Pass status gate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,3 +179,17 @@ jobs:
           run:
             uv run pytest tests/benchmark --codspeed -W
             "ignore:Signature:UserWarning"
+
+  status:
+    name: CI Pass
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
+    needs: [pre-commit, smoke, checks, check_interop, benchmark]
+    steps:
+      - name: All required jobs passed
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}
+          # benchmark only runs on workflow_dispatch / the run-benchmarks label /
+          # push to main (see its `if:`), so it's intentionally skipped on most PRs.
+          allowed-skips: benchmark


### PR DESCRIPTION
## Summary
- Adds a `CI Pass` status job to `.github/workflows/ci.yml` that aggregates `pre-commit`, `smoke`, `checks`, `check_interop`, and `benchmark` into a single required check via `re-actors/alls-green`, matching the pattern used in [unxt](https://github.com/GalacticDynamics/unxt) and [coordinax](https://github.com/GalacticDynamics/coordinax)
- `benchmark` is listed in `allowed-skips` since it only runs conditionally (workflow_dispatch, the `run-benchmarks` label, or push to main)

## Why
Branch protection can point at one stable check name (`CI Pass`) instead of enumerating every individual job, which also avoids protection breaking whenever a job is renamed or the matrix changes.

## Test plan
- [ ] Verify `CI Pass` appears and passes on this PR's checks
- [ ] Update branch protection required status checks to use `CI Pass` instead of individual job names

🤖 Generated with [Claude Code](https://claude.com/claude-code)