### PR TITLE
🔧 config: trim macOS/Windows Python matrix in checks job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,20 @@ jobs:
       matrix:
         python-version: ["3.12", "3.14"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        # macOS runners bill at 10x the Linux rate (and run ~3x slower
+        # wall-clock for this JAX-heavy suite even with the same xdist
+        # settings -- 3 workers vs Linux's 4, but each core is also slower);
+        # Windows bills at 2x. Both Python versions are already fully
+        # exercised on Linux, so re-running both on macOS/Windows is
+        # cross-OS coverage, not cross-version coverage -- one version per
+        # non-Linux OS still catches a platform-specific break. Pinned to the
+        # newest version so it doubles as "does the latest Python work here".
+        # Matches the pattern in unxt's CI.
+        exclude:
+          - runs-on: macos-latest
+            python-version: "3.12"
+          - runs-on: windows-latest
+            python-version: "3.12"
 
         # TODO: figure out OpenBLAS install
         #   ``ERROR: Dependency "OpenBLAS" not found, tried pkgconfig and cmake``


### PR DESCRIPTION
## Summary
- Pin `macos-latest` and `windows-latest` to only the newest Python version (3.14) in the `checks` job matrix; `ubuntu-latest` keeps the full version matrix
- Matches the pattern already used in [unxt](https://github.com/GalacticDynamics/unxt)'s CI (`tests-unxt` job)

## Why
Checked actual job timings on a recent successful `main` run (34226380206):

| Job | Wall time | xdist workers |
|---|---|---|
| Check Python 3.14 on ubuntu-latest | ~13 min | 4/4 |
| Check Python 3.14 on macos-latest | ~35 min | 3/3 |
| Check Python 3.14 on windows-latest | ~20 min | n/a |

`-n logical --dist=loadfile` is already wired up in both `checks` and `check_interop` (via the CI workflow directly, and via `noxfile.py`'s `_xdist_args` for local runs) and is already using every available core on each runner — macOS gets 3 workers vs Linux's 4, and each macOS core is also slower for this JAX-heavy suite. So xdist is already maxed out; the actual lever is that both Python versions run on all three OSes, meaning macOS and Windows re-run the whole suite twice. Since Linux already fully covers both versions, this is duplicated cross-OS coverage, not extra cross-version coverage.

macOS bills at 10x the Linux rate and Windows at 2x, so this removes the most expensive job entirely and roughly halves the second-most-expensive one, on every PR.

## Test plan
- [ ] Confirm `checks` now produces 4 matrix jobs instead of 6 (ubuntu×2, macos×1, windows×1)
- [ ] Confirm CI still passes end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)