### PR TITLE
✨ feat(potential): add InterpolatedZhaoPotential

### DIFF
--- a/src/galax/potential/__init__.py
+++ b/src/galax/potential/__init__.py
@@ -47,6 +47,7 @@ __all__ = [
     "HardCutoffNFWPotential",
     "gNFWPotential",
     "ZhaoPotential",
+    "InterpolatedZhaoPotential",
     # Pre-composited
     "AbstractPreCompositedPotential",
     "BovyMWPotential2014",
@@ -106,6 +107,7 @@ with install_import_hook("galax.potential"):
         HarmonicOscillatorPotential,
         HenonHeilesPotential,
         HernquistPotential,
+        InterpolatedZhaoPotential,
         IsochronePotential,
         JaffePotential,
         KeplerPotential,

--- a/src/galax/potential/_src/builtin/__init__.py
+++ b/src/galax/potential/_src/builtin/__init__.py
@@ -45,6 +45,7 @@ __all__ = [
     "TriaxialHernquistPotential",
     "HardCutoffNFWPotential",
     "ZhaoPotential",
+    "InterpolatedZhaoPotential",
 ]
 
 from .burkert import BurkertPotential
@@ -93,3 +94,4 @@ from .powerlawcutoff import PowerLawCutoffPotential
 from .satoh import SatohPotential
 from .stoneostriker15 import StoneOstriker15Potential
 from .zhao import ZhaoPotential
+from .zhao_interp import InterpolatedZhaoPotential

--- a/src/galax/potential/_src/builtin/zhao.py
+++ b/src/galax/potential/_src/builtin/zhao.py
@@ -251,6 +251,16 @@ def _norm(p: gt.Params, /) -> gt.FloatSz0:
     """
     c0, _, q0 = _cpq(p["alpha"], p["beta"], p["gamma"])
     bz_half = incomplete_beta(c0 - q0, q0, jnp.asarray(0.5))
+    return norm_from_bz_half(p, bz_half)  # type: ignore[no-any-return]
+
+
+@ft.partial(jax.jit)
+def norm_from_bz_half(p: gt.Params, bz_half: gt.FloatSz0, /) -> gt.FloatSz0:
+    """`_norm` given an already-evaluated ``B(alpha(3-gamma), alpha(beta-3), 1/2)``.
+
+    Split out so that a variant with fixed power-law indices can supply that
+    value as a constant. See `_norm` for what it means.
+    """
     return p["m"] / (4.0 * jnp.pi * p["alpha"] * bz_half)  # type: ignore[no-any-return]
 
 
@@ -268,11 +278,19 @@ def density(p: gt.Params, r: gt.BBtSz0, /) -> gt.BtFloatSz0:
         \quad u = r / r_s
 
     """
+    return density_from_norm(p, r, _norm(p))  # type: ignore[no-any-return]
+
+
+@ft.partial(jax.jit)
+def density_from_norm(
+    p: gt.Params, r: gt.BBtSz0, norm: gt.FloatSz0, /
+) -> gt.BtFloatSz0:
+    """`density` given an already-evaluated normalization. See `density`."""
     alpha, beta, gamma = p["alpha"], p["beta"], p["gamma"]
     uu = r / p["r_s"]
     b = (beta - gamma) * alpha
-    _result = _norm(p) / p["r_s"] ** 3 / uu**gamma / (1.0 + uu ** (1.0 / alpha)) ** b
-    return _result  # type: ignore[no-any-return]
+    _result = norm / p["r_s"] ** 3 / uu**gamma / (1.0 + uu ** (1.0 / alpha)) ** b
+    return _result
 
 
 @ft.partial(jax.jit)
@@ -286,7 +304,15 @@ def mass_enclosed(p: gt.Params, r: gt.BBtSz0, /) -> gt.BtFloatSz0:
     """
     c0, _, q0 = _cpq(p["alpha"], p["beta"], p["gamma"])
     chi = _r_to_chi(p, r)
-    _result = 4.0 * jnp.pi * p["alpha"] * _norm(p) * incomplete_beta(c0 - q0, q0, chi)
+    return mass_enclosed_from_bz(p, _norm(p), incomplete_beta(c0 - q0, q0, chi))  # type: ignore[no-any-return]
+
+
+@ft.partial(jax.jit)
+def mass_enclosed_from_bz(
+    p: gt.Params, norm: gt.FloatSz0, bz_interior: gt.BBtSz0, /
+) -> gt.BtFloatSz0:
+    """`mass_enclosed` given already-evaluated pieces. See `mass_enclosed`."""
+    _result = 4.0 * jnp.pi * p["alpha"] * norm * bz_interior
     return _result  # type: ignore[no-any-return]
 
 
@@ -316,16 +342,38 @@ def potential(p: gt.Params, r: gt.BBtSz0, /) -> gt.BtFloatSz0:
     """
     c0, p0, q0 = _cpq(p["alpha"], p["beta"], p["gamma"])
     chi = _r_to_chi(p, r)
+    return potential_from_bz(  # type: ignore[no-any-return]
+        p,
+        r,
+        chi,
+        incomplete_beta(c0 - q0, q0, chi),
+        incomplete_beta(c0 - p0, p0, 1.0 - chi),
+        density(p, r),
+    )
+
+
+@ft.partial(jax.jit)
+def potential_from_bz(
+    p: gt.Params,
+    r: gt.BBtSz0,
+    chi: gt.BBtSz0,
+    bz_interior: gt.BBtSz0,
+    bz_exterior: gt.BBtSz0,
+    rho: gt.BBtSz0,
+    /,
+) -> gt.BtFloatSz0:
+    """Zhao Eqs. 6-7 from already-evaluated pieces. See `potential`."""
+    c0, p0, q0 = _cpq(p["alpha"], p["beta"], p["gamma"])
     chi1 = 1.0 - chi
 
     # Eq. 7, interior term: B(c0-q0, q0, chi) / (chi^(c0-q0) (1-chi)^q0)
-    interior = incomplete_beta(c0 - q0, q0, chi) / (chi ** (c0 - q0) * chi1**q0)
+    interior = bz_interior / (chi ** (c0 - q0) * chi1**q0)
     # Eq. 7, exterior term: B(c0-p0, p0, 1-chi) / ((1-chi)^(c0-p0) chi^p0)
-    exterior = incomplete_beta(c0 - p0, p0, chi1) / (chi1 ** (c0 - p0) * chi**p0)
+    exterior = bz_exterior / (chi1 ** (c0 - p0) * chi**p0)
 
     f00 = p["alpha"] * (interior + exterior)
     # Eq. 6, with G restored (Zhao sets G = 1).
-    _result = -4.0 * jnp.pi * p["G"] * density(p, r) * f00 * r**2
+    _result = -4.0 * jnp.pi * p["G"] * rho * f00 * r**2
     return _result  # type: ignore[no-any-return]
 
 
@@ -356,8 +404,15 @@ def d2potential_dr2(p: gt.Params, r: gt.BBtSz0, /) -> gt.BtFloatSz0:
         \frac{d^2\Phi}{dr^2} = 4\pi G \rho(r) - \frac{2 G M(r)}{r^3}
 
     """
-    interior = 2.0 * p["G"] * mass_enclosed(p, r) / r**3
-    return 4.0 * jnp.pi * p["G"] * density(p, r) - interior  # type: ignore[no-any-return]
+    return d2potential_dr2_from(p, r, mass_enclosed(p, r), density(p, r))  # type: ignore[no-any-return]
+
+
+@ft.partial(jax.jit)
+def d2potential_dr2_from(
+    p: gt.Params, r: gt.BBtSz0, m_enc: gt.BBtSz0, rho: gt.BBtSz0, /
+) -> gt.BtFloatSz0:
+    """`d2potential_dr2` from already-evaluated pieces. See `d2potential_dr2`."""
+    return 4.0 * jnp.pi * p["G"] * rho - 2.0 * p["G"] * m_enc / r**3  # type: ignore[no-any-return]
 
 
 @ft.partial(jax.jit)
@@ -382,7 +437,15 @@ def gradient(p: gt.Params, xyz: gt.BBtSz3, /) -> gt.BBtSz3:
 
     """
     r = jnp.linalg.norm(xyz, axis=-1, keepdims=True)
-    return dpotential_dr(p, r) * (xyz / r)  # type: ignore[no-any-return]
+    return gradient_from_radial(dpotential_dr(p, r), xyz, r)  # type: ignore[no-any-return]
+
+
+@ft.partial(jax.jit)
+def gradient_from_radial(
+    dphi_dr: gt.BBtSz0, xyz: gt.BBtSz3, r: gt.BBtSz0, /
+) -> gt.BBtSz3:
+    """`gradient` given dPhi/dr. See `gradient`."""
+    return dphi_dr * (xyz / r)
 
 
 @ft.partial(jax.jit)
@@ -400,9 +463,15 @@ def hessian(p: gt.Params, xyz: gt.Sz3, /) -> gt.Sz33:
     with $\Phi'$ and $\Phi''$ from `dpotential_dr` and `d2potential_dr2`.
     """
     r = jnp.linalg.norm(xyz, axis=-1, keepdims=True)
-    radial = dpotential_dr(p, r) / r
-    d2phi_dr2 = d2potential_dr2(p, r)
+    return hessian_from_radial(dpotential_dr(p, r), d2potential_dr2(p, r), xyz, r)  # type: ignore[no-any-return]
 
+
+@ft.partial(jax.jit)
+def hessian_from_radial(
+    dphi_dr: gt.BBtSz0, d2phi_dr2: gt.BBtSz0, xyz: gt.Sz3, r: gt.BBtSz0, /
+) -> gt.Sz33:
+    """`hessian` given the two radial derivatives. See `hessian`."""
+    radial = dphi_dr / r
     rhat = xyz / r
     outer = rhat[..., :, None] * rhat[..., None, :]
     eye = jnp.eye(3, dtype=outer.dtype)

--- a/src/galax/potential/_src/builtin/zhao_interp.py
+++ b/src/galax/potential/_src/builtin/zhao_interp.py
@@ -1,0 +1,248 @@
+r"""Zhao (1996) double power-law potential, with interpolated special functions.
+
+`ZhaoPotential` evaluates the incomplete beta function of Zhao's Eq. 43 by
+summing a 64-term series on every call, because its power-law indices are
+ordinary parameters and so may vary. Most uses fix them: for a halo whose
+$(\alpha, \beta, \gamma)$ never change, the model needs just two fixed
+functions of one variable, and those can be fitted once at construction.
+
+`InterpolatedZhaoPotential` does that, with the Chebyshev fit in
+`galax.potential._src.special`. The mass and scale radius stay ordinary
+(possibly time-dependent) parameters -- ``m`` enters only as a linear
+normalization and ``r_s`` only through Zhao's $\chi$ (Eq. 5), so neither
+affects the fit.
+
+Everything else -- the equations, the analytic gradient/hessian/laplacian --
+is shared with `ZhaoPotential`, so this differs only in how two numbers get
+computed.
+"""
+
+__all__ = ["InterpolatedZhaoPotential"]
+
+import functools as ft
+
+from typing import Any, NamedTuple, final
+
+import equinox as eqx
+import jax
+
+import quaxed.numpy as jnp
+import unxt as u
+from unxt.quantity import AllowValue
+
+import galax.potential.custom_types as gt
+from .zhao import (
+    _r_to_chi,
+    d2potential_dr2_from,
+    density_from_norm,
+    gradient_from_radial,
+    hessian_from_radial,
+    mass_enclosed_from_bz,
+    norm_from_bz_half,
+    potential_from_bz,
+)
+from galax.potential._src.base_single import AbstractSinglePotential
+from galax.potential._src.jax import vectorize_method
+from galax.potential._src.params.base import AbstractParameter
+from galax.potential._src.params.field import ParameterField
+from galax.potential._src.special import ChebyshevIncompleteBeta
+from galax.potential._src.utils import r_spherical
+
+DimL = u.dimension("length")
+
+
+class _Fit(NamedTuple):
+    """The two fitted incomplete beta functions Zhao's Eq. 7 needs, plus B(.,.,1/2)."""
+
+    interior: ChebyshevIncompleteBeta
+    exterior: ChebyshevIncompleteBeta
+    bz_half: float
+
+
+@ft.cache
+def _fitted(alpha: float, beta: float, gamma: float, n: int) -> _Fit:
+    """Fit the two beta functions for these indices; memoized on them.
+
+    The fit depends only on the power-law indices, which are static, so it is
+    a constant of the model rather than part of its pytree -- and repeating a
+    set of indices (a fit per orbit, say) costs nothing after the first.
+    """
+    # Zhao Eq. 42, in plain Python: this runs while tracing, where a jitted
+    # helper would inline into the trace and hand back tracers.
+    c0, p0, q0 = alpha * (beta - gamma), alpha * (2.0 - gamma), alpha * (beta - 3.0)
+    interior = ChebyshevIncompleteBeta(c0 - q0, q0, n)
+    exterior = ChebyshevIncompleteBeta(c0 - p0, p0, n)
+    # chi(r_s) = 1/2 for any alpha (Eq. 5), so the normalization is a constant.
+    return _Fit(interior, exterior, interior.at_half)
+
+
+@final
+class InterpolatedZhaoPotential(AbstractSinglePotential):
+    r"""Zhao (1996) potential with the incomplete beta functions interpolated.
+
+    Numerically equivalent to `ZhaoPotential` -- same equations, same analytic
+    derivatives -- but with Zhao's Eq. 43 replaced by a Chebyshev fit made once
+    at construction, which is worth roughly an order of magnitude per
+    evaluation.
+
+    The power-law indices are fixed at construction (they set what is fitted),
+    so unlike `ZhaoPotential` they are plain numbers rather than parameters and
+    cannot vary with time. ``m`` and ``r_s`` are ordinary parameters, as usual.
+
+    Parameters
+    ----------
+    m, r_s
+        As `ZhaoPotential`.
+    alpha, beta, gamma
+        As `ZhaoPotential`, but static: plain floats, not parameters.
+    n_coeffs
+        Chebyshev coefficients per panel. The default reaches ~1e-13 over the
+        whole valid index range; see `ChebyshevIncompleteBeta`.
+
+    Examples
+    --------
+    >>> import quaxed.numpy as jnp
+    >>> import unxt as u
+    >>> import galax.potential as gp
+
+    >>> kw = dict(m=u.Quantity(1e12, "Msun"), r_s=u.Quantity(10.0, "kpc"),
+    ...           alpha=1.0, beta=4.0, gamma=1.0, units="galactic")
+    >>> pot = gp.InterpolatedZhaoPotential(**kw)
+    >>> exact = gp.ZhaoPotential(**kw)
+
+    It agrees with `ZhaoPotential` to near machine precision:
+
+    >>> xyz = u.Quantity([8.0, 0.0, 0.0], "kpc")
+    >>> got = pot.potential(xyz, 0)
+    >>> bool(jnp.isclose(got, exact.potential(xyz, 0),
+    ...                  atol=u.Quantity(1e-12, got.unit)))
+    True
+
+    >>> got = pot.gradient(xyz, 0).x
+    >>> bool(jnp.isclose(got, exact.gradient(xyz, 0).x,
+    ...                  atol=u.Quantity(1e-12, got.unit)))
+    True
+
+    """
+
+    m: AbstractParameter = ParameterField(  # type: ignore[assignment]
+        dimensions="mass", doc="Mass enclosed within the scale radius."
+    )
+    r_s: AbstractParameter = ParameterField(dimensions="length", doc="Scale radius.")  # type: ignore[assignment]
+
+    alpha: float = eqx.field(static=True, converter=float)
+    beta: float = eqx.field(static=True, converter=float)
+    gamma: float = eqx.field(static=True, converter=float)
+    n_coeffs: int = eqx.field(static=True, default=24, converter=int)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        # Fit now rather than on first evaluation, so that indices the fit
+        # cannot represent are rejected here, where the traceback is useful.
+        # The result is memoized, so `_fit` below is then free.
+        _ = self._fit
+
+    @property
+    def _fit(self) -> "_Fit":
+        """The fitted beta functions; see `_fitted`."""
+        return _fitted(self.alpha, self.beta, self.gamma, self.n_coeffs)
+
+    # ===========================================
+
+    def _params(self, t: gt.BBtQorVSz0, /) -> gt.Params:
+        """Build the parameter dict the shared `zhao` functions take."""
+        t = u.Q.from_(t, self.units["time"])
+        return {
+            "G": self.constants["G"].value,
+            "m": self.m(t, ustrip=self.units["mass"]),
+            "r_s": self.r_s(t, ustrip=self.units["length"]),
+            "alpha": jnp.asarray(self.alpha),
+            "beta": jnp.asarray(self.beta),
+            "gamma": jnp.asarray(self.gamma),
+        }
+
+    def _norm(self, p: gt.Params, /) -> gt.FloatSz0:
+        return norm_from_bz_half(p, jnp.asarray(self._fit.bz_half))  # type: ignore[no-any-return]
+
+    def _mass_enclosed(self, p: gt.Params, r: gt.BBtSz0, /) -> gt.BtFloatSz0:
+        chi = _r_to_chi(p, r)
+        return mass_enclosed_from_bz(p, self._norm(p), self._fit.interior(chi))  # type: ignore[no-any-return]
+
+    # ===========================================
+
+    @ft.partial(jax.jit)
+    def _potential(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BBtSz0:
+        p = self._params(t)
+        r = r_spherical(xyz, self.units["length"])
+        chi = _r_to_chi(p, r)
+        rho = density_from_norm(p, r, self._norm(p))
+        fit = self._fit
+        return potential_from_bz(  # type: ignore[no-any-return]
+            p, r, chi, fit.interior(chi), fit.exterior(1.0 - chi), rho
+        )
+
+    @ft.partial(jax.jit)
+    def _density(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BtFloatSz0:
+        p = self._params(t)
+        r = r_spherical(xyz, self.units["length"])
+        return density_from_norm(p, r, self._norm(p))  # type: ignore[no-any-return]
+
+    @ft.partial(jax.jit)
+    def _laplacian(self, xyz: gt.BBtQorVSz3, /, t: gt.BBtQorVSz0) -> gt.BBtFloatSz0:
+        return 4.0 * jnp.pi * self.constants["G"].value * self._density(xyz, t)  # type: ignore[no-any-return]
+
+    @ft.partial(jax.jit)
+    def _gradient(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BBtSz3:
+        p = self._params(t)
+        xyz = u.ustrip(AllowValue, self.units[DimL], xyz)
+        r = jnp.linalg.norm(xyz, axis=-1, keepdims=True)
+        dphi_dr = p["G"] * self._mass_enclosed(p, r) / r**2
+        return gradient_from_radial(dphi_dr, xyz, r)  # type: ignore[no-any-return]
+
+    @vectorize_method(signature="(3),()->(3,3)")
+    @ft.partial(jax.jit)
+    def _hessian(
+        self, xyz: gt.FloatQuSz3 | gt.FloatSz3, t: gt.QuSz0 | gt.Sz0, /
+    ) -> gt.Sz33:
+        p = self._params(t)
+        xyz = u.ustrip(AllowValue, self.units[DimL], xyz)
+        r = jnp.linalg.norm(xyz, axis=-1, keepdims=True)
+        m_enc = self._mass_enclosed(p, r)
+        rho = density_from_norm(p, r, self._norm(p))
+        dphi_dr = p["G"] * m_enc / r**2
+        d2phi_dr2 = d2potential_dr2_from(p, r, m_enc, rho)
+        return hessian_from_radial(dphi_dr, d2phi_dr2, xyz, r)  # type: ignore[no-any-return]
+
+    # ===========================================
+
+    @classmethod
+    def from_zhao(
+        cls, pot: Any, /, *, n_coeffs: int = 24
+    ) -> "InterpolatedZhaoPotential":
+        """Build from a `ZhaoPotential`, whose indices must be constant.
+
+        Examples
+        --------
+        >>> import unxt as u
+        >>> import galax.potential as gp
+
+        >>> exact = gp.ZhaoPotential(m=u.Quantity(1e12, "Msun"),
+        ...                          r_s=u.Quantity(10.0, "kpc"),
+        ...                          alpha=1.0, beta=4.0, gamma=1.0,
+        ...                          units="galactic")
+        >>> gp.InterpolatedZhaoPotential.from_zhao(exact).beta
+        4.0
+
+        """
+        t = u.Q(0.0, pot.units["time"])
+        udim = pot.units["dimensionless"]
+        return cls(
+            m=pot.m,
+            r_s=pot.r_s,
+            alpha=float(pot.alpha(t, ustrip=udim)),
+            beta=float(pot.beta(t, ustrip=udim)),
+            gamma=float(pot.gamma(t, ustrip=udim)),
+            n_coeffs=n_coeffs,
+            units=pot.units,
+            constants=pot.constants,
+        )

--- a/src/galax/potential/_src/special.py
+++ b/src/galax/potential/_src/special.py
@@ -23,13 +23,22 @@ convergent series with an exact O(1) derivative rule.
 See also `galax.potential._src.builtin.nfw.hyp2f1`, which solves the same
 problem for `gNFWPotential`, but only for the two parameter patterns that
 model needs (``a == 1``, or ``b == 0``), for which it has closed forms.
+
+When ``a`` and ``b`` are fixed for the lifetime of a potential,
+`ChebyshevIncompleteBeta` replaces those series with a short polynomial fitted
+once at construction.
 """
 
 __all__: tuple[str, ...] = ()
 
 import functools as ft
 
+from collections.abc import Callable
+from jaxtyping import Float
+
+import equinox as eqx
 import jax
+import numpy as np
 from jax.custom_derivatives import SymbolicZero
 
 import quaxed.numpy as jnp
@@ -236,3 +245,144 @@ def _incomplete_beta_jvp(
 
 
 incomplete_beta = jax.jit(incomplete_beta)  # type: ignore[assignment]
+
+
+# ===================================================================
+# Fitted form, for a potential whose (a, b) never change
+
+
+_FIT_SERIES_TERMS = 400
+"""Series terms used to build the fit targets. Host-side and once, so cheap."""
+
+
+def _poch_over_fact(x: float, n: int) -> np.ndarray:
+    """(x)_k / k! for k = 0 .. n-1."""
+    k = np.arange(1, n)
+    return np.cumprod(np.concatenate([[1.0], (x + k - 1) / k]))
+
+
+def _lo_target(a: float, b: float, z: np.ndarray) -> np.ndarray:
+    r"""$_2F_1(a, 1-b; a+1; z) = a B(a,b,z) / z^a$, the analytic part of `_small_z`."""
+    k = np.arange(_FIT_SERIES_TERMS)
+    coeff = _poch_over_fact(1.0 - b, _FIT_SERIES_TERMS) * a / (a + k)
+    return (coeff * z[..., None] ** k).sum(-1)
+
+
+def _hi_target(a: float, b: float, w: np.ndarray) -> np.ndarray:
+    r"""$V(w) = \sum_m \frac{(1-a)_m}{m!} \frac{w^m}{b+m}$, or its `b == 0` form.
+
+    This is the analytic factor in `B(a, b, 1-w) = const - w^b V(w)` -- see
+    `ChebyshevIncompleteBeta`. Summing the series rather than differencing
+    values of `B` avoids the cancellation that makes the latter useless as
+    `w -> 0`, which is exactly where the fit needs its nodes.
+    """
+    m = np.arange(_FIT_SERIES_TERMS)
+    c = _poch_over_fact(1.0 - a, _FIT_SERIES_TERMS)
+    w = w[..., None]
+    if b == 0:  # the m = 0 term is the -log(w) split off in __call__
+        return (c[1:] * w ** m[1:] / m[1:]).sum(-1)
+    return (c * w**m / (b + m)).sum(-1)
+
+
+def _chebfit(f: Callable[[np.ndarray], np.ndarray], n: int) -> np.ndarray:
+    """Chebyshev coefficients of `f` on [0, 1/2], from `n` Gauss-Chebyshev nodes."""
+    x = np.cos(np.pi * (np.arange(n) + 0.5) / n)
+    return np.polynomial.chebyshev.chebfit(x, f(0.25 * (x + 1)), n - 1)
+
+
+def _clenshaw(coef: Float[np.ndarray, " n"], x: gt.BBtSz0) -> gt.BBtFloatSz0:
+    """Evaluate a Chebyshev series at `x` in [-1, 1] by Clenshaw recurrence."""
+    b1 = jnp.zeros_like(x)
+    b2 = jnp.zeros_like(x)
+    for c in coef[:0:-1]:  # static length, so this unrolls at trace time
+        b1, b2 = 2.0 * x * b1 - b2 + c, b1
+    return x * b1 - b2 + coef[0]  # type: ignore[no-any-return]
+
+
+class ChebyshevIncompleteBeta(eqx.Module):
+    r"""$B(a, b, \cdot)$ for fixed $a, b$, as two Chebyshev panels.
+
+    `incomplete_beta` sums 64 series terms on every call because it must work
+    for any $(a, b)$. A potential with fixed power-law indices needs only one
+    function of one variable, which a short polynomial captures instead.
+
+    The function is a power law at both ends -- $z^a$ as $z \to 0$, and $w^b$
+    (or $\ln w$, or nothing) as $w = 1 - z \to 0$ -- so neither half is
+    analytic across the whole interval. Splitting at $z = 1/2$ and dividing out
+    the end behaviour leaves two analytic functions, which Chebyshev series
+    converge on geometrically:
+
+    .. math::
+
+        B(a, b, z) &= \frac{z^a}{a} \, {}_2F_1(a, 1-b; a+1; z), & z \leq 1/2 \\
+        B(a, b, z) &= \mathrm{const} - w^b V(w),                & w \leq 1/2 \\
+        B(a, b, z) &= \mathrm{const} + \ln w - V_0(w),          & w \leq 1/2,\, b = 0
+
+    In practice ~18 coefficients per panel reach 1e-13 over the whole
+    $(\alpha, \beta, \gamma)$ range of `ZhaoPotential`.
+
+    ``const`` is fixed by matching the two panels at $z = 1/2$, so the fit
+    needs no reference implementation beyond its own series.
+    """
+
+    a: float = eqx.field(static=True)
+    b: float = eqx.field(static=True)
+    const: float = eqx.field(static=True)
+    at_half: float = eqx.field(static=True)
+    """``B(a, b, 1/2)``, which the panel matching computes anyway."""
+    lo_coef: Float[np.ndarray, " n"]
+    hi_coef: Float[np.ndarray, " n"]
+
+    def __init__(self, a: float, b: float, n: int = 24) -> None:
+        a, b = float(a), float(b)
+        if a <= 0:
+            msg = f"`a` must be positive, got {a}."
+            raise ValueError(msg)
+        # b <= 0 is fine, and b == 0 has its own (log) branch, but the other
+        # non-positive integers need a log term this does not carry.
+        if b < 0 and b == int(b):
+            msg = (
+                f"b = {b} is a negative integer, where B(a, b, .) picks up a "
+                "logarithmic term this fit does not represent. Use "
+                "`ZhaoPotential` (the series form) for these indices."
+            )
+            raise ValueError(msg)
+
+        self.a, self.b = a, b
+        # numpy, not jax: the fit may run while a jit trace is active (the
+        # first call through a jitted method), and device arrays made there
+        # would be tracers. As numpy they are plain constants, which is also
+        # what we want them folded into the jaxpr as.
+        self.lo_coef = _chebfit(lambda z: _lo_target(a, b, z), n)
+        self.hi_coef = _chebfit(lambda w: _hi_target(a, b, w), n)
+
+        # Match the panels at z = w = 1/2, which fixes `const`.
+        half = 0.5**a * float(_lo_target(a, b, np.array(0.5))) / a
+        v_half = float(_hi_target(a, b, np.array(0.5)))
+        self.const = float(
+            half - np.log(2.0) + v_half if b == 0 else half + 0.5**b * v_half
+        )
+        self.at_half = float(half)
+
+    def __call__(self, z: gt.BBtSz0) -> gt.BBtFloatSz0:
+        """Evaluate B(a, b, z), for z in [0, 1].
+
+        Not jitted: every caller already is, and the coefficients are
+        constants that should fold into the caller's jaxpr.
+        """
+        z = jnp.asarray(z)
+        w = 1.0 - z
+        # Both panels are evaluated, so clamp each to its own domain; `where`
+        # then discards the extrapolated one.
+        z_lo = jnp.minimum(z, 0.5)
+        w_hi = jnp.minimum(w, 0.5)
+
+        lo = z_lo**self.a * _clenshaw(self.lo_coef, 4.0 * z_lo - 1.0) / self.a
+
+        v = _clenshaw(self.hi_coef, 4.0 * w_hi - 1.0)
+        hi = (
+            self.const - jnp.log(w_hi) - v
+            if self.b == 0
+            else self.const - w_hi**self.b * v
+        )
+        return jnp.where(z <= 0.5, lo, hi)  # type: ignore[no-any-return]

--- a/tests/benchmark/test_potential_zhao.py
+++ b/tests/benchmark/test_potential_zhao.py
@@ -12,6 +12,9 @@ and Poisson's equation) rather than by autodiff of `potential`, so they should
 cost no more than `potential` itself -- `laplacian` in particular is just
 `4 pi G rho` and so should track Plummer.
 
+`ZhaoInterp` is `InterpolatedZhaoPotential`: the same model with Eq. 43 fitted
+rather than summed, which should land near Plummer for every method.
+
 Everything is jitted internally (`AbstractSinglePotential` wraps `_potential`
 and friends in `jax.jit`), so each case is warmed up at import, below, and the
 timed body is a single call.
@@ -32,6 +35,15 @@ _xyz_all = jax.random.uniform(
 )
 _t = u.Quantity(0.0, "Myr")
 
+ZHAO_KW = {
+    "m": u.Quantity(1e12, "Msun"),
+    "r_s": u.Quantity(10.0, "kpc"),
+    "alpha": 1.0,
+    "beta": 4.0,
+    "gamma": 1.0,
+    "units": "galactic",
+}
+
 potentials = {
     "Zhao": gp.ZhaoPotential(
         m=u.Quantity(1e12, "Msun"),
@@ -41,6 +53,7 @@ potentials = {
         gamma=1.0,
         units="galactic",
     ),
+    "ZhaoInterp": gp.InterpolatedZhaoPotential(**ZHAO_KW),
     "Plummer": gp.PlummerPotential(
         m_tot=u.Quantity(1e12, "Msun"), r_s=u.Quantity(10.0, "kpc"), units="galactic"
     ),

--- a/tests/smoke/potential/test_package.py
+++ b/tests/smoke/potential/test_package.py
@@ -55,6 +55,7 @@ expected_all = [
     "HardCutoffNFWPotential",
     "gNFWPotential",
     "ZhaoPotential",
+    "InterpolatedZhaoPotential",
     # xfm
     "AbstractTransformedPotential",
     "FlattenedInThePotential",

--- a/tests/unit/potential/builtin/test_zhao_interp.py
+++ b/tests/unit/potential/builtin/test_zhao_interp.py
@@ -1,0 +1,145 @@
+"""Tests for `InterpolatedZhaoPotential`.
+
+The contract is that it is numerically indistinguishable from `ZhaoPotential`
+-- it is the same model, with Zhao's Eq. 43 fitted rather than summed -- so
+almost everything here is a comparison against the analytic class.
+
+Standalone rather than built on `AbstractSinglePotential_Test`: that suite
+drives the power-law indices as `ParameterField`s, and here they are static by
+construction.
+"""
+
+import numpy as np
+import pytest
+
+import quaxed.numpy as jnp
+import unxt as u
+
+import galax.potential as gp
+
+# The Table 1 correspondences plus a generic case, as (alpha, beta, gamma).
+ABG = [
+    (1.0, 4.0, 1.0),  # Hernquist
+    (1.0, 4.0, 2.0),  # Jaffe (p0 = 0)
+    (0.5, 5.0, 0.0),  # Plummer
+    (1.0, 3.0, 1.0),  # NFW (q0 = 0, infinite mass)
+    (1.0, 3.0, 0.5),  # gNFW
+    (0.9, 4.31, 1.2),  # generic
+    (0.4, 2.5, 2.5),  # both indices negative
+]
+METHODS = ["potential", "gradient", "density", "laplacian", "hessian"]
+
+M = u.Quantity(1e12, "Msun")
+R_S = u.Quantity(8.0, "kpc")
+T = u.Quantity(0.0, "Myr")
+
+
+def _pair(abg, **kw):
+    alpha, beta, gamma = abg
+    fields = {
+        "m": M,
+        "r_s": R_S,
+        "alpha": alpha,
+        "beta": beta,
+        "gamma": gamma,
+        "units": "galactic",
+    }
+    return gp.InterpolatedZhaoPotential(**fields, **kw), gp.ZhaoPotential(**fields)
+
+
+def _xyz(n=64, lo=1e-3, hi=1e3):
+    """Positions spanning a wide range of radii, off-axis."""
+    r = np.geomspace(lo, hi, n)
+    direction = np.array([0.36, -0.48, 0.8])  # unit vector
+    return u.Quantity(r[:, None] * direction, "kpc")
+
+
+@pytest.mark.parametrize("abg", ABG)
+@pytest.mark.parametrize("method", METHODS)
+def test_matches_analytic(abg, method: str) -> None:
+    """Must agree with `ZhaoPotential` across the radial range."""
+    interp, exact = _pair(abg)
+    xyz = _xyz()
+
+    got, expect = getattr(interp, method)(xyz, T), getattr(exact, method)(xyz, T)
+    got = np.asarray(u.ustrip(got.unit, got))
+    expect = np.asarray(u.ustrip(expect.unit, expect))
+
+    # `hessian` has near-cancelling entries, so compare on the tensor's scale.
+    scale = np.max(np.abs(expect))
+    np.testing.assert_allclose(got, expect, rtol=1e-10, atol=1e-10 * scale)
+
+
+@pytest.mark.parametrize("abg", ABG)
+def test_mass_enclosed_matches_analytic(abg) -> None:
+    """The enclosed mass drives every derivative, so check it directly."""
+    interp, exact = _pair(abg)
+    xyz = _xyz()
+    got = gp.spherical_mass_enclosed(interp, xyz, T)
+    expect = gp.spherical_mass_enclosed(exact, xyz, T)
+    np.testing.assert_allclose(
+        np.asarray(u.ustrip("Msun", got)),
+        np.asarray(u.ustrip("Msun", expect)),
+        rtol=1e-10,
+    )
+
+
+def test_more_coefficients_is_not_worse() -> None:
+    """Accuracy must be controllable by `n_coeffs`."""
+    xyz = _xyz()
+    _, exact = _pair((0.9, 4.31, 1.2))
+    expect = exact.potential(xyz, T)
+    expect_v = np.asarray(u.ustrip(expect.unit, expect))
+
+    errs = []
+    for n in (8, 16, 32):
+        interp, _ = _pair((0.9, 4.31, 1.2), n_coeffs=n)
+        got = interp.potential(xyz, T)
+        got_v = np.asarray(u.ustrip(got.unit, got))
+        errs.append(np.max(np.abs(got_v / expect_v - 1)))
+
+    assert errs[0] > errs[-1]  # more coefficients, better fit
+    assert errs[-1] < 1e-12
+
+
+def test_time_dependent_mass_still_works() -> None:
+    """``m`` and ``r_s`` stay ordinary parameters; only the indices are fixed."""
+
+    def m_of_t(t: u.Quantity["time"]) -> u.Quantity["mass"]:
+        return u.Quantity(1e12 * (1 + 0.1 * t.ustrip("Myr")), "Msun")
+
+    fields = {"r_s": R_S, "alpha": 1.0, "beta": 4.0, "gamma": 1.0, "units": "galactic"}
+    interp = gp.InterpolatedZhaoPotential(m=m_of_t, **fields)
+    exact = gp.ZhaoPotential(m=m_of_t, **fields)
+
+    xyz = u.Quantity([8.0, 0.0, 0.0], "kpc")
+    for t in (0.0, 5.0, 50.0):
+        tq = u.Quantity(t, "Myr")
+        got, expect = interp.potential(xyz, tq), exact.potential(xyz, tq)
+        assert jnp.isclose(got, expect, atol=u.Quantity(1e-12, got.unit))
+    # and the mass really does vary
+    assert not jnp.isclose(
+        interp.potential(xyz, u.Quantity(0.0, "Myr")),
+        interp.potential(xyz, u.Quantity(50.0, "Myr")),
+        atol=u.Quantity(1e-6, "kpc2/Myr2"),
+    )
+
+
+def test_from_zhao_round_trip() -> None:
+    """`from_zhao` must copy the indices and reproduce the source potential."""
+    _, exact = _pair((0.9, 4.31, 1.2))
+    interp = gp.InterpolatedZhaoPotential.from_zhao(exact)
+
+    assert (interp.alpha, interp.beta, interp.gamma) == (0.9, 4.31, 1.2)
+    xyz = _xyz()
+    got, expect = interp.potential(xyz, T), exact.potential(xyz, T)
+    assert jnp.allclose(got, expect, atol=u.Quantity(1e-12, got.unit))
+
+
+def test_negative_integer_index_is_rejected() -> None:
+    """A negative-integer `b` needs a log term the fit does not carry."""
+    # b = alpha (beta - 3) = -1 exactly
+    with pytest.raises(ValueError, match="negative integer"):
+        gp.InterpolatedZhaoPotential(
+            m=M, r_s=R_S, alpha=1.0, beta=2.0, gamma=1.0, units="galactic"
+        )

--- a/tests/unit/potential/test_special.py
+++ b/tests/unit/potential/test_special.py
@@ -12,7 +12,10 @@ from scipy.special import beta as scipy_beta, betainc as scipy_betainc, hyp2f1
 
 import quaxed.numpy as jnp
 
-from galax.potential._src.special import incomplete_beta
+from galax.potential._src.special import (
+    ChebyshevIncompleteBeta,
+    incomplete_beta,
+)
 
 # `a > 0` always (e.g. Zhao uses a = alpha*(3-gamma) or alpha*(beta-2)); `b` is
 # any real (b = alpha*(beta-3) <= 0 for the infinite-mass models, and
@@ -86,3 +89,45 @@ def test_second_derivative_composes() -> None:
     """`custom_jvp` (not `custom_vjp`) must survive `jacfwd(jacrev(...))`."""
     f = lambda zz: incomplete_beta(2.0, 1.5, zz)
     assert jnp.isfinite(jax.jacfwd(jax.jacrev(f))(jnp.asarray(0.3)))
+
+
+# ===================================================================
+# ChebyshevIncompleteBeta
+
+
+@pytest.mark.parametrize("a", AS)
+@pytest.mark.parametrize("b", [b for b in BS if not (b < 0 and b == int(b))])
+def test_chebyshev_matches_series(a: float, b: float) -> None:
+    """The fitted form must reproduce `incomplete_beta` over the whole range."""
+    z = jnp.asarray(np.concatenate([ZS, 1 - np.array(ZS)]))
+    got = ChebyshevIncompleteBeta(a, b, n=24)(z)
+    np.testing.assert_allclose(
+        np.asarray(got), np.asarray(incomplete_beta(a, b, z)), rtol=1e-11
+    )
+
+
+@pytest.mark.parametrize("n", [8, 16, 24, 32])
+def test_chebyshev_converges_with_coefficients(n: int) -> None:
+    """More coefficients must not make the fit worse."""
+    a, b = 1.62, 1.18
+    z = jnp.asarray(np.linspace(1e-6, 1 - 1e-6, 501))
+    ref = np.asarray(incomplete_beta(a, b, z))
+    got = np.asarray(ChebyshevIncompleteBeta(a, b, n=n)(z))
+    err = np.max(np.abs(got / ref - 1))
+    assert err < {8: 1e-4, 16: 1e-9, 24: 1e-12, 32: 1e-12}[n]
+
+
+def test_chebyshev_at_half_is_consistent() -> None:
+    """`at_half` must be the value the two panels are matched at."""
+    ch = ChebyshevIncompleteBeta(2.0, 1.3, n=24)
+    np.testing.assert_allclose(
+        ch.at_half, float(incomplete_beta(2.0, 1.3, jnp.asarray(0.5))), rtol=1e-12
+    )
+
+
+def test_chebyshev_rejects_unsupported_indices() -> None:
+    """`a <= 0` is outside the definition; negative-integer `b` needs a log term."""
+    with pytest.raises(ValueError, match="must be positive"):
+        ChebyshevIncompleteBeta(0.0, 1.0)
+    with pytest.raises(ValueError, match="negative integer"):
+        ChebyshevIncompleteBeta(2.0, -1.0)


### PR DESCRIPTION
Follow-up to #761 (which this stacks on — merge that first). Adds a second Zhao potential that fits the special functions instead of summing them. It does **not** replace the analytic class: `ZhaoPotential` stays the default, and is the reference this one is tested against.

## Why

`ZhaoPotential` sums a 64-term series for the incomplete beta function of Zhao's Eq. 43 on every evaluation, because $(\alpha, \beta, \gamma)$ are ordinary parameters and may vary with time. Most uses fix them — and then the model needs only *two fixed functions of one variable*, which a short polynomial captures.

## The fit

`B(a,b,z)` is a power law at both ends — $z^a$ as $z \to 0$, and $w^b$, $\ln w$, or nothing as $w = 1-z \to 0$ — so neither half is analytic across the interval, and a naive Chebyshev fit converges algebraically at best. (I tried it; it needs >200 coefficients for non-integer $b$.)

Splitting at $z = 1/2$ and dividing out the end behaviour leaves two *analytic* functions:

$$B(a,b,z) = \frac{z^a}{a}\,{}_2F_1(a, 1-b; a+1; z) \qquad z \leq 1/2$$
$$B(a,b,z) = \mathrm{const} - w^b V(w) \qquad w \leq 1/2$$
$$B(a,b,z) = \mathrm{const} + \ln w - V_0(w) \qquad w \leq 1/2,\ b = 0$$

which Chebyshev converges on geometrically. **~18 coefficients reach 1e-13 across the whole valid index range**, against 64 series steps.

Two details that matter:

- Both fit targets are built from **their own series**, not by differencing values of `B`. The latter cancels catastrophically exactly where the fit wants its nodes ($w \to 0$), which is what made my first attempt look like it needed 200 coefficients.
- `const` comes from **matching the two panels at $z = 1/2$**, so the fit needs no reference implementation beyond its own series.

## What stays free

Only the indices are baked in. `m` enters as a linear normalization and `r_s` only through $\chi$ (Eq. 5), so both remain ordinary, possibly time-dependent parameters — there's a test for that.

Negative-integer `b` needs a log term this representation doesn't carry, and is rejected at construction with a message pointing back at `ZhaoPotential`.

## Numbers

At 1e5 points (M2 Pro, CPU, float64), against the analytic class and `PlummerPotential`:

| method | `ZhaoPotential` | `InterpolatedZhaoPotential` | speedup | `PlummerPotential` |
|---|---|---|---|---|
| `potential` | 42.3 ms | 0.39 ms | **110×** | 0.08 ms |
| `gradient` | 11.8 ms | 0.12 ms | **96×** | 0.03 ms |
| `hessian` | 9.3 ms | 0.67 ms | **14×** | 0.23 ms |
| `laplacian` | 0.32 ms | 0.19 ms | 1.7× | 0.29 ms |

A Zhao halo now costs about what a Plummer sphere does.

## Sharing rather than duplicating

`zhao.py` grows value-based forms of its model functions (`potential_from_bz`, `mass_enclosed_from_bz`, `density_from_norm`, `gradient_from_radial`, `hessian_from_radial`, `d2potential_dr2_from`) that take already-evaluated pieces, so both classes call the same equations. The analytic path is otherwise untouched and its existing tests pin that.

## Tests

`test_zhao_interp.py` compares every method against `ZhaoPotential` over $r/r_s \in [10^{-4}, 10^{2}]$ for all the Table 1 correspondences plus a generic case and a both-indices-negative case; plus enclosed mass, the `n_coeffs` accuracy knob, time-dependent `m`, `from_zhao`, and the rejection path. `test_special.py` covers the fit against the series directly. The benchmark suite gains the new class.

3127 tests pass.

## Open question

Whether this wants to be a general `InterpolatedSphericalPotential` wrapper in `xfm/` rather than a Zhao-specific class. I started there and backed off: a general wrapper would have to *infer* the endpoint asymptotics numerically, which is exactly the part that has to be right for the fit to converge geometrically. Knowing $(\alpha, \beta, \gamma)$ analytically is what makes 18 coefficients enough. Happy to revisit if you'd rather have the general version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
