### PR TITLE
✨ feat(potential): add analytic density for 9 more potentials

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,7 @@ build.targets.wheel.packages = ["src/galax"]
 
 
 [tool.codespell]
-ignore-words-list = "Hart" # in dynamics/_src/cluster/relax_time.py
+ignore-words-list = "Hart,numer" # Hart: dynamics/_src/cluster/relax_time.py; numer: numerator abbreviation
 
 
 [tool.commitizen]

--- a/src/galax/potential/_src/builtin/gaussian/axisymmetric.py
+++ b/src/galax/potential/_src/builtin/gaussian/axisymmetric.py
@@ -19,14 +19,17 @@ from xmmutablemap import ImmutableMap
 
 import galax.potential.custom_types as gt
 from galax.potential._src.base import default_constants
-from galax.potential._src.base_single import AbstractSinglePotential
+from galax.potential._src.base_single import (
+    AbstractSinglePotential,
+    LaplacianFromDensityMixin,
+)
 from galax.potential._src.params.base import AbstractParameter
 from galax.potential._src.params.field import ParameterField
 from galax.potential._src.utils import GaussLegendreIntegrator
 
 
 @final
-class AxisymmetricGaussianPotential(AbstractSinglePotential):
+class AxisymmetricGaussianPotential(LaplacianFromDensityMixin, AbstractSinglePotential):
     r"""Axisymmetric (oblate/prolate) Gaussian Potential.
 
     .. math::

--- a/src/galax/potential/_src/builtin/gaussian/base.py
+++ b/src/galax/potential/_src/builtin/gaussian/base.py
@@ -26,14 +26,17 @@ from xmmutablemap import ImmutableMap
 
 import galax.potential.custom_types as gt
 from galax.potential._src.base import default_constants
-from galax.potential._src.base_single import AbstractSinglePotential
+from galax.potential._src.base_single import (
+    AbstractSinglePotential,
+    LaplacianFromDensityMixin,
+)
 from galax.potential._src.params.base import AbstractParameter
 from galax.potential._src.params.field import ParameterField
 from galax.potential._src.utils import r_spherical
 
 
 @final
-class GaussianPotential(AbstractSinglePotential):
+class GaussianPotential(LaplacianFromDensityMixin, AbstractSinglePotential):
     r"""Gaussian Potential.
 
     A spherical mass distribution with a Gaussian density profile.

--- a/src/galax/potential/_src/builtin/gaussian/triaxial.py
+++ b/src/galax/potential/_src/builtin/gaussian/triaxial.py
@@ -19,14 +19,17 @@ from xmmutablemap import ImmutableMap
 
 import galax.potential.custom_types as gt
 from galax.potential._src.base import default_constants
-from galax.potential._src.base_single import AbstractSinglePotential
+from galax.potential._src.base_single import (
+    AbstractSinglePotential,
+    LaplacianFromDensityMixin,
+)
 from galax.potential._src.params.base import AbstractParameter
 from galax.potential._src.params.field import ParameterField
 from galax.potential._src.utils import GaussLegendreIntegrator
 
 
 @final
-class TriaxialGaussianPotential(AbstractSinglePotential):
+class TriaxialGaussianPotential(LaplacianFromDensityMixin, AbstractSinglePotential):
     r"""Triaxial (density) Gaussian Potential.
 
     .. math::

--- a/src/galax/potential/_src/builtin/isochrone.py
+++ b/src/galax/potential/_src/builtin/isochrone.py
@@ -5,6 +5,7 @@ __all__ = [
     "IsochronePotential",
     # functions
     "potential",
+    "density",
 ]
 
 import functools as ft
@@ -21,18 +22,32 @@ from xmmutablemap import ImmutableMap
 
 import galax.potential.custom_types as gt
 from galax.potential._src.base import default_constants
-from galax.potential._src.base_single import AbstractSinglePotential
+from galax.potential._src.base_single import (
+    AbstractSinglePotential,
+    LaplacianFromDensityMixin,
+)
 from galax.potential._src.params.base import AbstractParameter
 from galax.potential._src.params.field import ParameterField
 from galax.potential._src.utils import r_spherical
 
 
 @final
-class IsochronePotential(AbstractSinglePotential):
+class IsochronePotential(LaplacianFromDensityMixin, AbstractSinglePotential):
     r"""Isochrone Potential.
+
+    Hénon, M. 1959, Annales d'Astrophysique, 22, 126 (the "isochrone" model).
+    See also Binney & Tremaine 2008, *Galactic Dynamics*, 2nd ed., Sec. 2.2.2c.
 
     $$
     \Phi(r) = -\frac{G M}{r_s + \sqrt{r^2 + r_s^2}}
+    $$
+
+    with corresponding density (derived from the potential above via
+    Poisson's equation):
+
+    $$
+    \rho(r) = \frac{M r_s \left(3 r_s s + 2r^2 + 3 r_s^2\right)}
+        {4\pi s^3 (r_s+s)^3}, \qquad s = \sqrt{r^2+r_s^2}
     $$
 
     """
@@ -72,6 +87,18 @@ class IsochronePotential(AbstractSinglePotential):
         }
         return potential(params, r)  # type: ignore[no-any-return]
 
+    @ft.partial(jax.jit)
+    def _density(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BBtSz0:
+        # Parse inputs
+        r = r_spherical(xyz, self.units["length"])
+        t = u.Q.from_(t, self.units["time"])
+
+        params = {
+            "m_tot": self.m_tot(t, ustrip=self.units["mass"]),
+            "r_s": self.r_s(t, ustrip=self.units["length"]),
+        }
+        return density(params, r)  # type: ignore[no-any-return]
+
 
 # ===================================================================
 
@@ -88,3 +115,22 @@ def potential(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
     r_s = p["r_s"]
     _result = -p["G"] * p["m_tot"] / (r_s + jnp.sqrt(r**2 + r_s**2))
     return _result  # type: ignore[no-any-return]
+
+
+@ft.partial(jax.jit)
+def density(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
+    r"""Density function for the isochrone potential.
+
+    Derived from the potential via Poisson's equation (Hénon 1959).
+
+    $$
+    \rho(r) = \frac{M r_s \left(3 r_s s + 2r^2 + 3 r_s^2\right)}
+        {4\pi s^3 (r_s+s)^3}, \qquad s = \sqrt{r^2+r_s^2}
+    $$
+
+    """
+    r_s, m_tot = p["r_s"], p["m_tot"]
+    s = jnp.sqrt(r**2 + r_s**2)
+    numer = m_tot * r_s * (3 * r_s * s + 2 * r**2 + 3 * r_s**2)
+    denom = 4 * jnp.pi * s**3 * (r_s + s) ** 3
+    return numer / denom  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/jaffe.py
+++ b/src/galax/potential/_src/builtin/jaffe.py
@@ -5,6 +5,7 @@ __all__ = [
     "JaffePotential",
     # functions
     "potential",
+    "density",
 ]
 
 import functools as ft
@@ -17,15 +18,27 @@ import quaxed.numpy as jnp
 import unxt as u
 
 import galax.potential.custom_types as gt
-from galax.potential._src.base_single import AbstractSinglePotential
+from galax.potential._src.base_single import (
+    AbstractSinglePotential,
+    LaplacianFromDensityMixin,
+)
 from galax.potential._src.params.base import AbstractParameter
 from galax.potential._src.params.field import ParameterField
 from galax.potential._src.utils import r_spherical
 
 
 @final
-class JaffePotential(AbstractSinglePotential):
-    """Jaffe Potential."""
+class JaffePotential(LaplacianFromDensityMixin, AbstractSinglePotential):
+    r"""Jaffe Potential.
+
+    Jaffe, W. 1983, MNRAS, 202, 995.
+    https://ui.adsabs.harvard.edu/abs/1983MNRAS.202..995J
+
+    $$
+    \rho(r) = \frac{M r_s}{4\pi r^2 (r+r_s)^2}
+    $$
+
+    """
 
     m_tot: AbstractParameter = ParameterField(dimensions="mass", doc="Total mass.")  # type: ignore[assignment]
     r_s: AbstractParameter = ParameterField(dimensions="length", doc="Scale length.")  # type: ignore[assignment]
@@ -43,6 +56,18 @@ class JaffePotential(AbstractSinglePotential):
         }
         return potential(params, r)  # type: ignore[no-any-return]
 
+    @ft.partial(jax.jit)
+    def _density(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BBtSz0:
+        # Parse inputs
+        r = r_spherical(xyz, self.units["length"])
+        t = u.Q.from_(t, self.units["time"])
+
+        params = {
+            "m_tot": self.m_tot(t, ustrip=self.units["mass"]),
+            "r_s": self.r_s(t, ustrip=self.units["length"]),
+        }
+        return density(params, r)  # type: ignore[no-any-return]
+
 
 # ===================================================================
 
@@ -52,9 +77,22 @@ def potential(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
     r"""Potential function for the Jaffe potential.
 
     $$
-    \phi(r) = -\frac{G M}{r_s} \log\left(1 + \frac{r}{r_s}\right)
+    \phi(r) = -\frac{G M}{r_s} \log\left(1 + \frac{r_s}{r}\right)
     $$
 
     """
     _result = -p["G"] * p["m_tot"] / p["r_s"] * jnp.log(1 + p["r_s"] / r)
+    return _result  # type: ignore[no-any-return]
+
+
+@ft.partial(jax.jit)
+def density(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
+    r"""Density function for the Jaffe potential (Jaffe 1983, eq. 2).
+
+    $$
+    \rho(r) = \frac{M r_s}{4\pi r^2 (r+r_s)^2}
+    $$
+
+    """
+    _result = p["m_tot"] * p["r_s"] / (4 * jnp.pi * r**2 * (r + p["r_s"]) ** 2)
     return _result  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/kuzmin.py
+++ b/src/galax/potential/_src/builtin/kuzmin.py
@@ -22,20 +22,35 @@ from xmmutablemap import ImmutableMap
 
 import galax.potential.custom_types as gt
 from galax.potential._src.base import default_constants
-from galax.potential._src.base_single import AbstractSinglePotential
+from galax.potential._src.base_single import (
+    AbstractSinglePotential,
+    LaplacianFromDensityMixin,
+)
 from galax.potential._src.params.base import AbstractParameter
 from galax.potential._src.params.field import ParameterField
 
 
 @final
-class KuzminPotential(AbstractSinglePotential):
+class KuzminPotential(LaplacianFromDensityMixin, AbstractSinglePotential):
     r"""Kuzmin Potential.
+
+    Kuzmin, G. G. 1956, Astronomicheskii Zhurnal, 33, 27. See also Binney &
+    Tremaine 2008, *Galactic Dynamics*, 2nd ed., Sec. 2.2.1(b).
 
     .. math::
 
         \Phi(x, t) = -\frac{G M(t)}{\sqrt{R^2 + (a(t) + |z|)^2}}
 
     See https://galaxiesbook.org/chapters/II-01.-Flattened-Mass-Distributions.html#Razor-thin-disk:-The-Kuzmin-model
+
+    This is a razor-thin disk: all of the mass lies in an infinitesimally
+    thin sheet at :math:`z=0`, given by the surface density :math:`\Sigma(R)
+    = a M / [2\pi (R^2+a^2)^{3/2}]` (Binney & Tremaine eq. 2.67). The
+    corresponding *volume* mass density is a distributional delta function
+    at :math:`z=0` and is exactly zero everywhere off the plane
+    (:math:`\nabla^2\Phi = 0` for :math:`z \neq 0`, verified directly from
+    the potential above via Poisson's equation), so :func:`density` and the
+    resulting :func:`~galax.potential.laplacian` return exact zeros there.
 
     """
 
@@ -66,6 +81,13 @@ class KuzminPotential(AbstractSinglePotential):
             "r_s": self.r_s(t, ustrip=self.units["length"]),
         }
         return potential(params, xyz)  # type: ignore[no-any-return]
+
+    @ft.partial(jax.jit, inline=True)
+    def _density(self, xyz: gt.BBtQorVSz3, _: gt.BBtQorVSz0, /) -> gt.BBtSz0:
+        # Razor-thin disk: zero volume density off the z=0 plane (all mass
+        # is in the surface density there, which can't be represented as a
+        # finite volume density).
+        return jnp.zeros(xyz.shape[:-1], dtype=xyz.dtype)  # type: ignore[no-any-return]
 
 
 # ====================================================================

--- a/src/galax/potential/_src/builtin/logarithmic.py
+++ b/src/galax/potential/_src/builtin/logarithmic.py
@@ -20,15 +20,29 @@ from xmmutablemap import ImmutableMap
 
 import galax.potential.custom_types as gt
 from galax.potential._src.base import default_constants
-from galax.potential._src.base_single import AbstractSinglePotential
+from galax.potential._src.base_single import (
+    AbstractSinglePotential,
+    LaplacianFromDensityMixin,
+)
 from galax.potential._src.params.base import AbstractParameter
 from galax.potential._src.params.field import ParameterField
 from galax.potential._src.utils import r_spherical
 
 
 @final
-class LogarithmicPotential(AbstractSinglePotential):
-    """Logarithmic Potential."""
+class LogarithmicPotential(LaplacianFromDensityMixin, AbstractSinglePotential):
+    r"""Logarithmic Potential.
+
+    The spherical (:math:`q=1`) case of the flattened logarithmic potential
+    of Binney & Tremaine 2008, *Galactic Dynamics*, 2nd ed., eq. 2.72 (a
+    classic flat-rotation-curve, cored-halo model). The corresponding
+    density (their eq. 2.71, with :math:`q=1`) is:
+
+    $$
+    \rho(r) = \frac{v_c^2 (3 r_s^2 + r^2)}{4\pi G (r_s^2+r^2)^2}
+    $$
+
+    """
 
     v_c: AbstractParameter = ParameterField(  # type: ignore[assignment]
         dimensions="speed", doc="Circular velocity."
@@ -52,12 +66,41 @@ class LogarithmicPotential(AbstractSinglePotential):
 
         return 0.5 * v_c**2 * jnp.log(r_s**2 + r**2)  # type: ignore[no-any-return]
 
+    @ft.partial(jax.jit)
+    def _density(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BBtSz0:
+        # Parse inputs
+        r = r_spherical(xyz, self.units["length"])
+        t = u.Q.from_(t, self.units["time"])
+        # Compute parameters
+        r_s = self.r_s(t, ustrip=self.units["length"])
+        v_c = self.v_c(t, ustrip=self.units["speed"])
+        G = self.constants["G"].value
+
+        numer = v_c**2 * (3 * r_s**2 + r**2)
+        denom = 4 * jnp.pi * G * (r_s**2 + r**2) ** 2
+        return numer / denom  # type: ignore[no-any-return]
+
 
 @final
-class LMJ09LogarithmicPotential(AbstractSinglePotential):
-    """Logarithmic Potential from LMJ09.
+class LMJ09LogarithmicPotential(LaplacianFromDensityMixin, AbstractSinglePotential):
+    r"""Logarithmic Potential from LMJ09.
 
     https://ui.adsabs.harvard.edu/abs/2009ApJ...703L..67L/abstract
+
+    The corresponding (triaxial) density, derived from the potential above
+    via Poisson's equation, is (using the bar-frame coordinates :math:`x,
+    y, z` after undoing the :math:`\phi` rotation):
+
+    $$
+    \rho(x,y,z) = \frac{v_c^2}{4\pi G D^2} \left[
+        D \left(q_1^2q_2^2 + q_1^2q_3^2 + q_2^2q_3^2\right)
+        - 2\left(q_1^4q_2^4 z^2 + q_1^4q_3^4 y^2 + q_2^4q_3^4 x^2\right)
+        \right]
+    $$
+
+    where :math:`D = q_1^2 q_2^2 q_3^2 r_s^2 + q_1^2 q_2^2 z^2 + q_1^2 q_3^2
+    y^2 + q_2^2 q_3^2 x^2`.
+
     """
 
     v_c: AbstractParameter = ParameterField(  # type: ignore[assignment]
@@ -106,3 +149,33 @@ class LMJ09LogarithmicPotential(AbstractSinglePotential):
 
         # Potential energy
         return 0.5 * v_c**2 * jnp.log(r_s**2 + r2)  # type: ignore[no-any-return]
+
+    @ft.partial(jax.jit)
+    def _density(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BBtSz0:
+        # Parse inputs
+        xyz = u.ustrip(AllowValue, self.units["length"], xyz)
+        t = u.Q.from_(t, self.units["time"])
+
+        # Compute parameters
+        u1 = self.units["dimensionless"]
+        r_s = self.r_s(t, ustrip=self.units["length"])
+        q1, q2, q3 = self.q1(t, ustrip=u1), self.q2(t, ustrip=u1), self.q3(t, ustrip=u1)
+        phi = self.phi(t, ustrip=self.units["angle"])
+        v_c = self.v_c(t, ustrip=self.units["speed"])
+        G = self.constants["G"].value
+
+        # Rotated coordinates (bar frame)
+        sphi, cphi = jnp.sin(phi), jnp.cos(phi)
+        x = xyz[..., 0] * cphi + xyz[..., 1] * sphi
+        y = -xyz[..., 0] * sphi + xyz[..., 1] * cphi
+        z = xyz[..., 2]
+
+        q1sq, q2sq, q3sq = q1**2, q2**2, q3**2
+        D = q1sq * q2sq * q3sq * r_s**2 + q1sq * q2sq * z**2 + q1sq * q3sq * y**2
+        D = D + q2sq * q3sq * x**2
+        numer = D * (q1sq * q2sq + q1sq * q3sq + q2sq * q3sq) - 2 * (
+            q1sq**2 * q2sq**2 * z**2
+            + q1sq**2 * q3sq**2 * y**2
+            + q2sq**2 * q3sq**2 * x**2
+        )
+        return v_c**2 * numer / (4 * jnp.pi * G * D**2)  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/longmurali.py
+++ b/src/galax/potential/_src/builtin/longmurali.py
@@ -5,6 +5,7 @@ __all__ = [
     "LongMuraliBarPotential",
     # function
     "potential",
+    "density",
 ]
 
 import functools as ft
@@ -18,18 +19,31 @@ import unxt as u
 from unxt.quantity import AllowValue
 
 import galax.potential.custom_types as gt
-from galax.potential._src.base_single import AbstractSinglePotential
+from galax.potential._src.base_single import (
+    AbstractSinglePotential,
+    LaplacianFromDensityMixin,
+)
 from galax.potential._src.params.base import AbstractParameter
 from galax.potential._src.params.field import ParameterField
 
 
 @final
-class LongMuraliBarPotential(AbstractSinglePotential):
-    """Long & Murali Bar Potential.
+class LongMuraliBarPotential(LaplacianFromDensityMixin, AbstractSinglePotential):
+    r"""Long & Murali Bar Potential.
+
+    Long, K., & Murali, C. 1992, ApJ, 397, 44.
+    https://ui.adsabs.harvard.edu/abs/1992ApJ...397...44L
 
     A simple, triaxial model for a galaxy bar. This is a softened “needle”
     density distribution with an analytic potential form. See Long & Murali
     (1992) for details.
+
+    The corresponding density (:func:`density`) is obtained by applying
+    Poisson's equation directly to the potential formula below; because of
+    the finite bar length, this expression is algebraically messy (it was
+    derived with a computer algebra system rather than transcribed from a
+    textbook), but it is exact and verified against the finite-difference /
+    autodiff Hessian of the potential.
 
     """
 
@@ -66,6 +80,23 @@ class LongMuraliBarPotential(AbstractSinglePotential):
         }
         return potential(params, xyz)  # type: ignore[no-any-return]
 
+    @ft.partial(jax.jit)
+    def _density(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BBtSz0:
+        # Parse inputs
+        xyz = u.ustrip(AllowValue, self.units["length"], xyz)
+        t = u.Q.from_(t, self.units["time"])
+
+        ul = self.units["length"]
+        params = {
+            "G": self.constants["G"].value,
+            "m_tot": self.m_tot(t, ustrip=self.units["mass"]),
+            "a": self.a(t, ustrip=ul),
+            "b": self.b(t, ustrip=ul),
+            "c": self.c(t, ustrip=ul),
+            "alpha": self.alpha(t, ustrip=self.units["angle"]),
+        }
+        return density(params, xyz)  # type: ignore[no-any-return]
+
 
 # ===================================================================
 
@@ -87,3 +118,96 @@ def potential(p: gt.Params, xyz: gt.Sz3, /) -> gt.Sz0:
     GM_R = p["G"] * p["m_tot"] / (2.0 * a)
     _result = GM_R * jnp.log((xp - a + T_minus) / (xp + a + T_plus))
     return _result  # type: ignore[no-any-return]
+
+
+@ft.partial(jax.jit)
+def density(p: gt.Params, xyz: gt.Sz3, /) -> gt.Sz0:
+    r"""Density for the Long & Murali (1992) bar potential.
+
+    Obtained by applying Poisson's equation, :math:`\nabla^2\Phi = 4\pi G
+    \rho`, to :func:`potential` with a computer algebra system (the
+    intermediate quantities below are its common sub-expressions, not
+    individually meaningful); verified numerically against the
+    finite-difference Hessian of :func:`potential`.
+    """
+    alpha = p["alpha"]
+    a, b, c, G, m_tot = p["a"], p["b"], p["c"], p["G"], p["m_tot"]
+
+    x0, y0, z = xyz[..., 0], xyz[..., 1], xyz[..., 2]
+    x = x0 * jnp.cos(alpha) + y0 * jnp.sin(alpha)
+    y = -x0 * jnp.sin(alpha) + y0 * jnp.cos(alpha)
+
+    e0 = a - x
+    e1 = e0**2
+    e2 = y**2
+    e3 = z**2
+    e4 = c**2 + e3
+    e5 = jnp.sqrt(e4)
+    e6 = b + e5
+    e7 = e6**2
+    e8 = e2 + e7
+    e9 = e1 + e8
+    e10 = jnp.sqrt(e9)
+    e11 = -a + x + e10
+    e12 = 1 / e11
+    e13 = e9 ** (-1.5)
+    e14 = 1 / e10
+    e15 = a + x
+    e16 = e15**2
+    e17 = e16 + e8
+    e18 = jnp.sqrt(e17)
+    e19 = 1 / e18
+    e20 = e15 * e19 + 1
+    e21 = e15 + e18
+    e22 = 1 / e21
+    e23 = e11 * e22
+    e24 = e0 * e14 - 1
+    e25 = e20 * e23 + e24
+    e26 = 1 / e4
+    e27 = 1 / e5
+    e28 = e21**-2.0
+    e29 = e19 * e23
+    e30 = -e14 + e29
+    e31 = e19 * e22
+    e32 = e26 * e3
+    e33 = e32 * e7
+    e34 = e4 ** (-1.5)
+    e35 = e17 ** (-1.5)
+    e36 = 1 / e17
+    e37 = 2 * e31
+
+    lap = (
+        0.5
+        * G
+        * m_tot
+        * e12
+        * (
+            e11 * e19 * e22 * e3 * e34 * e6
+            + e11 * e19 * e22 * (e16 * e36 - 1)
+            + e11 * e2 * e22 * e35
+            + 2 * e11 * e2 * e28 * e36
+            + 2 * e11 * e20**2 * e28
+            + e11 * e22 * e26 * e3 * e35 * e7
+            + 2 * e11 * e26 * e28 * e3 * e36 * e7
+            + e12 * e14 * e2 * e30
+            + e12 * e14 * e26 * e3 * e30 * e7
+            - e12 * e24 * e25
+            - e13 * e2
+            - e13 * e33
+            - e14 * e2 * e37
+            + e14 * e26 * e3
+            + e14 * e27 * e6
+            - e14 * e3 * e34 * e6
+            - e14 * e32 * e37 * e7
+            - e14 * (e1 / e9 - 1)
+            - e2 * e30 * e31
+            + 2 * e20 * e22 * e24
+            - e20 * e22 * e25
+            - e27 * e29 * e6
+            - e29 * e32
+            - e30 * e31 * e33
+            - e30
+        )
+        / a
+    )
+    return lap / (4 * jnp.pi * G)  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/miyamotonagai.py
+++ b/src/galax/potential/_src/builtin/miyamotonagai.py
@@ -21,14 +21,32 @@ from xmmutablemap import ImmutableMap
 
 import galax.potential.custom_types as gt
 from galax.potential._src.base import default_constants
-from galax.potential._src.base_single import AbstractSinglePotential
+from galax.potential._src.base_single import (
+    AbstractSinglePotential,
+    LaplacianFromDensityMixin,
+)
 from galax.potential._src.params.base import AbstractParameter
 from galax.potential._src.params.field import ParameterField
 
 
 @final
-class MiyamotoNagaiPotential(AbstractSinglePotential):
-    """Miyamoto-Nagai Potential."""
+class MiyamotoNagaiPotential(LaplacianFromDensityMixin, AbstractSinglePotential):
+    r"""Miyamoto-Nagai Potential.
+
+    Miyamoto, M., & Nagai, R. 1975, PASJ, 27, 533.
+    https://ui.adsabs.harvard.edu/abs/1975PASJ...27..533M
+
+    The density is given by their eq. 4 (see also Binney & Tremaine 2008,
+    *Galactic Dynamics*, 2nd ed., eq. 2.69a):
+
+    $$
+    \rho(R, z) = \frac{b^2 M}{4\pi} \,
+        \frac{a R^2 + (a + 3\zeta)(a + \zeta)^2}
+             {[R^2 + (a+\zeta)^2]^{5/2} \, \zeta^3},
+        \qquad \zeta = \sqrt{z^2 + b^2}
+    $$
+
+    """
 
     m_tot: AbstractParameter = ParameterField(  # type: ignore[assignment]
         dimensions="mass", doc="Total mass of the potential."
@@ -65,6 +83,21 @@ class MiyamotoNagaiPotential(AbstractSinglePotential):
         }
         return potential(p, xyz)  # type: ignore[no-any-return]
 
+    @ft.partial(jax.jit, inline=True)
+    def _density(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BBtSz0:
+        # Parse inputs
+        xyz = u.ustrip(AllowValue, self.units["length"], xyz)
+        t = u.Q.from_(t, self.units["time"])
+
+        # Compute parameters
+        ul = self.units["length"]
+        p = {
+            "m_tot": self.m_tot(t, ustrip=self.units["mass"]),
+            "a": self.a(t, ustrip=ul),
+            "b": self.b(t, ustrip=ul),
+        }
+        return density(p, xyz)  # type: ignore[no-any-return]
+
 
 # ===================================================================
 # Functions
@@ -76,3 +109,14 @@ def potential(p: gt.Params, xyz: gt.Sz3) -> gt.Sz0:
     R2 = xyz[..., 0] ** 2 + xyz[..., 1] ** 2
     zp2 = (jnp.sqrt(xyz[..., 2] ** 2 + p["b"] ** 2) + p["a"]) ** 2
     return -p["G"] * p["m_tot"] / jnp.sqrt(R2 + zp2)  # type: ignore[no-any-return]
+
+
+@ft.partial(jax.jit)
+def density(p: gt.Params, xyz: gt.Sz3) -> gt.Sz0:
+    r"""Miyamoto-Nagai density function (Miyamoto & Nagai 1975, eq. 4)."""
+    a, b, m_tot = p["a"], p["b"], p["m_tot"]
+    R2 = xyz[..., 0] ** 2 + xyz[..., 1] ** 2
+    zeta = jnp.sqrt(xyz[..., 2] ** 2 + b**2)
+    numer = a * R2 + (a + 3 * zeta) * (a + zeta) ** 2
+    denom = (R2 + (a + zeta) ** 2) ** 2.5 * zeta**3
+    return b**2 * m_tot / (4 * jnp.pi) * numer / denom  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/monari2016.py
+++ b/src/galax/potential/_src/builtin/monari2016.py
@@ -5,6 +5,7 @@ __all__ = [
     "MonariEtAl2016BarPotential",
     # function
     "potential",
+    "density",
 ]
 
 import functools as ft
@@ -19,20 +20,40 @@ import unxt as u
 from unxt.quantity import AllowValue
 
 import galax.potential.custom_types as gt
-from galax.potential._src.base_single import AbstractSinglePotential
+from galax.potential._src.base_single import (
+    AbstractSinglePotential,
+    LaplacianFromDensityMixin,
+)
 from galax.potential._src.jax import vectorize_method
 from galax.potential._src.params.base import AbstractParameter
 from galax.potential._src.params.field import ParameterField
 
 
 @final
-class MonariEtAl2016BarPotential(AbstractSinglePotential):
-    """Monari et al. (2016) Bar Potential.
+class MonariEtAl2016BarPotential(LaplacianFromDensityMixin, AbstractSinglePotential):
+    r"""Monari et al. (2016) Bar Potential.
 
-    This is a generalization to 3D of the Dehnen 2000 bar potential.
-    We take the defaults from Monari et al. (2016) paper.
+    This is a generalization to 3D of the Dehnen (2000) bar potential
+    (Dehnen, W. 2000, AJ, 119, 800,
+    https://ui.adsabs.harvard.edu/abs/2000AJ....119..800D), replacing
+    Dehnen's cylindrical radius with the spherical radius. We take the
+    defaults from Monari et al. (2016).
 
     https://ui.adsabs.harvard.edu/abs/2016MNRAS.461.3835M/abstract
+
+    The density, derived from the potential below via Poisson's equation
+    (matching Dehnen's construction: a genuine mass quadrupole confined to
+    :math:`r < R_b`, and exactly zero outside):
+
+    $$
+    \rho(r,\theta,\phi) = \frac{\text{prefactor}}{4\pi G} \,
+        L(r) \, \sin^2\theta \, \cos(2(\phi-\phi_b-\Omega t)),
+        \qquad
+        L(r) = \begin{cases}
+            \dfrac{12}{r^2} + \dfrac{6r}{R_b^3}, & r < R_b \\[4pt]
+            0, & r \geq R_b
+        \end{cases}
+    $$
 
     Examples
     --------
@@ -106,6 +127,24 @@ class MonariEtAl2016BarPotential(AbstractSinglePotential):
         }
         return potential(params, xyz, t)  # type: ignore[no-any-return]
 
+    @ft.partial(jax.jit)
+    @vectorize_method(signature="(3),()->()")
+    def _density(self, xyz: gt.QuSz3 | gt.Sz3, t: gt.QuSz0 | gt.Sz0) -> gt.Sz0:
+        # Parse inputs
+        xyz = u.ustrip(AllowValue, self.units["length"], xyz)
+        t = u.ustrip(AllowValue, self.units["time"], t)
+        # Compute parameters
+        params = {
+            "alpha": self.alpha(t, ustrip=self.units["dimensionless"]),
+            "v0": self.v0(t, ustrip=self.units["speed"]),
+            "R0": self.R0(t, ustrip=self.units["length"]),
+            "Rb": self.Rb(t, ustrip=self.units["length"]),
+            "phi_b": self.phi_b(t, ustrip=self.units["angle"]),
+            "Omega": self.Omega(t, ustrip=self.units["frequency"]),
+            "G": self.constants["G"].value,
+        }
+        return density(params, xyz, t)  # type: ignore[no-any-return]
+
 
 @ft.partial(jax.jit)
 def U_of_r(s: gt.Sz0, /) -> gt.Sz0:
@@ -118,6 +157,16 @@ def U_of_r(s: gt.Sz0, /) -> gt.Sz0:
 
     pred = s >= 1
     return jax.lax.cond(pred, gtr_func, less_func, s)  # type: ignore[no-any-return]
+
+
+@ft.partial(jax.jit)
+def L_of_r(r: gt.Sz0, r_b: gt.Sz0, /) -> gt.Sz0:
+    r"""Radial part of the density, :math:`\nabla^2_r[U(r/R_b)]` for l=2.
+
+    Exactly zero outside the bar (:math:`r \geq R_b`), since ``U`` there is
+    :math:`-(r/R_b)^{-3}`, a source-free (harmonic) l=2 radial solution.
+    """
+    return jnp.where(r < r_b, 12 / r**2 + 6 * r / r_b**3, 0.0)  # type: ignore[no-any-return]
 
 
 # ===================================================================
@@ -136,3 +185,18 @@ def potential(p: gt.Params, xyz: gt.Sz3, t: gt.Sz0, /) -> gt.Sz0:
 
     energy = prefactor * u_of_r * (R2 / r2) * jnp.cos(gamma_b)  # M+2016 eq.1
     return energy  # type: ignore[no-any-return]
+
+
+@ft.partial(jax.jit)
+def density(p: gt.Params, xyz: gt.Sz3, t: gt.Sz0, /) -> gt.Sz0:
+    r"""Density derived from the potential above via Poisson's equation."""
+    R2 = xyz[0] ** 2 + xyz[1] ** 2
+    r2 = R2 + xyz[2] ** 2
+    r = jnp.sqrt(r2)
+
+    prefactor = p["alpha"] * (p["v0"] ** 2 / 3) * (p["R0"] / p["Rb"]) ** 3
+    phi = jnp.arctan2(xyz[1], xyz[0])
+    gamma_b = 2 * (phi - p["phi_b"] - p["Omega"] * t)  # M+2016 eq.2
+
+    lap_ang = prefactor * L_of_r(r, p["Rb"]) * (R2 / r2) * jnp.cos(gamma_b)
+    return lap_ang / (4 * jnp.pi * p["G"])  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/multipole.py
+++ b/src/galax/potential/_src/builtin/multipole.py
@@ -23,13 +23,28 @@ import unxt as u
 from unxt.quantity import AllowValue
 
 import galax.potential.custom_types as gt
-from galax.potential._src.base_single import AbstractSinglePotential
+from galax.potential._src.base_single import (
+    AbstractSinglePotential,
+    LaplacianFromDensityMixin,
+)
 from galax.potential._src.params.base import AbstractParameter
 from galax.potential._src.params.field import ParameterField
 
 
-class AbstractMultipolePotential(AbstractSinglePotential):
-    """Abstract Multipole Potential."""
+class AbstractMultipolePotential(LaplacianFromDensityMixin, AbstractSinglePotential):
+    r"""Abstract Multipole Potential.
+
+    Each term :math:`r^l Y_{lm}(\theta,\phi)` ("inner") and :math:`r^{-(l+1)}
+    Y_{lm}(\theta,\phi)` ("outer") is a *solid harmonic*: an exact,
+    source-free solution of Laplace's equation, :math:`\nabla^2 \Phi = 0`,
+    for every :math:`l, m` (Binney & Tremaine 2008, *Galactic Dynamics*, 2nd
+    ed., Sec. 2.4). Since :math:`\nabla^2` is linear, any sum of such terms
+    — inner, outer, or both, as used by the concrete subclasses below — is
+    itself source-free away from the origin. So the density is exactly zero
+    everywhere these potentials are evaluated (:math:`r>0`); all of the
+    represented mass sits, formally, at :math:`r=0` (for outer/mixed terms)
+    or at infinity (for inner terms only).
+    """
 
     m_tot: AbstractParameter = ParameterField(  # type: ignore[assignment]
         dimensions="mass", doc="Total mass."
@@ -39,6 +54,10 @@ class AbstractMultipolePotential(AbstractSinglePotential):
 
     _: KW_ONLY
     l_max: int = field(static=True)
+
+    @ft.partial(jax.jit, inline=True)
+    def _density(self, xyz: gt.BBtQorVSz3, _: gt.BBtQorVSz0, /) -> gt.BBtFloatSz0:
+        return jnp.zeros(xyz.shape[:-1], dtype=xyz.dtype)  # type: ignore[no-any-return]
 
 
 @final

--- a/src/galax/potential/_src/builtin/powerlawcutoff.py
+++ b/src/galax/potential/_src/builtin/powerlawcutoff.py
@@ -5,6 +5,7 @@ __all__ = [
     "PowerLawCutoffPotential",
     # functions
     "potential",
+    "density",
 ]
 
 import functools as ft
@@ -15,13 +16,17 @@ from typing import final
 import equinox as eqx
 import jax
 
+import quaxed.numpy as jnp
 import quaxed.scipy.special as jsp
 import unxt as u
 from xmmutablemap import ImmutableMap
 
 import galax.potential.custom_types as gt
 from galax.potential._src.base import default_constants
-from galax.potential._src.base_single import AbstractSinglePotential
+from galax.potential._src.base_single import (
+    AbstractSinglePotential,
+    LaplacianFromDensityMixin,
+)
 from galax.potential._src.params.base import AbstractParameter
 from galax.potential._src.params.field import ParameterField
 from galax.potential._src.utils import r_spherical
@@ -33,12 +38,17 @@ def _safe_gamma_inc(a: gt.SzN, x: gt.SzN) -> gt.SzN:
 
 
 @final
-class PowerLawCutoffPotential(AbstractSinglePotential):
+class PowerLawCutoffPotential(LaplacianFromDensityMixin, AbstractSinglePotential):
     r"""A spherical power-law density profile with an exponential cutoff.
+
+    This model (matching Gala's ``PowerLawCutoffPotential``) is *defined* by
+    the density below, with the potential obtained by directly integrating
+    Poisson's equation; it is not tied to a specific named paper.
 
     .. math::
 
-        \rho(r) = \frac{G M}{2\pi \Gamma((3-\alpha)/2) r_c^3} \left(\frac{r_c}{r}\right)^\alpha \exp{-(r / r_c)^2}
+        \rho(r) = \frac{M}{2\pi \Gamma((3-\alpha)/2) r_c^3}
+            \left(\frac{r_c}{r}\right)^\alpha \exp{-(r / r_c)^2}
 
     Parameters
     ----------
@@ -48,7 +58,7 @@ class PowerLawCutoffPotential(AbstractSinglePotential):
         Power law index. Must satisfy: ``0 <= alpha < 3``.
     r_c : :class:`~unxt.Quantity`[length]
         Cutoff radius.
-    """  # noqa: E501
+    """
 
     m_tot: AbstractParameter = ParameterField(dimensions="mass", doc="Total mass.")  # type: ignore[assignment]
     """Total mass of the potential."""
@@ -80,6 +90,20 @@ class PowerLawCutoffPotential(AbstractSinglePotential):
             "r_c": self.r_c(t, ustrip=ul),
         }
         return potential(params, r)  # type: ignore[no-any-return]
+
+    @ft.partial(jax.jit)
+    def _density(self, xyz: gt.BBtQuSz3, t: gt.BBtQuSz0, /) -> gt.BtSz0:
+        # Parse inputs
+        ul = self.units["length"]
+        r = r_spherical(xyz, ul)
+        t = u.Q.from_(t, self.units["time"])
+
+        params = {
+            "m_tot": self.m_tot(t, ustrip=self.units["mass"]),
+            "alpha": self.alpha(t, ustrip=self.units["dimensionless"]),
+            "r_c": self.r_c(t, ustrip=ul),
+        }
+        return density(params, r)  # type: ignore[no-any-return]
 
 
 # ===================================================================
@@ -115,3 +139,19 @@ def potential(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
     )
 
     return term1 + term2 - phi_infinity  # type: ignore[no-any-return]
+
+
+@ft.partial(jax.jit)
+def density(p: gt.Params, r: gt.Sz0, /) -> gt.FloatSz0:
+    r"""Density for the power-law cutoff profile that defines this model.
+
+    $$
+    \rho(r) = \frac{M}{2\pi \Gamma((3-\alpha)/2) r_c^3}
+        \left(\frac{r_c}{r}\right)^\alpha \exp{-(r / r_c)^2}
+    $$
+
+    """
+    alpha, r_c, m_tot = p["alpha"], p["r_c"], p["m_tot"]
+    norm = m_tot / (2 * jnp.pi * jsp.gamma(1.5 - alpha / 2) * r_c**3)
+    _result = norm * (r_c / r) ** alpha * jnp.exp(-((r / r_c) ** 2))
+    return _result  # type: ignore[no-any-return]

--- a/src/galax/potential/_src/builtin/satoh.py
+++ b/src/galax/potential/_src/builtin/satoh.py
@@ -5,6 +5,7 @@ __all__ = [
     "SatohPotential",
     # functions
     "potential",
+    "density",
 ]
 
 import functools as ft
@@ -18,14 +19,20 @@ import unxt as u
 from unxt.quantity import AllowValue
 
 import galax.potential.custom_types as gt
-from galax.potential._src.base_single import AbstractSinglePotential
+from galax.potential._src.base_single import (
+    AbstractSinglePotential,
+    LaplacianFromDensityMixin,
+)
 from galax.potential._src.params.base import AbstractParameter
 from galax.potential._src.params.field import ParameterField
 
 
 @final
-class SatohPotential(AbstractSinglePotential):
+class SatohPotential(LaplacianFromDensityMixin, AbstractSinglePotential):
     r"""SatohPotential(m, a, b, units=None, origin=None, R=None).
+
+    Satoh, C. 1980, PASJ, 32, 41.
+    https://ui.adsabs.harvard.edu/abs/1980PASJ...32...41S
 
     Satoh potential for a flattened mass distribution.
     This is a good distribution for both disks and spheroids.
@@ -33,6 +40,15 @@ class SatohPotential(AbstractSinglePotential):
     .. math::
 
         \Phi = -\frac{G M}{\sqrt{R^2 + z^2 + a(a + 2\sqrt{z^2 + b^2})}}
+
+    with corresponding density (derived from the potential above via
+    Poisson's equation):
+
+    $$
+    \rho(R,z) = \frac{M a b^2 \left[\zeta(R^2+a^2+6b^2+7z^2) + 5a\zeta^2\right]}
+        {4\pi \zeta^4 \left(R^2+z^2+a(a+2\zeta)\right)^{5/2}},
+        \qquad \zeta = \sqrt{z^2+b^2}
+    $$
 
     """
 
@@ -56,6 +72,19 @@ class SatohPotential(AbstractSinglePotential):
         }
         return potential(params, xyz)  # type: ignore[no-any-return]
 
+    @ft.partial(jax.jit)
+    def _density(self, xyz: gt.BBtQorVSz3, t: gt.BBtQorVSz0, /) -> gt.BBtSz0:
+        # Parse inputs
+        xyz = u.ustrip(AllowValue, self.units["length"], xyz)
+        t = u.Q.from_(t, self.units["time"])
+
+        params = {
+            "m_tot": self.m_tot(t, ustrip=self.units["mass"]),
+            "a": self.a(t, ustrip=self.units["length"]),
+            "b": self.b(t, ustrip=self.units["length"]),
+        }
+        return density(params, xyz)  # type: ignore[no-any-return]
+
 
 # ===================================================================
 
@@ -67,3 +96,18 @@ def potential(p: gt.Params, xyz: gt.Sz3, /) -> gt.Sz0:
     z = xyz[..., 2]
     term = R2 + z**2 + p["a"] * (p["a"] + 2 * jnp.sqrt(z**2 + p["b"] ** 2))
     return -p["G"] * p["m_tot"] / jnp.sqrt(term)  # type: ignore[no-any-return]
+
+
+@ft.partial(jax.jit)
+def density(p: gt.Params, xyz: gt.Sz3, /) -> gt.Sz0:
+    r"""Density function for the Satoh potential (Satoh 1980)."""
+    a, b, m_tot = p["a"], p["b"], p["m_tot"]
+    R2 = xyz[..., 0] ** 2 + xyz[..., 1] ** 2
+    z = xyz[..., 2]
+    zeta = jnp.sqrt(z**2 + b**2)
+    term = R2 + z**2 + a * (a + 2 * zeta)
+    numer = (
+        m_tot * a * b**2 * (zeta * (R2 + a**2 + 6 * b**2 + 7 * z**2) + 5 * a * zeta**2)
+    )
+    denom = 4 * jnp.pi * zeta**4 * term**2.5
+    return numer / denom  # type: ignore[no-any-return]

--- a/tests/unit/potential/builtin/test_abstractmultipole.py
+++ b/tests/unit/potential/builtin/test_abstractmultipole.py
@@ -127,3 +127,16 @@ class MultipoleTestMixin:
             inner_pot.potential(x, t=0)
 
         init_potential_evaluate()
+
+    def test_potential_density_correspondence(
+        self, pot: gp.AbstractPotential, x: gt.QuSz3
+    ) -> None:
+        # Multipole potentials are exact solid harmonics, so the density is
+        # exactly zero everywhere (see `AbstractMultipolePotential._density`).
+        # `pot.hessian` computes the "true" side via autodiff as a
+        # near-perfect cancellation of nonzero terms, which can leave
+        # float64 roundoff noise a little above the base test's tight
+        # `atol=1e-15`. Use a slightly looser tolerance here.
+        lhs = jnp.trace(pot.hessian(x, 0))
+        rhs = 4 * jnp.pi * pot.constants["G"] * pot.density(x, 0)
+        assert jnp.isclose(lhs, rhs, atol=u.Q(1e-14, pot.units["frequency drift"]))

--- a/tests/unit/potential/builtin/test_density_vs_gala.py
+++ b/tests/unit/potential/builtin/test_density_vs_gala.py
@@ -1,0 +1,101 @@
+"""Cross-check the analytic ``_density`` formulas added this session against gala.
+
+Most potentials already get this coverage for free from
+`GalaIOMixin.test_method_gala` (see ``tests/unit/potential/io/test_gala.py``),
+which every ``AbstractSinglePotential_Test`` subclass inherits. This module
+makes that check explicit and consolidated for the closed-form densities
+newly derived here (Poisson's equation applied to potentials that previously
+had no ``_density`` override, or a stray-unit bug), so a regression in any of
+them is easy to spot in one place.
+"""
+
+import astropy.units as apyu
+import pytest
+from plum import convert
+
+import quaxed.numpy as jnp
+import unxt as u
+
+import galax.potential as gp
+from galax.interop.optional_deps import GSL_ENABLED, OptDeps
+
+X = u.Q([3.5, 2.0, 1.0], "kpc")  # generic off-axis evaluation point
+
+POTENTIALS = [
+    pytest.param(
+        gp.MiyamotoNagaiPotential(m_tot=6e10, a=6.5, b=0.26, units="galactic"),
+        id="miyamotonagai",
+    ),
+    pytest.param(gp.JaffePotential(m_tot=1e12, r_s=10.0, units="galactic"), id="jaffe"),
+    pytest.param(
+        gp.IsochronePotential(m_tot=1e11, r_s=5.0, units="galactic"), id="isochrone"
+    ),
+    pytest.param(
+        gp.LogarithmicPotential(v_c=220.0, r_s=8.0, units="galactic"),
+        id="logarithmic",
+    ),
+    pytest.param(
+        gp.LMJ09LogarithmicPotential(
+            v_c=220.0,
+            r_s=12.0,
+            q1=1.3,
+            q2=1.0,
+            q3=0.8,
+            phi=u.Q(20, "deg"),
+            units="galactic",
+        ),
+        id="lmj09logarithmic",
+        # Not our bug: gala's compiled `logarithmic_density` (in
+        # builtin_potentials.cpp) uses the *un*-rotated position `q[0],
+        # q[1]` directly, while `logarithmic_value`/`logarithmic_gradient`
+        # correctly rotate by `phi` first. So gala's own potential/gradient
+        # and density disagree with each other whenever `phi != 0` and `q1
+        # != q2`; galax's `density` (verified exactly self-consistent with
+        # its own potential via Poisson's equation) is unaffected. Already
+        # flagged as a TODO in test_lmj09logarithmic.py::test_method_gala.
+        marks=pytest.mark.xfail(
+            reason="gala's logarithmic_density omits the phi rotation "
+            "(compiled builtin_potentials.cpp bug, not a galax issue)",
+            strict=True,
+        ),
+    ),
+    pytest.param(
+        gp.SatohPotential(m_tot=1e11, a=6.0, b=0.3, units="galactic"), id="satoh"
+    ),
+    pytest.param(
+        gp.KuzminPotential(m_tot=1e11, r_s=1.0, units="galactic"), id="kuzmin"
+    ),
+    pytest.param(
+        gp.LongMuraliBarPotential(
+            m_tot=1e10, a=5.0, b=1.0, c=0.3, alpha=u.Q(0.9, "rad"), units="galactic"
+        ),
+        id="longmuralibar",
+    ),
+    pytest.param(
+        gp.PowerLawCutoffPotential(m_tot=1e11, alpha=1.2, r_c=10.0, units="galactic"),
+        id="powerlawcutoff",
+        marks=pytest.mark.skipif(not GSL_ENABLED, reason="requires gala + GSL"),
+    ),
+]
+
+
+@pytest.mark.skipif(not OptDeps.GALA.installed, reason="requires gala")
+@pytest.mark.parametrize("pot", POTENTIALS)
+def test_density_matches_gala(pot: gp.AbstractSinglePotential) -> None:
+    """`density` matches gala's reference implementation for the same model."""
+    gala_pot = gp.io.convert_potential(gp.io.GalaLibrary, pot)
+
+    galax_density = convert(pot.density(X, t=0), u.Quantity)
+    gala_density = convert(gala_pot.density(convert(X, apyu.Quantity)), u.Quantity)
+    assert jnp.allclose(galax_density, gala_density, atol=u.Q(1e-8, galax_density.unit))
+
+
+# ---------------------------------------------------------------------------
+# Not comparable to gala:
+#
+# - `MonariEtAl2016BarPotential`: this model has no gala counterpart.
+# - `MultipoleInnerPotential` / `MultipoleOuterPotential` / `MultipolePotential`:
+#   already tested directly (`_density` is exactly zero for every solid-harmonic
+#   term, verified in test_multipole.py / test_innermultipole.py /
+#   test_outermultipole.py); their `test_method_gala` is separately marked
+#   xfail for reasons unrelated to density (see test_multipole.py).

--- a/tests/unit/potential/builtin/test_innermultipole.py
+++ b/tests/unit/potential/builtin/test_innermultipole.py
@@ -81,7 +81,9 @@ class TestMultipoleInnerPotential(
         return pot.gradient(x, t=0).ustrip(pot.units["acceleration"])
 
     def test_density(self, pot: gp.MultipoleInnerPotential, x: gt.QuSz3) -> None:
-        exp = u.Q(2.89194575e-05, unit="solMass / kpc3")
+        # Exactly zero: r^l Y_lm is a solid harmonic (source-free) for every
+        # l, m. See `AbstractMultipolePotential._density`.
+        exp = u.Q(0, unit="solMass / kpc3")
         got = pot.density(x, t=0)
 
         assert jnp.isclose(got, exp, atol=u.Q(1e-8, exp.unit))

--- a/tests/unit/potential/builtin/test_kuzmin.py
+++ b/tests/unit/potential/builtin/test_kuzmin.py
@@ -46,7 +46,9 @@ class TestKuzminPotential(
         return pot.gradient(x, t=0).ustrip(pot.units["acceleration"])
 
     def test_density(self, pot: gp.KuzminPotential, x: gt.QuSz3) -> None:
-        expect = u.Q(2.45494884e-07, "solMass / kpc3")
+        # Exactly zero off the z=0 plane: a razor-thin disk's volume density
+        # vanishes identically away from the plane. See `KuzminPotential._density`.
+        expect = u.Q(0, "solMass / kpc3")
         assert jnp.isclose(pot.density(x, t=0), expect, atol=u.Q(1e-8, expect.unit))
 
     @pytest.mark.array_compare(

--- a/tests/unit/potential/builtin/test_multipole.py
+++ b/tests/unit/potential/builtin/test_multipole.py
@@ -277,7 +277,9 @@ class TestMultipolePotential(
         return pot.gradient(x, t=0).ustrip(pot.units["acceleration"])
 
     def test_density(self, pot: gp.MultipolePotential, x: gt.QuSz3) -> None:
-        expect = u.Q(4.73805126e-05, pot.units["mass density"])
+        # Exactly zero: both r^l Y_lm and r^{-(l+1)} Y_lm are solid harmonics
+        # (source-free) for every l, m. See `AbstractMultipolePotential._density`.
+        expect = u.Q(0, pot.units["mass density"])
         assert jnp.isclose(pot.density(x, t=0), expect, atol=u.Q(1e-8, expect.unit))
 
     @pytest.mark.array_compare(


### PR DESCRIPTION
## Summary

Follow-up to #823. Extends the closed-form-density + `LaplacianFromDensityMixin` treatment to every other built-in potential with a genuine analytic density. Each density is verified via Poisson's equation applied to the *exact implemented potential* (not just transcribed from a paper), cross-checked against `jax.hessian`, and — where a gala equivalent exists — against gala's independent implementation:

- **Miyamoto & Nagai (1975)**: closed-form disk density (their eq. 4).
- **Jaffe (1983)**: closed-form density; also fixes a stale docstring formula that didn't match the actually-implemented potential (`log(1+r/r_s)` vs. the code's `log(1+r_s/r)`).
- **Isochrone (Hénon 1959)**: density derived from the potential.
- **Logarithmic** (spherical and LMJ09 triaxial): density derived from the potential (Binney & Tremaine 2008 for the spherical case).
- **Satoh (1980)**: closed-form density.
- **Kuzmin (1956)**: a razor-thin disk has exactly zero volume density off the `z=0` plane; `_density` now returns `0` instead of the tiny autodiff noise the default hessian-trace path previously produced.
- **Long & Murali (1992)**: density derived via computer algebra directly from the (algebraically messy, finite-bar) potential formula.
- **`PowerLawCutoffPotential`**: implements the density that already defines this model (matching Gala), fixing a stray `G` in the docstring formula.
- **Monari et al. (2016) bar** (3D generalization of the Dehnen 2000 bar): density derived from the potential, confined to `r < R_b` and exactly zero outside, matching Dehnen's construction. No gala counterpart to cross-verify against.
- **`MultipoleInnerPotential` / `MultipoleOuterPotential` / `MultipolePotential`**: `r^l Y_lm` and `r^{-(l+1)} Y_lm` are *solid harmonics* — exact, source-free solutions of Laplace's equation for every `l, m` (Binney & Tremaine 2008, Sec. 2.4) — so density is exactly zero wherever these are evaluated.

**Not changed**: `HarmonicOscillatorPotential` (density already known-broken and skipped in tests), and `LeeSutoTriaxialNFWPotential` / `Vogelsberger08TriaxialNFWPotential` (their potentials are only approximate/ad-hoc solutions to Poisson's equation for an assumed density — verified numerically that `trace(hessian(Φ))` does *not* match `4πG·ρ_assumed` for these — so no density exists that's exactly consistent with the implemented potential).

## Tests

- Updated three hardcoded `test_density` expectations (Kuzmin, `MultipoleInnerPotential`, `MultipolePotential`) that hardcoded the old hessian-trace noise instead of the new exact `0.`.
- Loosened the multipole potentials' shared `test_potential_density_correspondence` tolerance slightly (`1e-15` → `1e-14`): comparing an exact `0.` density against an autodiff Hessian trace that computes it via near-perfect cancellation of nonzero terms can leave float64 roundoff just above the old bound.
- Added `tests/unit/potential/builtin/test_density_vs_gala.py`: an explicit, consolidated cross-check of every closed-form density above against gala's own implementation of the same model. All pass except `LMJ09LogarithmicPotential`, marked `xfail` — **found and root-caused a real bug in gala**: its compiled `logarithmic_density` (`builtin_potentials.cpp`) uses the un-rotated position directly, while `logarithmic_value`/`logarithmic_gradient` correctly rotate by `phi` first. This was already flagged with an unexplained `TODO: get gala and galax to agree` in this repo's own `test_lmj09logarithmic.py` predating this PR; this PR identifies the exact cause. galax's density is unaffected (verified exactly self-consistent with its own potential via Poisson's equation).
- Full `tests/unit/potential/` + `tests/smoke/potential/` suite passes locally (1298 passed) with gala installed (`uv sync --extra interop-gala`), which is also what CI's `check_interop` job runs.

## Test plan

- [x] `pytest tests/unit/potential/ tests/smoke/potential/` — 1298 passed, 0 failed.
- [x] `pytest tests/unit/potential/builtin/test_density_vs_gala.py` — 8 passed, 1 xfailed (gala bug, documented above).
- [x] `pre-commit run --all-files` (ruff, mypy, codespell, etc.) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)