### PR TITLE
Wildcard-import submodules in private __init__.py files, alphabetize builtin's __all__

### DIFF
--- a/src/galax/potential/_src/builtin/__init__.py
+++ b/src/galax/potential/_src/builtin/__init__.py
@@ -5,91 +5,25 @@ See the public API in `galax.potential`.
 
 """
 
-__all__ = [
-    "LongMuraliBarPotential",
-    "MonariEtAl2016BarPotential",
-    "KuzminPotential",
-    "MiyamotoNagaiPotential",
-    "MN3ExponentialPotential",
-    "MN3Sech2Potential",
-    "HarmonicOscillatorPotential",
-    "HenonHeilesPotential",
-    "SatohPotential",
-    "LMJ09LogarithmicPotential",
-    "LogarithmicPotential",
-    "AbstractMultipolePotential",
-    "MultipoleInnerPotential",
-    "MultipoleOuterPotential",
-    "MultipolePotential",
-    "AxisymmetricGaussianPotential",
-    "GaussianPotential",
-    "TriaxialGaussianPotential",
-    "LeeSutoTriaxialNFWPotential",
-    "NFWPotential",
-    "TriaxialNFWPotential",
-    "Vogelsberger08TriaxialNFWPotential",
-    "gNFWPotential",
-    "NullPotential",
-    "BovyMWPotential2014",
-    "LM10Potential",
-    "MilkyWayPotential",
-    "MilkyWayPotential2022",
-    "BurkertPotential",
-    "HernquistPotential",
-    "IsochronePotential",
-    "JaffePotential",
-    "KeplerPotential",
-    "PlummerPotential",
-    "PowerLawCutoffPotential",
-    "StoneOstriker15Potential",
-    "TriaxialHernquistPotential",
-    "HardCutoffNFWPotential",
-    "ZhaoPotential",
-]
-
-from .burkert import BurkertPotential
-from .example import (
-    HarmonicOscillatorPotential,
-    HenonHeilesPotential,
-)
-from .gaussian import (
-    AxisymmetricGaussianPotential,
-    GaussianPotential,
-    TriaxialGaussianPotential,
-)
-from .hernquist import HernquistPotential, TriaxialHernquistPotential
-from .isochrone import IsochronePotential
-from .jaffe import JaffePotential
-from .kepler import KeplerPotential
-from .kuzmin import KuzminPotential
-from .logarithmic import LMJ09LogarithmicPotential, LogarithmicPotential
-from .longmurali import LongMuraliBarPotential
-from .milkyway import (
-    BovyMWPotential2014,
-    LM10Potential,
-    MilkyWayPotential,
-    MilkyWayPotential2022,
-)
-from .miyamotonagai import MiyamotoNagaiPotential
-from .mn3 import MN3ExponentialPotential, MN3Sech2Potential
-from .monari2016 import MonariEtAl2016BarPotential
-from .multipole import (
-    AbstractMultipolePotential,
-    MultipoleInnerPotential,
-    MultipoleOuterPotential,
-    MultipolePotential,
-)
-from .nfw import (
-    HardCutoffNFWPotential,
-    LeeSutoTriaxialNFWPotential,
-    NFWPotential,
-    TriaxialNFWPotential,
-    Vogelsberger08TriaxialNFWPotential,
-    gNFWPotential,
-)
-from .null import NullPotential
-from .plummer import PlummerPotential
-from .powerlawcutoff import PowerLawCutoffPotential
-from .satoh import SatohPotential
-from .stoneostriker15 import StoneOstriker15Potential
-from .zhao import ZhaoPotential
+from .burkert import *
+from .example import *
+from .gaussian import *
+from .hernquist import *
+from .isochrone import *
+from .jaffe import *
+from .kepler import *
+from .kuzmin import *
+from .logarithmic import *
+from .longmurali import *
+from .milkyway import *
+from .miyamotonagai import *
+from .mn3 import *
+from .monari2016 import *
+from .multipole import *
+from .nfw import *
+from .null import *
+from .plummer import *
+from .powerlawcutoff import *
+from .satoh import *
+from .stoneostriker15 import *
+from .zhao import *


### PR DESCRIPTION
Takes over #757 (rebased onto current `main`, which has moved on quite a bit since that PR was opened).

Implements the idea from #757, more precisely: several private `_src/**/__init__.py` files hand-maintained an `__all__` list plus a matching block of explicit named imports, one per submodule, purely to re-export each class/function that each submodule *already* declares in its own `__all__`. Since these files are private API (only consumed by their corresponding public, user-facing module, which always imports specific names explicitly), the private duplication is pure upkeep with no value — replace it with `from .<submodule> import *` per submodule, dropping the redundant private `__all__` entirely:

- `potential/_src/builtin` (and its `gaussian`, `nfw` subpackages) — also alphabetizes the submodule import order, in the spirit of #757's "make it alphabetical"
- `potential/_src/xfm`
- `potential/_src/params`
- `coordinates/_src/frames`
- `coordinates/_src/pscs`
- `coordinates/_src/psps`
- `dynamics/_src/cluster`
- `dynamics/_src/legacy`
- `dynamics/_src/mockstream`

**Every public, user-facing `__init__.py` is unchanged** (`galax.potential`, `galax.coordinates`, `galax.dynamics`, and submodules like `galax.potential.params`, `galax.dynamics.mockstream`, `galax.dynamics.cluster`) — those keep explicit named imports and an explicit `__all__`, since that's the actual public API contract and should stay under deliberate control rather than being derived from whatever a private module happens to export.

A few submodules also export helper functions under generic names (e.g. `potential`, `density`) alongside their class. The wildcard imports mean those names can collide/shadow across submodules within the private `__init__.py`'s own namespace, but that's harmless — nothing outside the file references those names; the public `__init__.py` only ever imports the specific class names it needs.

`dynamics/_src/legacy/mockstream/df/__init__.py` already used this wildcard-import pattern; left as-is, since a smoke test asserts on its `__all__` directly.

## Verification
- `ruff check` clean on all edited files
- `tests/smoke` (12 tests, exact `__all__` checks for every public package) — all pass
- `tests/unit/potential` — 1297 passed, 198 skipped (optional deps), 14 xfailed (pre-existing)
- `tests/unit/coordinates` + `tests/unit/dynamics` — 142 passed

Closes #757.

🤖 Generated with [Claude Code](https://claude.com/claude-code)