### PR TITLE
Wildcard-import submodules in more private __init__.py files

### DIFF
--- a/src/galax/coordinates/_src/frames/__init__.py
+++ b/src/galax/coordinates/_src/frames/__init__.py
@@ -4,7 +4,5 @@ Building off of `coordinax.frames`.
 
 """
 
-__all__ = ["SimulationFrame", "simulation_frame", "OrphanChenab"]
-
-from .orphan_chenab import OrphanChenab
-from .simulation import SimulationFrame, simulation_frame
+from .orphan_chenab import *
+from .simulation import *

--- a/src/galax/coordinates/_src/pscs/__init__.py
+++ b/src/galax/coordinates/_src/pscs/__init__.py
@@ -4,23 +4,11 @@ This is private API.
 
 """
 
-__all__ = [
-    # Base
-    "AbstractPhaseSpaceCoordinate",
-    "ComponentShapeTuple",
-    # Single
-    "AbstractBasicPhaseSpaceCoordinate",
-    "PhaseSpaceCoordinate",
-    # Composite
-    "AbstractCompositePhaseSpaceCoordinate",
-    "CompositePhaseSpaceCoordinate",
-]
-
-from .base import AbstractPhaseSpaceCoordinate, ComponentShapeTuple
-from .base_composite import AbstractCompositePhaseSpaceCoordinate
-from .base_single import AbstractBasicPhaseSpaceCoordinate
-from .composite import CompositePhaseSpaceCoordinate
-from .single import PhaseSpaceCoordinate
+from .base import *
+from .base_composite import *
+from .base_single import *
+from .composite import *
+from .single import *
 
 # Register by import
 # isort: split

--- a/src/galax/coordinates/_src/psps/__init__.py
+++ b/src/galax/coordinates/_src/psps/__init__.py
@@ -4,9 +4,7 @@ This is private API.
 
 """
 
-__all__ = ["PhaseSpacePosition", "ComponentShapeTuple"]
-
-from .core import ComponentShapeTuple, PhaseSpacePosition
+from .core import *
 
 # Register by import
 # isort: split

--- a/src/galax/dynamics/_src/cluster/__init__.py
+++ b/src/galax/dynamics/_src/cluster/__init__.py
@@ -1,41 +1,11 @@
 """Cluster evolution."""
 
-__all__ = [
-    # Modules
-    "radius",
-    "relax_time",
-    # Solvers
-    "MassSolver",
-    # Fields
-    "MassVectorField",
-    "AbstractMassRateField",
-    "CustomMassRateField",
-    "ZeroMassRate",
-    "ConstantMassRate",
-    "Baumgardt1998MassLossRate",
-    # Events
-    "MassBelowThreshold",
-    # Sample
-    "ReleaseTimeSampler",
-    # Functions
-    "lagrange_points",
-    "tidal_radius",
-    "relaxation_time",
-]
-
-from . import radius, relax_time
-from .api import lagrange_points, relaxation_time, tidal_radius
-from .dmdt import (
-    AbstractMassRateField,
-    Baumgardt1998MassLossRate,
-    ConstantMassRate,
-    CustomMassRateField,
-    MassVectorField,
-    ZeroMassRate,
-)
-from .events import MassBelowThreshold
-from .sample import ReleaseTimeSampler
-from .solver import MassSolver
+from . import radius as radius, relax_time as relax_time
+from .api import *
+from .dmdt import *
+from .events import *
+from .sample import *
+from .solver import *
 
 # Register by import
 # isort: split

--- a/src/galax/dynamics/_src/legacy/__init__.py
+++ b/src/galax/dynamics/_src/legacy/__init__.py
@@ -4,13 +4,6 @@ This is private API.
 
 """
 
-__all__ = [
-    "evaluate_orbit",
-    "Integrator",
-    # Interpolation
-    "InterpolatedPhaseSpaceCoordinate",
-]
-
-from .funcs import evaluate_orbit
-from .integrator import Integrator
-from .interp_psp import InterpolatedPhaseSpaceCoordinate
+from .funcs import *
+from .integrator import *
+from .interp_psp import *

--- a/src/galax/dynamics/_src/mockstream/__init__.py
+++ b/src/galax/dynamics/_src/mockstream/__init__.py
@@ -4,10 +4,5 @@ This is private API.
 
 """
 
-__all__ = [
-    "MockStream",
-    "MockStreamArm",
-]
-
-from .arm import MockStreamArm
-from .core import MockStream
+from .arm import *
+from .core import *

--- a/src/galax/potential/_src/builtin/gaussian/__init__.py
+++ b/src/galax/potential/_src/builtin/gaussian/__init__.py
@@ -1,11 +1,5 @@
 """Gaussian-density potentials."""
 
-__all__ = [
-    "AxisymmetricGaussianPotential",
-    "GaussianPotential",
-    "TriaxialGaussianPotential",
-]
-
-from .axisymmetric import AxisymmetricGaussianPotential
-from .base import GaussianPotential
-from .triaxial import TriaxialGaussianPotential
+from .axisymmetric import *
+from .base import *
+from .triaxial import *

--- a/src/galax/potential/_src/builtin/nfw/__init__.py
+++ b/src/galax/potential/_src/builtin/nfw/__init__.py
@@ -1,17 +1,8 @@
 """NFW-like potentials."""
 
-__all__ = [
-    "NFWPotential",
-    "LeeSutoTriaxialNFWPotential",
-    "TriaxialNFWPotential",
-    "HardCutoffNFWPotential",
-    "Vogelsberger08TriaxialNFWPotential",
-    "gNFWPotential",
-]
-
-from .base import NFWPotential
-from .generalized import gNFWPotential
-from .leesuto import LeeSutoTriaxialNFWPotential
-from .triaxial import TriaxialNFWPotential
-from .truncated import HardCutoffNFWPotential
-from .vogelsburger08 import Vogelsberger08TriaxialNFWPotential
+from .base import *
+from .generalized import *
+from .leesuto import *
+from .triaxial import *
+from .truncated import *
+from .vogelsburger08 import *

--- a/src/galax/potential/_src/params/__init__.py
+++ b/src/galax/potential/_src/params/__init__.py
@@ -1,26 +1,7 @@
 """`galax.potential.params`."""
 
-__all__ = [
-    # Fields
-    "ParameterField",
-    # Parameters
-    "AbstractParameter",
-    "ParameterCallable",
-    "ConstantParameter",
-    "LinearParameter",
-    "CustomParameter",
-    # Attributes
-    "AbstractParametersAttribute",
-    "ParametersAttribute",
-    "CompositeParametersAttribute",
-]
-
-from .attr import (
-    AbstractParametersAttribute,
-    CompositeParametersAttribute,
-    ParametersAttribute,
-)
-from .base import AbstractParameter, ParameterCallable
-from .constant import ConstantParameter
-from .core import CustomParameter, LinearParameter
-from .field import ParameterField
+from .attr import *
+from .base import *
+from .constant import *
+from .core import *
+from .field import *

--- a/src/galax/potential/_src/xfm/__init__.py
+++ b/src/galax/potential/_src/xfm/__init__.py
@@ -1,17 +1,7 @@
 """Transformed Galax Potentials."""
 
-__all__ = [
-    "AbstractTransformedPotential",
-    "FlattenedInThePotential",
-    "TransformedPotential",
-    "TriaxialInThePotential",
-    # Translation
-    "TranslatedPotential",
-    "TimeDependentTranslationParameter",
-]
-
-from .base import AbstractTransformedPotential
-from .flattened import FlattenedInThePotential
-from .translate import TimeDependentTranslationParameter, TranslatedPotential
-from .triaxial import TriaxialInThePotential
-from .xop import TransformedPotential
+from .base import *
+from .flattened import *
+from .translate import *
+from .triaxial import *
+from .xop import *


### PR DESCRIPTION
Follow-up to #830, which applied this pattern only to `potential/_src/builtin/__init__.py`. This extends it to the other private `_src/**/__init__.py` files with the same shape: a hand-maintained `__all__` plus a matching block of explicit named imports, one per submodule, purely to re-export what each submodule already declares in its own `__all__`.

Since these files are private API — only consumed by their corresponding public, user-facing module, which always imports specific names explicitly — the private duplication is pure upkeep with no value. Replace each with `from .<submodule> import *` per submodule, dropping the redundant private `__all__` entirely:

- `potential/_src/xfm`
- `potential/_src/params`
- `potential/_src/builtin/gaussian`
- `potential/_src/builtin/nfw`
- `coordinates/_src/frames`
- `coordinates/_src/pscs`
- `coordinates/_src/psps`
- `dynamics/_src/cluster`
- `dynamics/_src/legacy`
- `dynamics/_src/mockstream`

**Every public, user-facing `__init__.py` is unchanged** (`galax.potential`, `galax.coordinates`, `galax.dynamics`, and submodules like `galax.potential.params`, `galax.dynamics.mockstream`, `galax.dynamics.cluster`) — those keep explicit named imports and an explicit `__all__`, since that's the actual public API contract.

A few submodules also export helper functions under generic names (e.g. `potential`, `density`) alongside their class. The wildcard imports mean those names can collide/shadow across submodules within a private `__init__.py`'s own namespace, but that's harmless — nothing outside the file references those names; each public `__init__.py` only ever imports the specific class names it needs.

One real fix needed along the way: `dynamics/_src/cluster/__init__.py` also does `from . import radius, relax_time` (re-exporting two submodules, not classes). Dropping its `__all__` made ruff flag those as unused imports, fixed with the standard `import x as x` re-export idiom.

`dynamics/_src/legacy/mockstream/df/__init__.py` already used this wildcard-import pattern; left as-is, since a smoke test asserts on its `__all__` directly.

## Verification
- `ruff check` clean on all edited files (pre-commit hooks pass, including mypy)
- `tests/smoke` (12 tests, exact `__all__` checks for every public package) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)