### PR TITLE
Wildcard-import submodules in remaining private __init__.py files

### DIFF
--- a/src/galax/dynamics/_src/experimental/__init__.py
+++ b/src/galax/dynamics/_src/experimental/__init__.py
@@ -1,6 +1,4 @@
 """Experimental dynamics."""
 
-__all__ = ["integrate_orbit", "StreamSimulator"]
-
-from .integrate import integrate_orbit
-from .stream import StreamSimulator
+from .integrate import *
+from .stream import *

--- a/src/galax/dynamics/_src/legacy/mockstream/__init__.py
+++ b/src/galax/dynamics/_src/legacy/mockstream/__init__.py
@@ -4,6 +4,4 @@ This is private API.
 
 """
 
-__all__ = ["MockStreamGenerator"]
-
-from .mockstream_generator import MockStreamGenerator
+from .mockstream_generator import *

--- a/src/galax/dynamics/_src/orbit/__init__.py
+++ b/src/galax/dynamics/_src/orbit/__init__.py
@@ -1,29 +1,14 @@
 """Orbits. Private module."""
 
-__all__ = [
-    "AbstractOrbit",
-    "Orbit",
-    # Solve orbits
-    "compute_orbit",
-    "OrbitSolver",
-    # Fields
-    "AbstractOrbitField",
-    "HamiltonianField",
-    "NBodyField",
-    # misc
-    "plot_components",
-    "PhaseSpaceInterpolation",
-]
-
-from .api import compute_orbit
+from .api import *
 from .base import AbstractOrbit
-from .field_base import AbstractOrbitField
-from .field_hamiltonian import HamiltonianField
-from .field_nbody import NBodyField
-from .interp import PhaseSpaceInterpolation
-from .orbit import Orbit
-from .plot_helper import ProxyAbstractOrbit, plot_components
-from .solver import OrbitSolver
+from .field_base import *
+from .field_hamiltonian import *
+from .field_nbody import *
+from .interp import *
+from .orbit import *
+from .plot_helper import ProxyAbstractOrbit, plot_components as plot_components
+from .solver import *
 
 # Register by import
 # isort: split


### PR DESCRIPTION
Follow-up to #830 and #831 (independent of #831 — no file overlap, mergeable in either order), covering the remaining private `_src/**/__init__.py` files with the same shape: a hand-maintained `__all__` plus a matching block of explicit named imports, purely to re-export what each submodule already declares in its own `__all__`.

- `dynamics/_src/orbit`
- `dynamics/_src/experimental`
- `dynamics/_src/legacy/mockstream`

`coordinates/_src/ops/__init__.py` has no submodule imports at all (`__all__: tuple[str, ...] = ()`) — nothing to simplify there.

`dynamics/_src/orbit/__init__.py` keeps two explicit (non-wildcard) imports, since the file itself uses them directly:
- `AbstractOrbit` — referenced by the `ProxyAbstractOrbit.deliver(AbstractOrbit)` call at the bottom of the file. A wildcard import there trips ruff's F405 ("may be undefined, or defined from star imports").
- `ProxyAbstractOrbit` — a private symbol needed only for that side effect; it isn't in `plot_helper`'s own `__all__`, so a wildcard import wouldn't bring it in anyway.

Every public, user-facing `__init__.py` is unchanged.

## Verification
- `ruff check` clean on all edited files (pre-commit hooks pass, including mypy)
- `tests/smoke` (12 tests) + `tests/unit/dynamics` (50 tests) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)