### PR TITLE
🐛 fix(potential): broadcast l/m in compute_Ylm

### DIFF
--- a/src/galax/dynamics/_src/cluster/solver.py
+++ b/src/galax/dynamics/_src/cluster/solver.py
@@ -129,7 +129,7 @@ class MassSolver(AbstractSolver):
 # Init Dispatches
 
 
-@MassSolver.init.dispatch  # type: ignore[misc,union-attr]
+@MassSolver.init.dispatch
 def init(
     self: MassSolver,
     field: AbstractMassRateField,
@@ -148,7 +148,7 @@ def init(
 # Run Dispatches
 
 
-@MassSolver.run.dispatch  # type: ignore[misc,union-attr]
+@MassSolver.run.dispatch
 def run(
     self: MassSolver,
     field: AbstractMassRateField,
@@ -181,7 +181,7 @@ def run(
 default_saveat = dfx.SaveAt(t1=True)
 
 
-@MassSolver.solve.dispatch  # type: ignore[misc,union-attr]
+@MassSolver.solve.dispatch
 @eqx.filter_jit
 def solve(
     self: MassSolver,

--- a/src/galax/dynamics/_src/examples/mw_lmc.py
+++ b/src/galax/dynamics/_src/examples/mw_lmc.py
@@ -192,7 +192,7 @@ class RigidMWandLMCField(AbstractField):
         raise NotImplementedError  # pragma: no cover
 
     @override
-    @AbstractField.parse_inputs.dispatch  # type: ignore[misc,union-attr]
+    @AbstractField.parse_inputs.dispatch
     def parse_inputs(  # type: ignore[override]
         self: "RigidMWandLMCField",
         t0: gt.LikeSz0 | gt.QuSz0,

--- a/src/galax/dynamics/_src/orbit/field_base.py
+++ b/src/galax/dynamics/_src/orbit/field_base.py
@@ -33,7 +33,7 @@ class AbstractOrbitField(AbstractField):
         raise NotImplementedError  # pragma: no cover
 
     @override
-    @AbstractField.parse_inputs.dispatch  # type: ignore[misc,override,union-attr]
+    @AbstractField.parse_inputs.dispatch  # type: ignore[override]
     def parse_inputs(
         self: "AbstractOrbitField", *args: Any, ustrip: bool = True, **kwargs: Any
     ) -> tuple[Array, PyTree[Array]]:

--- a/src/galax/dynamics/_src/orbit/field_hamiltonian.py
+++ b/src/galax/dynamics/_src/orbit/field_hamiltonian.py
@@ -253,7 +253,7 @@ class HamiltonianField(AbstractOrbitField):
 # Terms dispatches
 
 
-@AbstractOrbitField.terms.dispatch  # type: ignore[misc,union-attr]
+@AbstractOrbitField.terms.dispatch
 def terms(
     self: HamiltonianField,
     _: dfx.SemiImplicitEuler,

--- a/src/galax/dynamics/_src/orbit/field_nbody.py
+++ b/src/galax/dynamics/_src/orbit/field_nbody.py
@@ -85,7 +85,7 @@ class NBodyField(AbstractOrbitField):
         raise NotImplementedError  # pragma: no cover
 
 
-@NBodyField.__call__.dispatch  # type: ignore[misc,union-attr]
+@NBodyField.__call__.dispatch
 @jax.jit
 def __call__(
     self: "NBodyField",

--- a/src/galax/dynamics/_src/orbit/solver.py
+++ b/src/galax/dynamics/_src/orbit/solver.py
@@ -771,7 +771,7 @@ def run(
 # TODO: check if this is any faster than the `init-run` pattern.
 
 
-@OrbitSolver.solve.dispatch(precedence=1)  # type: ignore[misc,union-attr]
+@OrbitSolver.solve.dispatch(precedence=1)  # type: ignore[misc]
 @ft.partial(eqx.filter_jit)
 def solve(
     self: OrbitSolver,
@@ -803,7 +803,7 @@ def solve(
     return soln
 
 
-scalar_solver = OrbitSolver.solve.invoke(  # type: ignore[union-attr]
+scalar_solver = OrbitSolver.solve.invoke(
     OrbitSolver,
     AbstractOrbitField,
     tuple[gdt.BBtQarr, gdt.BBtParr],

--- a/src/galax/dynamics/_src/solver.py
+++ b/src/galax/dynamics/_src/solver.py
@@ -426,7 +426,7 @@ def integrate_field(
         else solver
     )
     # Parse t0, y0. Important for Quantities
-    _, y0 = field.parse_inputs(ts[0], y0, ustrip=True)  # type: ignore[misc]
+    _, y0 = field.parse_inputs(ts[0], y0, ustrip=True)
 
     # Make SaveAt
     u_t = field.units["time"]

--- a/src/galax/potential/_src/builtin/multipole.py
+++ b/src/galax/potential/_src/builtin/multipole.py
@@ -288,5 +288,11 @@ def compute_Ylm(
     *,
     l_max: int,
 ) -> tuple[Float[Array, "*batch"], Float[Array, "*batch"]]:
-    Ylm = sph_harm_y(jnp.atleast_1d(l), jnp.atleast_1d(m), theta, phi, n_max=l_max)
+    # `sph_harm_y` requires `l`, `m`, `theta`, `phi` to be 1D arrays of equal
+    # length: it pairs them up element-wise. Passing length-1 `l`/`m` against a
+    # length-N `theta` silently returns wrong values at every index but 0.
+    shape = jnp.shape(theta)
+    theta, phi = jnp.reshape(theta, (-1,)), jnp.reshape(phi, (-1,))
+    ls, ms = jnp.full(theta.shape, l), jnp.full(theta.shape, m)
+    Ylm = jnp.reshape(sph_harm_y(ls, ms, theta, phi, n_max=l_max), shape)
     return Ylm.real, Ylm.imag

--- a/tests/unit/potential/builtin/test_multipole.py
+++ b/tests/unit/potential/builtin/test_multipole.py
@@ -327,3 +327,69 @@ class TestMultipolePotential(
         atol: float,
     ) -> None:
         super().test_method_gala(pot, method0, method1, x, atol)
+
+
+###############################################################################
+# Regression: batched evaluation must match per-position evaluation.
+#
+# `compute_Ylm` used to pass length-1 `l`/`m` arrays to `sph_harm_y` against a
+# length-N `theta`, which silently returned wrong values at every batch index
+# but 0 for any `l > 0` term. Every other Multipole fixture here evaluates a
+# single position, so nothing caught it.
+
+
+def _lm_coeffs(l_max: int) -> tuple[Shaped[Array, "3 3"], Shaped[Array, "3 3"]]:
+    """Build ``Slm``/``Tlm`` with non-zero entries at ``m >= 1``."""
+    Slm = jnp.zeros((l_max + 1, l_max + 1))
+    Slm = Slm.at[1, 0].set(0.4).at[1, 1].set(0.3).at[2, 2].set(0.15)
+    Tlm = jnp.zeros((l_max + 1, l_max + 1))
+    Tlm = Tlm.at[1, 1].set(0.25).at[2, 1].set(-0.2)
+    return Slm, Tlm
+
+
+_BATCH_XYZ = u.Q(
+    [[1.3, -2.1, 0.7], [4.0, 3.0, -5.0], [-1.5, 2.5, 3.5], [0.2, 0.6, -0.1]], "kpc"
+)
+
+
+@pytest.mark.parametrize(
+    "pot",
+    [
+        gp.MultipoleInnerPotential(
+            m_tot=u.Q(1e12, "Msun"),
+            r_s=u.Q(10.0, "kpc"),
+            Slm=_lm_coeffs(2)[0],
+            Tlm=_lm_coeffs(2)[1],
+            l_max=2,
+            units="galactic",
+        ),
+        gp.MultipoleOuterPotential(
+            m_tot=u.Q(1e12, "Msun"),
+            r_s=u.Q(10.0, "kpc"),
+            Slm=_lm_coeffs(2)[0],
+            Tlm=_lm_coeffs(2)[1],
+            l_max=2,
+            units="galactic",
+        ),
+        gp.MultipolePotential(
+            m_tot=u.Q(1e12, "Msun"),
+            r_s=u.Q(10.0, "kpc"),
+            ISlm=_lm_coeffs(2)[0],
+            ITlm=_lm_coeffs(2)[1],
+            OSlm=_lm_coeffs(2)[0],
+            OTlm=_lm_coeffs(2)[1],
+            l_max=2,
+            units="galactic",
+        ),
+    ],
+    ids=["inner", "outer", "both"],
+)
+def test_batched_matches_per_position(pot: gp.AbstractPotential) -> None:
+    """Evaluate a batch of positions and each position alone; require equality."""
+    t = u.Q(0.0, "Gyr")
+    batched = pot.potential(_BATCH_XYZ, t)
+    one_at_a_time = jnp.stack([pot.potential(xyz, t) for xyz in _BATCH_XYZ])
+
+    assert jnp.allclose(
+        batched, one_at_a_time, rtol=1e-12, atol=u.Q(1e-14, batched.unit)
+    )

--- a/tests/unit/potential/builtin/test_multipole.py
+++ b/tests/unit/potential/builtin/test_multipole.py
@@ -338,8 +338,14 @@ class TestMultipolePotential(
 # single position, so nothing caught it.
 
 
-def _lm_coeffs(l_max: int) -> tuple[Shaped[Array, "3 3"], Shaped[Array, "3 3"]]:
-    """Build ``Slm``/``Tlm`` with non-zero entries at ``m >= 1``."""
+def _lm_coeffs(
+    l_max: int,
+) -> tuple[Shaped[Array, "{l_max}+1 {l_max}+1"], Shaped[Array, "{l_max}+1 {l_max}+1"]]:
+    """Build ``Slm``/``Tlm`` with non-zero entries at ``m >= 1``.
+
+    Requires ``l_max >= 2``: the coefficients set below reach ``(2, 2)``, which
+    is what puts a non-zero ``m >= 1`` term into the expansion.
+    """
     Slm = jnp.zeros((l_max + 1, l_max + 1))
     Slm = Slm.at[1, 0].set(0.4).at[1, 1].set(0.3).at[2, 2].set(0.15)
     Tlm = jnp.zeros((l_max + 1, l_max + 1))
@@ -390,6 +396,11 @@ def test_batched_matches_per_position(pot: gp.AbstractPotential) -> None:
     batched = pot.potential(_BATCH_XYZ, t)
     one_at_a_time = jnp.stack([pot.potential(xyz, t) for xyz in _BATCH_XYZ])
 
+    # The two paths agree exactly (max relative difference 0.0) in float64, but
+    # requiring bit-identity would over-specify the contract: XLA may fuse the
+    # batched and scalar paths differently, and more so on an accelerator. The
+    # regression this guards against is ~1e-1 relative, so 1e-8 keeps seven
+    # orders of detection margin while staying robust. Do not tighten.
     assert jnp.allclose(
-        batched, one_at_a_time, rtol=1e-12, atol=u.Q(1e-14, batched.unit)
+        batched, one_at_a_time, rtol=1e-8, atol=u.Q(1e-10, batched.unit)
     )


### PR DESCRIPTION
## The bug

`jax.scipy.special.sph_harm_y` does **not** broadcast its arguments. It indexes `legendre[..., jnp.arange(len(n))]`, pairing `l[i]`, `m[i]`, `theta[i]`, `phi[i]` positionally.

`compute_Ylm` passed `jnp.atleast_1d(l)` and `jnp.atleast_1d(m)` — shape `(1,)` — against a length-N `theta`. Every batch index but 0 therefore read the Legendre value belonging to index 0.

No error, no `NaN` — just wrong floats.

Measured against `scipy.special.lpmv` for `l = 0..3`, `m = 0..l`:

| | max abs error |
| --- | --- |
| before | **0.1 – 0.7** for every `l >= 1` |
| after | 4e-16 |

`l = 0` is unaffected, but only because `Y_0^0` is constant.

## Impact — this has shipped

`MultipoleInnerPotential`, `MultipoleOuterPotential` and `MultipolePotential` are affected for any `l > 0` term whenever more than one position is evaluated per call. A batched evaluation disagrees with the same positions evaluated one at a time:

```python
pot = gp.MultipoleInnerPotential(
    m_tot=u.Q(1e12, "Msun"), r_s=u.Q(10.0, "kpc"), l_max=2,
    Slm=Slm, Tlm=Tlm, units="galactic",
)
xyz = np.array([[8., 1., 2.], [-3., 4., 5.], [1., -6., 3.]])

batched = pot.potential(u.Q(xyz, "kpc"), t)
looped  = [pot.potential(u.Q(x, "kpc"), t) for x in xyz]
# batched: [-0.08195814,  0.02224250, 0.00993130]
# looped:  [-0.08195814,  0.02651835, 0.00775166]
#           ^ index 0 agrees        ^ everything else does not
```

No existing test caught this because **every** Multipole fixture evaluates a single position, where index 0 is correct.

## The fix

Flatten `theta`/`phi` to 1-D, build matching `l`/`m` arrays, reshape back.

Broadcasting `l`/`m` with `jnp.full(theta.shape, l)` alone is *not* sufficient — `len(n)` is the leading axis, not the total size, so it is still wrong for rank >= 2 input, and it still fails at rank 0 because `len()` raises on a scalar. The flatten/reshape handles 0-d, 1-D and higher-rank uniformly. Verified correct for shapes `()`, `(5,)`, `(3,4)` and `(2,3,4)`, under `jit` and `vmap`.

0-d input previously raised; it now works.

## Test

`test_batched_matches_per_position` asserts batched evaluation equals per-position evaluation for all three Multipole classes, with `l_max = 2` and non-zero coefficients at `m >= 1` and off-axis positions. It fails on the previous implementation (all three classes) and passes after.

## Note on the first commit

`889334b8` removes ten `type: ignore` codes that mypy now reports as unused. It is **unrelated** to this fix, but the pre-commit mypy hook currently fails on `main` for any commit touching `src/` (reproducible by running the hook against an untouched file such as `plummer.py`), so nothing can be committed without it. It appears to be fallout from #806 adding quax to the mypy hook. Happy to split it into its own PR if preferred.

## Why now

This is being sent ahead of the planned migration of galax's special functions to [spexial](https://github.com/JAXtronomy/spexial), so that the fix lands in the code that ships today and so the migration inherits the correct behaviour and the regression test rather than reproducing the bug.

Found while implementing `SCFPotential`, which is affected identically and cannot be correct without this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
