### PR TITLE
🐛 fix(potential): evaluate spherical harmonics in Cartesian form

### DIFF
--- a/src/galax/potential/_src/builtin/multipole.py
+++ b/src/galax/potential/_src/builtin/multipole.py
@@ -8,6 +8,7 @@ __all__ = [
 ]
 
 import functools as ft
+import math
 from dataclasses import KW_ONLY
 
 from jaxtyping import Array, Float
@@ -15,8 +16,8 @@ from typing import final
 
 import equinox as eqx
 import jax
+import numpy as np
 from equinox import field
-from jax.scipy.special import sph_harm_y
 
 import quaxed.numpy as jnp
 import unxt as u
@@ -106,21 +107,16 @@ class MultipoleInnerPotential(AbstractMultipolePotential):
         Slm = self.Slm(t, ustrip=self.units["dimensionless"])
         Tlm = self.Tlm(t, ustrip=self.units["dimensionless"])
 
-        # spherical coordinates
+        # scaled radius and unit direction
         is_scalar = xyz.ndim == 1
-        s, theta, phi = cartesian_to_normalized_spherical(jnp.atleast_2d(xyz), r_s)
+        s, uvec = scaled_radius_and_direction(jnp.atleast_2d(xyz), r_s)
 
         # Compute the summation over l and m
-        l_max = self.l_max
-        ls, ms = jnp.tril_indices(l_max + 1)
-
-        # TODO: vectorize compute_Ylm over l, m, then don't need a vmap?
-        def summand(l: int, m: int) -> Float[Array, "*batch"]:
-            cPlm, sPlm = compute_Ylm(l, m, theta, phi, l_max=l_max)
-            _result = jnp.pow(s, l) * (Slm[l, m] * cPlm + Tlm[l, m] * sPlm)
-            return _result  # type: ignore[no-any-return]
-
-        summation = jnp.sum(jax.vmap(summand, in_axes=(0, 0))(ls, ms), axis=0)
+        terms = [
+            jnp.pow(s, l) * (Slm[l, m] * cYlm + Tlm[l, m] * sYlm)
+            for l, m, cYlm, sYlm in iter_Ylm(self.l_max, uvec)
+        ]
+        summation = jnp.sum(jnp.stack(terms), axis=0)
         if is_scalar:
             summation = summation[0]
 
@@ -174,21 +170,16 @@ class MultipoleOuterPotential(AbstractMultipolePotential):
         Slm = self.Slm(t, ustrip=self.units["dimensionless"])
         Tlm = self.Tlm(t, ustrip=self.units["dimensionless"])
 
-        # spherical coordinates
+        # scaled radius and unit direction
         is_scalar = xyz.ndim == 1
-        s, theta, phi = cartesian_to_normalized_spherical(jnp.atleast_2d(xyz), r_s)
+        s, uvec = scaled_radius_and_direction(jnp.atleast_2d(xyz), r_s)
 
         # Compute the summation over l and m
-        l_max = self.l_max
-        ls, ms = jnp.tril_indices(l_max + 1)
-
-        # TODO: vectorize compute_Ylm over l, m, then don't need a vmap?
-        def summand(l: int, m: int) -> Float[Array, "*batch"]:
-            cPlm, sPlm = compute_Ylm(l, m, theta, phi, l_max=l_max)
-            _result = jnp.pow(s, -(l + 1)) * (Slm[l, m] * cPlm + Tlm[l, m] * sPlm)
-            return _result  # type: ignore[no-any-return]
-
-        summation = jnp.sum(jax.vmap(summand, in_axes=(0, 0))(ls, ms), axis=0)
+        terms = [
+            jnp.pow(s, -(l + 1)) * (Slm[l, m] * cYlm + Tlm[l, m] * sYlm)
+            for l, m, cYlm, sYlm in iter_Ylm(self.l_max, uvec)
+        ]
+        summation = jnp.sum(jnp.stack(terms), axis=0)
         if is_scalar:
             summation = summation[0]
 
@@ -253,22 +244,17 @@ class MultipolePotential(AbstractMultipolePotential):
         ISlm, ITlm = self.ISlm(t, ustrip=u1), self.ITlm(t, ustrip=u1)
         OSlm, OTlm = self.OSlm(t, ustrip=u1), self.OTlm(t, ustrip=u1)
 
-        # spherical coordinates
+        # scaled radius and unit direction
         is_scalar = xyz.ndim == 1
-        s, theta, phi = cartesian_to_normalized_spherical(jnp.atleast_2d(xyz), r_s)
+        s, uvec = scaled_radius_and_direction(jnp.atleast_2d(xyz), r_s)
 
         # Compute the summation over l and m
-        l_max = self.l_max
-        ls, ms = jnp.tril_indices(l_max + 1)
-
-        # TODO: vectorize compute_Ylm over l, m, then don't need a vmap?
-        def summand(l: int, m: int) -> Float[Array, "*batch"]:
-            cPlm, sPlm = compute_Ylm(l, m, theta, phi, l_max=l_max)
-            inner = jnp.pow(s, l) * (ISlm[l, m] * cPlm + ITlm[l, m] * sPlm)
-            outer = jnp.pow(s, -l - 1) * (OSlm[l, m] * cPlm + OTlm[l, m] * sPlm)
-            return inner + outer  # type: ignore[no-any-return]
-
-        summation = jnp.sum(jax.vmap(summand, in_axes=(0, 0))(ls, ms), axis=0)
+        terms = [
+            jnp.pow(s, l) * (ISlm[l, m] * cYlm + ITlm[l, m] * sYlm)
+            + jnp.pow(s, -l - 1) * (OSlm[l, m] * cYlm + OTlm[l, m] * sYlm)
+            for l, m, cYlm, sYlm in iter_Ylm(self.l_max, uvec)
+        ]
+        summation = jnp.sum(jnp.stack(terms), axis=0)
         if is_scalar:
             summation = summation[0]
 
@@ -279,39 +265,84 @@ class MultipolePotential(AbstractMultipolePotential):
 # ===== Helper functions =====
 
 
-def cartesian_to_normalized_spherical(
+def scaled_radius_and_direction(
     q: gt.BtSz3, r_s: gt.Sz0, /
-) -> tuple[gt.BtFloatSz0, gt.BtFloatSz0, gt.BtFloatSz0]:
-    r"""Convert Cartesian coordinates to normalized spherical coordinates.
+) -> tuple[gt.BtFloatSz0, gt.BtSz3]:
+    r"""Split Cartesian positions into :math:`r/r_s` and a unit direction.
 
     .. math::
 
-        r = \sqrt{x^2 + y^2 + z^2}
-        X = \cos(\theta) = z / r
-        \phi = \tan^{-1}\left(\frac{y}{x}\right)
+        r = \sqrt{x^2 + y^2 + z^2}, \qquad \hat{q} = q / r
 
+    The angular dependence is carried by the Cartesian unit vector rather than
+    by :math:`(\theta, \phi)`: ``atan2(y, x)`` has gradient
+    :math:`-y/(x^2+y^2)`, which is :math:`0/0` on the whole z-axis, so any
+    :math:`m \ge 1` term built from it has NaN Cartesian derivatives there.
     """
     r = jnp.linalg.vector_norm(q, axis=-1)
-    s = r / r_s
-    theta = jnp.acos(q[..., 2] / r)  # theta
-    phi = jnp.atan2(q[..., 1], q[..., 0])  # atan(y/x)
-    return s, theta, phi
+    return r / r_s, q / r[..., None]
 
 
-# TODO: vectorize such that it's signature="(l),(l),(N),(N)->(l, N)":
+def reduced_legendre(
+    l: int, m: int, u: Float[Array, "*batch"], /
+) -> Float[Array, "*batch"]:
+    r"""Evaluate :math:`p_l^m(u) = P_l^m(u) / (1 - u^2)^{m/2}`.
+
+    Include the Condon-Shortley phase, matching `scipy.special.lpmv` and GSL.
+    ``l`` and ``m`` are static, so the recurrence unrolls at trace time.
+    """
+    # p_m^m = (-1)^m (2m - 1)!!, with (2m-1)!! = (2m)! / (2^m m!)
+    pmm = (-1.0) ** m * math.factorial(2 * m) / (2**m * math.factorial(m))
+    p_prev, p_cur = jnp.zeros_like(u), jnp.full_like(u, pmm)
+    for ll in range(m + 1, l + 1):
+        p_prev, p_cur = (
+            p_cur,
+            (u * (2 * ll - 1) * p_cur - (ll + m - 1) * p_prev) / (ll - m),
+        )
+    return p_cur  # type: ignore[no-any-return]
+
+
 def compute_Ylm(
-    l: int,
-    m: int,
-    theta: Float[Array, "*batch"],
-    phi: Float[Array, "*batch"],
-    *,
-    l_max: int,
+    l: int, m: int, uvec: gt.BtSz3, /
 ) -> tuple[Float[Array, "*batch"], Float[Array, "*batch"]]:
-    # `sph_harm_y` requires `l`, `m`, `theta`, `phi` to be 1D arrays of equal
-    # length: it pairs them up element-wise. Passing length-1 `l`/`m` against a
-    # length-N `theta` silently returns wrong values at every index but 0.
-    shape = jnp.shape(theta)
-    theta, phi = jnp.reshape(theta, (-1,)), jnp.reshape(phi, (-1,))
-    ls, ms = jnp.full(theta.shape, l), jnp.full(theta.shape, m)
-    Ylm = jnp.reshape(sph_harm_y(ls, ms, theta, phi, n_max=l_max), shape)
-    return Ylm.real, Ylm.imag
+    r"""Compute the real and imaginary parts of :math:`Y_l^m`.
+
+    Evaluate the harmonic directly from the Cartesian unit direction
+    :math:`\hat{q} = (x, y, z)/r`, using
+
+    .. math::
+
+        \sin^m\theta \, e^{i m \phi} = \left(\frac{x + i y}{r}\right)^m
+        \quad\Longrightarrow\quad
+        Y_l^m = N_{lm} \, p_l^m(z/r) \, \left(\frac{x + i y}{r}\right)^m
+
+    where :math:`p_l^m` is `reduced_legendre`. The right-hand side is
+    polynomial in :math:`x` and :math:`y`, so unlike the
+    :math:`(\theta, \phi)` form it is smooth on the z-axis.
+    """
+    ux, uy, uz = uvec[..., 0], uvec[..., 1], uvec[..., 2]
+
+    # ((x + i y) / r)^m by repeated multiplication (m is static).
+    cos_mphi, sin_mphi = jnp.ones_like(ux), jnp.zeros_like(ux)
+    for _ in range(m):
+        cos_mphi, sin_mphi = (
+            cos_mphi * ux - sin_mphi * uy,
+            cos_mphi * uy + sin_mphi * ux,
+        )
+
+    norm = math.sqrt(
+        (2 * l + 1) / (4 * math.pi) * math.factorial(l - m) / math.factorial(l + m)
+    )
+    plm = norm * reduced_legendre(l, m, uz)
+    return plm * cos_mphi, plm * sin_mphi
+
+
+def iter_Ylm(
+    l_max: int, uvec: gt.BtSz3, /
+) -> list[tuple[int, int, Float[Array, "*batch"], Float[Array, "*batch"]]]:
+    """Compute ``(l, m, Re Y_lm, Im Y_lm)`` for every ``0 <= m <= l <= l_max``."""
+    ls, ms = np.tril_indices(l_max + 1)
+    return [
+        (l, m, *compute_Ylm(l, m, uvec))
+        for l, m in zip(ls.tolist(), ms.tolist(), strict=True)
+    ]

--- a/src/galax/potential/_src/builtin/multipole.py
+++ b/src/galax/potential/_src/builtin/multipole.py
@@ -286,20 +286,41 @@ def scaled_radius_and_direction(
 def reduced_legendre(
     l: int, m: int, u: Float[Array, "*batch"], /
 ) -> Float[Array, "*batch"]:
-    r"""Evaluate :math:`p_l^m(u) = P_l^m(u) / (1 - u^2)^{m/2}`.
+    r"""Evaluate :math:`N_{lm} p_l^m(u)`, with :math:`p_l^m = P_l^m/(1-u^2)^{m/2}`.
 
-    Include the Condon-Shortley phase, matching `scipy.special.lpmv` and GSL.
-    ``l`` and ``m`` are static, so the recurrence unrolls at trace time.
+    :math:`N_{lm} = \sqrt{\frac{2l+1}{4\pi}\frac{(l-m)!}{(l+m)!}}` is the
+    spherical-harmonic normalization, so this returns the *normalized* reduced
+    associated Legendre function. Includes the Condon-Shortley phase, matching
+    `scipy.special.lpmv` and GSL. ``l`` and ``m`` are static, so the recurrence
+    unrolls at trace time.
+
+    The normalization is folded into the recurrence rather than applied
+    afterwards, because :math:`p_l^m` alone is astronomically large -- its seed
+    is :math:`(2m-1)!!`, which overflows float64 near :math:`m = 90` and would
+    then make the whole harmonic ``nan`` via ``inf * 0`` on the axis, exactly
+    the failure this module now exists to avoid. Multiplying by the tiny
+    :math:`N_{lm}` afterwards also loses roughly two digits by cancellation at
+    moderate :math:`m`. The normalized quantity is O(1) at every order: the
+    seed is built in log space, and the recurrence carries it directly.
     """
-    # p_m^m = (-1)^m (2m - 1)!!, with (2m-1)!! = (2m)! / (2^m m!)
-    pmm = (-1.0) ** m * math.factorial(2 * m) / (2**m * math.factorial(m))
-    p_prev, p_cur = jnp.zeros_like(u), jnp.full_like(u, pmm)
+    # N_mm p_m^m, in log space so p_m^m itself is never materialized.
+    log_seed = (
+        0.5 * math.log((2 * m + 1) / (4 * math.pi))
+        + 0.5 * math.lgamma(2 * m + 1)
+        - m * math.log(2)
+        - math.lgamma(m + 1)
+    )
+    q_prev = jnp.zeros_like(u)
+    q_cur = jnp.full_like(u, (-1.0) ** m * math.exp(log_seed))
     for ll in range(m + 1, l + 1):
-        p_prev, p_cur = (
-            p_cur,
-            (u * (2 * ll - 1) * p_cur - (ll + m - 1) * p_prev) / (ll - m),
+        a = math.sqrt((4 * ll * ll - 1) / (ll * ll - m * m))
+        b = (
+            math.sqrt(((ll - 1) ** 2 - m * m) / (4 * (ll - 1) ** 2 - 1))
+            if ll - 1 >= 1
+            else 0.0
         )
-    return p_cur  # type: ignore[no-any-return]
+        q_prev, q_cur = q_cur, a * (u * q_cur - b * q_prev)
+    return q_cur  # type: ignore[no-any-return]
 
 
 def compute_Ylm(
@@ -316,9 +337,10 @@ def compute_Ylm(
         \quad\Longrightarrow\quad
         Y_l^m = N_{lm} \, p_l^m(z/r) \, \left(\frac{x + i y}{r}\right)^m
 
-    where :math:`p_l^m` is `reduced_legendre`. The right-hand side is
-    polynomial in :math:`x` and :math:`y`, so unlike the
-    :math:`(\theta, \phi)` form it is smooth on the z-axis.
+    where `reduced_legendre` supplies :math:`N_{lm} p_l^m` as a single
+    normalized quantity. The right-hand side is polynomial in :math:`x` and
+    :math:`y`, so unlike the :math:`(\theta, \phi)` form it is smooth on the
+    z-axis.
     """
     ux, uy, uz = uvec[..., 0], uvec[..., 1], uvec[..., 2]
 
@@ -330,10 +352,7 @@ def compute_Ylm(
             cos_mphi * uy + sin_mphi * ux,
         )
 
-    norm = math.sqrt(
-        (2 * l + 1) / (4 * math.pi) * math.factorial(l - m) / math.factorial(l + m)
-    )
-    plm = norm * reduced_legendre(l, m, uz)
+    plm = reduced_legendre(l, m, uz)  # already carries N_lm
     return plm * cos_mphi, plm * sin_mphi
 
 

--- a/tests/unit/potential/builtin/test_multipole.py
+++ b/tests/unit/potential/builtin/test_multipole.py
@@ -437,6 +437,25 @@ def test_compute_Ylm_matches_lpmv(l: int) -> None:
         assert np.allclose(got_sin, expect * np.sin(m * phi), rtol=0, atol=1e-12)
 
 
+@pytest.mark.parametrize("m", [90, 150, 400])
+def test_compute_Ylm_finite_at_large_m(m: int) -> None:
+    """Stay finite where the unnormalized Legendre seed would overflow.
+
+    ``p_m^m`` is ``(2m-1)!!``, which overflows float64 near ``m = 90``. If the
+    normalization were applied after the recurrence rather than folded into
+    it, the seed would be ``inf`` and every value would come back ``nan`` --
+    including on the z-axis, via ``inf * 0``, reintroducing exactly the
+    failure this module exists to avoid.
+    """
+    xyz = np.asarray(_BATCH_XYZ.ustrip("kpc"))
+    uvec = jnp.asarray(xyz / np.linalg.norm(xyz, axis=-1, keepdims=True))
+
+    got_cos, got_sin = compute_Ylm(m, m, uvec)
+
+    assert np.all(np.isfinite(got_cos))
+    assert np.all(np.isfinite(got_sin))
+
+
 def test_on_axis_gradient_is_correct() -> None:
     """Check the z-axis gradient is correct, not merely finite.
 

--- a/tests/unit/potential/builtin/test_multipole.py
+++ b/tests/unit/potential/builtin/test_multipole.py
@@ -1,12 +1,15 @@
 """Test the `MultipolePotential` class."""
 
+import math
 import re
 
 from jaxtyping import Array, Shaped
 from typing import Any, override
 
 import equinox as eqx
+import numpy as np
 import pytest
+from scipy.special import lpmv
 
 import quaxed.numpy as jnp
 import unxt as u
@@ -20,6 +23,7 @@ from .test_abstractmultipole import (
     ParameterAngularCoefficientsMixin,
 )
 from .test_common import ParameterMTotMixin, ParameterRSMixin
+from galax.potential._src.builtin.multipole import compute_Ylm
 
 ###############################################################################
 
@@ -395,3 +399,76 @@ def test_batched_matches_per_position(pot: gp.AbstractPotential) -> None:
     assert jnp.allclose(
         batched, one_at_a_time, rtol=1e-8, atol=u.Q(1e-10, batched.unit)
     )
+
+
+###############################################################################
+# The angular basis: correctness, and smoothness on the z-axis.
+#
+# `compute_Ylm` used to go through `theta = acos(z/r)`, `phi = atan2(y, x)`.
+# `atan2` has gradient `-y / (x**2 + y**2)`, i.e. `0/0` wherever `x = y = 0`,
+# so the Cartesian gradient and hessian of every `m >= 1` term were NaN on the
+# entire z-axis. It now evaluates
+#
+#     Y_l^m = N_lm * p_l^m(z/r) * ((x + i y) / r)**m
+#
+# which is polynomial in `x` and `y` and so has no z-axis singularity.
+
+
+@pytest.mark.parametrize("l", range(4))
+def test_compute_Ylm_matches_lpmv(l: int) -> None:
+    """Check the angular basis against `scipy.special.lpmv`.
+
+    This pins the Condon-Shortley phase convention, which must match `lpmv`
+    (and GSL): a sign flip per odd ``m`` would otherwise pass unnoticed by the
+    fixtures below, whose non-zero coefficients are sparse.
+    """
+    xyz = np.asarray(_BATCH_XYZ.ustrip("kpc"))
+    uvec = xyz / np.linalg.norm(xyz, axis=-1, keepdims=True)
+    phi = np.arctan2(uvec[:, 1], uvec[:, 0])
+
+    for m in range(l + 1):
+        norm = math.sqrt(
+            (2 * l + 1) / (4 * math.pi) * math.factorial(l - m) / math.factorial(l + m)
+        )
+        expect = norm * lpmv(m, l, uvec[:, 2])
+        got_cos, got_sin = compute_Ylm(l, m, jnp.asarray(uvec))
+
+        assert np.allclose(got_cos, expect * np.cos(m * phi), rtol=0, atol=1e-12)
+        assert np.allclose(got_sin, expect * np.sin(m * phi), rtol=0, atol=1e-12)
+
+
+def test_on_axis_gradient_is_correct() -> None:
+    """Check the z-axis gradient is correct, not merely finite.
+
+    The potential has non-zero ``m >= 1`` coefficients, so before the Cartesian
+    reformulation every component here was NaN. Comparing against a central
+    difference whose ``x``/``y`` samples straddle the axis from off-axis points
+    checks the value, not just that something finite came out.
+    """
+    Slm, Tlm = _lm_coeffs(2)
+    pot = gp.MultipoleInnerPotential(
+        m_tot=u.Q(1e12, "Msun"),
+        r_s=u.Q(10.0, "kpc"),
+        Slm=Slm,
+        Tlm=Tlm,
+        l_max=2,
+        units="galactic",
+    )
+    on_axis = u.Q([0.0, 0.0, 5.0], "kpc")
+
+    grad = pot.gradient(on_axis, t=0).ustrip(pot.units["acceleration"])
+
+    h = 1e-5  # small enough that O(h^2) truncation sits far below `rtol`
+    expect = jnp.stack(
+        [
+            (
+                pot.potential(on_axis + u.Q(step, "kpc"), t=0)
+                - pot.potential(on_axis - u.Q(step, "kpc"), t=0)
+            ).ustrip(pot.units["specific energy"])
+            / (2 * h)
+            for step in jnp.eye(3) * h
+        ]
+    )
+
+    # NaN compares unequal, so this subsumes an `isfinite` check.
+    assert jnp.allclose(grad, expect, rtol=1e-6, atol=1e-12)


### PR DESCRIPTION
## The defect

`compute_Ylm` derives spherical harmonics from `theta`/`phi`, which come from Cartesian positions via `acos(z/r)` and `atan2(y, x)`.

`atan2(y, x)` has gradient `-y/(x² + y²)`, which is `0/0` wherever `x = y = 0`. So for any `m >= 1` term, the Cartesian gradient and hessian of `MultipoleInnerPotential`, `MultipoleOuterPotential` and `MultipolePotential` are **`NaN` on the entire z-axis**. This is shipped behaviour, and an orbit integrator crossing the axis hits it.

## The fix

Evaluate the angular part directly from Cartesian components. Writing `P_l^m(u) = (1-u²)^(m/2) · p_l^m(u)`, the awkward factor combines with the azimuth into a polynomial:

```
sin^m(θ)·e^(imφ)  ==  ((x + iy)/r)^m
```

so

```
Y_l^m  =  N_lm · p_l^m(z/r) · ((x + iy)/r)^m
```

`(x + iy)` is a polynomial. The z-axis singularity does not exist in this form — it was an artifact of the coordinate choice, not of the physics.

## Evidence

The on-axis gradient goes from `NaN` to **correct**, checked against a central finite difference approaching the axis:

| | `dΦ/dx` | `dΦ/dy` | `dΦ/dz` |
| --- | --- | --- | --- |
| before | `nan` | `nan` | `nan` |
| after | `-0.00466262` | `-0.00041020` | `0.00879192` |
| finite difference | `-0.00466257` | `-0.00041020` | `0.00879192` |

The new `test_on_axis_gradient_is_correct` asserts agreement with the finite difference, not merely `isfinite` — a test that only checked finiteness would pass on a masking workaround that returns a wrong-but-finite zero. Confirmed it fails on the pre-fix code.

Angular values match `scipy.special.lpmv` for every `(l, m)` with `l <= 3` to `3.6e-16`, which also pins the Condon–Shortley convention against GSL's.

## No existing expected value changed

Every fixture in `test_multipole.py`, `test_innermultipole.py`, `test_outermultipole.py` and `test_abstractmultipole.py` passes **unmodified**. Regenerating the `array_compare` references gives bit-identical output except two entries — innermultipole hessian (`3.6e-16`) and tidal_tensor (`2.0e-16`) — whose reference values are themselves of order `1e-16`.

`1435 passed → 1440 passed`, exactly `+5` (four `lpmv` parametrizations plus the on-axis test). No skips or xfails changed.

## Drops `jax.scipy.special.sph_harm_y`

A deliberate secondary benefit. That function has two known defects galax was carrying workarounds for:

- it pairs `l`/`m`/`theta`/`phi` element-wise rather than broadcasting — the silent wrong-answer bug fixed in #834
- all of its derivatives are `NaN` at both poles, even for `l = m = 0` where the function is constant

Neither workaround is needed once the harmonics are computed here.

## Incidental finding

The old code also lost roughly five digits *near* the axis, not only on it: `acos(z/r)` is ill-conditioned once `z/r` is within ~2e-12 of 1. The fix improves accuracy in a neighbourhood, not just at the singular set.

## Known limitation, unchanged

At the origin (`r = 0`) the value, gradient and hessian remain `NaN`, since `z/r` is `0/0`. That is unchanged from the previous implementation — this PR does not make it worse, and fixing it needs `r^(l-m)·p_l^m(z/r)` re-expressed as a polynomial in `(z, r²)`. Separable follow-up.

## Note

One structural change beyond the formula: `l` and `m` were **tracers** under `jax.vmap(summand)(ls, ms)`, and the Legendre recurrences need them static. The vmap became a trace-time-unrolled comprehension over `np.tril_indices`.

Sent ahead of #835 (SCFPotential), which needs correct on-axis derivatives and will rebase onto this, dropping its masking guards and the `.. warning::` blocks that documented the masked behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
