### PR TITLE
⚡️ perf(potential): share the Ylm recurrences across the multipole table

### DIFF
--- a/src/galax/potential/_src/builtin/multipole.py
+++ b/src/galax/potential/_src/builtin/multipole.py
@@ -16,7 +16,6 @@ from typing import final
 
 import equinox as eqx
 import jax
-import numpy as np
 from equinox import field
 
 import quaxed.numpy as jnp
@@ -291,6 +290,37 @@ def scaled_radius_and_direction(
     return r / r_s, q / r[..., None]
 
 
+def legendre_seed(m: int, u: Float[Array, "*batch"], /) -> Float[Array, "*batch"]:
+    r"""Seed the reduced-Legendre recurrence at :math:`l = m` with :math:`N_{mm}p_m^m`.
+
+    Built in log space so :math:`p_m^m = (-1)^m (2m-1)!!` -- which overflows
+    float64 near :math:`m = 90` -- is never materialized; see
+    `reduced_legendre` for why that matters.
+    """
+    log_seed = (
+        0.5 * math.log((2 * m + 1) / (4 * math.pi))
+        + 0.5 * math.lgamma(2 * m + 1)
+        - m * math.log(2)
+        - math.lgamma(m + 1)
+    )
+    return jnp.full_like(u, (-1.0) ** m * math.exp(log_seed))  # type: ignore[no-any-return]
+
+
+def legendre_step_coeffs(l: int, m: int, /) -> tuple[float, float]:
+    r"""Give the ``(a, b)`` coefficients of the :math:`l-1 \to l` recurrence step.
+
+    :math:`q_l = a (u q_{l-1} - b q_{l-2})` for the normalized reduced Legendre
+    functions :math:`q_l = N_{lm} p_l^m`.
+    """
+    a = math.sqrt((4 * l * l - 1) / (l * l - m * m))
+    b = (
+        math.sqrt(((l - 1) ** 2 - m * m) / (4 * (l - 1) ** 2 - 1))
+        if l - 1 >= 1
+        else 0.0
+    )
+    return a, b
+
+
 def reduced_legendre(
     l: int, m: int, u: Float[Array, "*batch"], /
 ) -> Float[Array, "*batch"]:
@@ -311,24 +341,12 @@ def reduced_legendre(
     moderate :math:`m`. The normalized quantity is O(1) at every order: the
     seed is built in log space, and the recurrence carries it directly.
     """
-    # N_mm p_m^m, in log space so p_m^m itself is never materialized.
-    log_seed = (
-        0.5 * math.log((2 * m + 1) / (4 * math.pi))
-        + 0.5 * math.lgamma(2 * m + 1)
-        - m * math.log(2)
-        - math.lgamma(m + 1)
-    )
     q_prev = jnp.zeros_like(u)
-    q_cur = jnp.full_like(u, (-1.0) ** m * math.exp(log_seed))
+    q_cur = legendre_seed(m, u)
     for ll in range(m + 1, l + 1):
-        a = math.sqrt((4 * ll * ll - 1) / (ll * ll - m * m))
-        b = (
-            math.sqrt(((ll - 1) ** 2 - m * m) / (4 * (ll - 1) ** 2 - 1))
-            if ll - 1 >= 1
-            else 0.0
-        )
+        a, b = legendre_step_coeffs(ll, m)
         q_prev, q_cur = q_cur, a * (u * q_cur - b * q_prev)
-    return q_cur  # type: ignore[no-any-return]
+    return q_cur
 
 
 def compute_Ylm(
@@ -367,9 +385,34 @@ def compute_Ylm(
 def iter_Ylm(
     l_max: int, uvec: gt.BtSz3, /
 ) -> list[tuple[int, int, Float[Array, "*batch"], Float[Array, "*batch"]]]:
-    """Compute ``(l, m, Re Y_lm, Im Y_lm)`` for every ``0 <= m <= l <= l_max``."""
-    ls, ms = np.tril_indices(l_max + 1)
-    return [
-        (l, m, *compute_Ylm(l, m, uvec))
-        for l, m in zip(ls.tolist(), ms.tolist(), strict=True)
-    ]
+    r"""Compute ``(l, m, Re Y_lm, Im Y_lm)`` for every ``0 <= m <= l <= l_max``.
+
+    Same values as `compute_Ylm` called on each pair, but both recurrences are
+    carried across the table instead of restarted: one pass per ``m`` advances
+    :math:`((x + iy)/r)^m` by a single complex multiply and walks the Legendre
+    recurrence up in ``l`` from its seed at ``l = m``. That makes the whole
+    table :math:`O(l_\mathrm{max}^2)` rather than cubic -- and since ``l`` and
+    ``m`` are static, the saving is in traced operations, so it shrinks the
+    HLO and hence trace and compile time.
+
+    Terms come out in m-major order rather than the l-major order of
+    ``np.tril_indices``; every caller sums them, so the order is immaterial.
+    """
+    ux, uy, uz = uvec[..., 0], uvec[..., 1], uvec[..., 2]
+    cos_mphi, sin_mphi = jnp.ones_like(ux), jnp.zeros_like(ux)
+
+    out = []
+    for m in range(l_max + 1):
+        if m > 0:  # advance ((x + i y) / r)^m by one complex multiply
+            cos_mphi, sin_mphi = (
+                cos_mphi * ux - sin_mphi * uy,
+                cos_mphi * uy + sin_mphi * ux,
+            )
+
+        q_prev, q_cur = jnp.zeros_like(uz), legendre_seed(m, uz)
+        out.append((m, m, q_cur * cos_mphi, q_cur * sin_mphi))
+        for l in range(m + 1, l_max + 1):
+            a, b = legendre_step_coeffs(l, m)
+            q_prev, q_cur = q_cur, a * (uz * q_cur - b * q_prev)
+            out.append((l, m, q_cur * cos_mphi, q_cur * sin_mphi))
+    return out

--- a/tests/unit/potential/builtin/test_multipole.py
+++ b/tests/unit/potential/builtin/test_multipole.py
@@ -23,7 +23,7 @@ from .test_abstractmultipole import (
     ParameterAngularCoefficientsMixin,
 )
 from .test_common import ParameterMTotMixin, ParameterRSMixin
-from galax.potential._src.builtin.multipole import compute_Ylm
+from galax.potential._src.builtin.multipole import compute_Ylm, iter_Ylm
 
 ###############################################################################
 
@@ -491,3 +491,28 @@ def test_on_axis_gradient_is_correct() -> None:
 
     # NaN compares unequal, so this subsumes an `isfinite` check.
     assert jnp.allclose(grad, expect, rtol=1e-6, atol=1e-12)
+
+
+@pytest.mark.parametrize("l_max", [0, 1, 6])
+def test_iter_Ylm_matches_compute_Ylm(l_max: int) -> None:
+    """Check the shared-recurrence table against the per-pair reference.
+
+    `iter_Ylm` carries the Legendre and azimuth recurrences across the whole
+    ``(l, m)`` table instead of restarting them for each pair. `compute_Ylm`
+    remains the readable single-pair definition, so it is the reference: the
+    two must agree exactly, up to round-off, for every pair. The order differs
+    (m-major vs l-major), so compare as a dict keyed by ``(l, m)``.
+    """
+    xyz = np.asarray(_BATCH_XYZ.ustrip("kpc"))
+    uvec = jnp.asarray(xyz / np.linalg.norm(xyz, axis=-1, keepdims=True))
+
+    got = {(l, m): (c, s) for l, m, c, s in iter_Ylm(l_max, uvec)}
+
+    expect_lm = [(l, m) for l in range(l_max + 1) for m in range(l + 1)]
+    assert sorted(got) == sorted(expect_lm)
+
+    for l, m in expect_lm:
+        want_cos, want_sin = compute_Ylm(l, m, uvec)
+        got_cos, got_sin = got[l, m]
+        assert np.allclose(got_cos, want_cos, rtol=1e-14, atol=1e-15)
+        assert np.allclose(got_sin, want_sin, rtol=1e-14, atol=1e-15)


### PR DESCRIPTION
Closes #837.

## What was redundant

`iter_Ylm` built the `(l, m)` table by calling `compute_Ylm(l, m, uvec)` independently for each pair, and each of those calls started from scratch:

- the Legendre recurrence ran from `m` up to `l` every time, re-deriving every intermediate order it had already computed for `(l-1, m)`
- `((x + iy)/r)^m` was rebuilt by `m` repeated complex multiplications, having just been built for `m-1`

Nothing was shared between neighbouring entries, even though both recurrences naturally produce the whole table as they go. `l` and `m` must be static for those recurrences, so the terms unroll at trace time — which meant the redundancy inflated the HLO, and therefore trace and compile time, rather than showing up purely at runtime.

This was the long-standing `TODO: vectorize compute_Ylm over l, m` in the same file.

## What changed

One pass per `m`: advance the azimuth by a single complex multiply, seed the Legendre recurrence at `l = m`, then step it up to `l_max` emitting each order as it goes.

`compute_Ylm` and `reduced_legendre` keep their signatures and behaviour — they remain the readable single-pair reference, and the tests exercise them directly. The seed and the `(a, b)` step coefficients are factored into shared helpers so both paths derive them from one place.

The returned order changes from `l`-major to `m`-major. All three consumers are the `_potential` methods, which index `Slm`/`Tlm` by the yielded `(l, m)` and sum, so none depend on order.

## Measured

`MultipoleInnerPotential`, N = 1e6, same script both sides, x64 on:

| l_max | trace | compile | run | temp |
| ---: | --- | --- | --- | --- |
| 2 | 0.04 → 0.03s | 0.04 → 0.04s | 2.0 → 0.9 ms | 8.0 → 8.0 MB |
| 6 | 0.16 → 0.05s | 0.11 → 0.10s | 4.0 → 4.1 ms | 8.0 → 8.0 MB |
| 12 | 0.42 → 0.12s | 0.49 → 0.34s | 16.6 → 14.9 ms | 8.0 → 8.0 MB |
| 20 | 1.58 → 0.34s | 1.81 → 1.04s | 49.2 → 42.3 ms | **32.0 → 8.0 MB** |

Trace is 3–4.6x faster and compile up to 1.7x. Peak temp no longer spills at `l_max = 20`.

**Run time is essentially flat, and that is the honest headline.** XLA was already fusing the redundant work away at execution, so the cost this removes is almost entirely in tracing and compiling an oversized HLO, not in evaluating it. If you were expecting a runtime win, there isn't one worth quoting.

Two corrections to #837 while I am here:

- the baseline table in the issue is wrong — its absolute figures (e.g. 0.29s trace at `l_max = 2` against 0.04s here) included JAX warm-up in the first measurement. Before/after above were taken identically, so the comparison stands, but the issue's absolute numbers should not be cited.
- the issue speculated this might also move the `lmax` axis of the SCF benchmark in #835. Given run time is flat, it probably will not. That claim should not be carried forward without re-measuring.

## Correctness

Pure refactor; values are bit-identical. The sum-over-N checksum matched exactly at every `l_max` tested, and all four multipole test files pass **unmodified** — including `test_compute_Ylm_matches_lpmv`, `test_compute_Ylm_finite_at_large_m`, and `test_on_axis_gradient_is_correct`, the last being the reason the Cartesian form exists at all.

Adds `test_iter_Ylm_matches_compute_Ylm`, asserting the batched table agrees with the per-pair reference for every `(l, m)` at `l_max` 0/1/6, `rtol=1e-14`. That is the direct statement of what this refactor has to preserve.

`tests/unit/potential`: 1443 passed → 1446 passed, 71 skipped, 15 xfailed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
