### PR TITLE
🐛 fix(potential): make the hessian finite at the origin

### DIFF
--- a/src/galax/potential/_src/builtin/multipole.py
+++ b/src/galax/potential/_src/builtin/multipole.py
@@ -289,10 +289,16 @@ def scaled_radius_and_direction(
     :math:`r \sim 10^{-154}` that cubes straight past the bottom of float64
     and evaluates to ``inf``, so the hessian is NaN even though the value and
     the gradient are finite. Flooring the direction's denominator at
-    ``tiny**(1/3)`` keeps :math:`r^3` representable. Both floors are far below
-    any physical position -- the unit direction is bit-identical either way
-    off the origin -- and the returned ``s`` is unaffected, since it is built
-    from the unfloored-for-direction ``r``.
+    ``tiny**(1/3)`` keeps :math:`r^3` representable.
+
+    That floor does perturb the direction for sufficiently small non-zero
+    :math:`|q|`: measured in float64, ``q / r`` is bit-identical with and
+    without it down to :math:`|q| \sim 10^{-90}` and starts to differ by
+    :math:`10^{-95}`. Both floors therefore sit some eighty orders of
+    magnitude below any physical position, but "unchanged everywhere except
+    the origin" would be too strong a claim. The returned ``s`` is unaffected
+    either way, since it is built from the ``r`` that is not floored for the
+    direction.
     """
     r = safe_vector_norm(q)
     # `tiny**(2/3)` inside the square root floors `r` itself at `tiny**(1/3)`.

--- a/src/galax/potential/_src/builtin/multipole.py
+++ b/src/galax/potential/_src/builtin/multipole.py
@@ -279,15 +279,26 @@ def scaled_radius_and_direction(
     :math:`-y/(x^2+y^2)`, which is :math:`0/0` on the whole z-axis, so any
     :math:`m \ge 1` term built from it has NaN Cartesian derivatives there.
 
-    ``r`` uses `safe_vector_norm`, which floors it at
-    ``sqrt(finfo(dtype).tiny)`` -- around 1e-154 in float64, 1e-19 in float32.
-    Without that, :math:`\hat{q} = q/r` is ``0/0`` at the origin and the value
-    itself -- not just its derivatives -- comes back NaN. The floor is far
-    below any physical position in either dtype, so nothing off the origin is
-    perturbed.
+    The scaled radius uses `safe_vector_norm`, which floors ``r`` at
+    ``sqrt(finfo(dtype).tiny)`` -- around 1e-154 in float64. Without that,
+    :math:`\hat{q} = q/r` is ``0/0`` at the origin and the value itself, not
+    just its derivatives, comes back NaN.
+
+    The *direction* needs a larger floor than the radius does. The second
+    derivative of :math:`q/r` carries a :math:`1/r^3` term, and at
+    :math:`r \sim 10^{-154}` that cubes straight past the bottom of float64
+    and evaluates to ``inf``, so the hessian is NaN even though the value and
+    the gradient are finite. Flooring the direction's denominator at
+    ``tiny**(1/3)`` keeps :math:`r^3` representable. Both floors are far below
+    any physical position -- the unit direction is bit-identical either way
+    off the origin -- and the returned ``s`` is unaffected, since it is built
+    from the unfloored-for-direction ``r``.
     """
     r = safe_vector_norm(q)
-    return r / r_s, q / r[..., None]
+    # `tiny**(2/3)` inside the square root floors `r` itself at `tiny**(1/3)`.
+    cube_safe = jnp.finfo(jnp.promote_types(q.dtype, float)).tiny ** (2 / 3)
+    r_dir = jnp.sqrt(jnp.sum(jnp.square(q), axis=-1) + cube_safe)
+    return r / r_s, q / r_dir[..., None]
 
 
 def legendre_seed(m: int, u: Float[Array, "*batch"], /) -> Float[Array, "*batch"]:

--- a/src/galax/potential/_src/builtin/scf/bfe.py
+++ b/src/galax/potential/_src/builtin/scf/bfe.py
@@ -46,6 +46,23 @@ def _nl_axes(
     return n, l, cn
 
 
+def _s_pow_l(
+    lmax: int, s: Float[Array, "*batch"], /
+) -> Float[Array, "{lmax}+1 *batch"]:
+    r""":math:`s^l` for :math:`l = 0 \ldots l_{max}`, stacked on a leading axis.
+
+    Built with *integer* exponents rather than as ``s ** l`` against a float
+    ``l`` array. The two agree in value, but the float form is not twice
+    differentiable at :math:`s = 0`: the derivative of :math:`s^0` is
+    :math:`0 \cdot s^{-1}`, which JAX evaluates as ``0 * inf`` and returns
+    ``nan``, so the hessian of every SCF potential was NaN at the origin even
+    though the value and gradient were finite. ``lmax`` is static, so the
+    comprehension unrolls at trace time and `jax` uses `lax.integer_pow`,
+    whose derivative at zero is exact.
+    """
+    return jnp.stack([s**i for i in range(lmax + 1)])  # type: ignore[no-any-return]
+
+
 @ft.partial(jax.jit, static_argnums=(0, 1))
 def phi_nl(
     nmax: int, lmax: int, s: Float[Array, "*batch"], /
@@ -69,7 +86,7 @@ def phi_nl(
 
     """
     _, l, cn = _nl_axes(nmax, lmax, s)
-    prefactor = -SQRT_FOURPI * s**l / (1 + s) ** (2 * l + 1)
+    prefactor = -SQRT_FOURPI * _s_pow_l(lmax, s) / (1 + s) ** (2 * l + 1)
     return prefactor * cn
 
 
@@ -95,7 +112,12 @@ def rho_nl(
     """
     n, l, cn = _nl_axes(nmax, lmax, s)
     knl = 0.5 * n * (n + 4 * l + 3) + (l + 1) * (2 * l + 1)
-    prefactor = SQRT_FOURPI * (knl / (2 * jnp.pi)) * s**l / (s * (1 + s) ** (2 * l + 3))
+    prefactor = (
+        SQRT_FOURPI
+        * (knl / (2 * jnp.pi))
+        * _s_pow_l(lmax, s)
+        / (s * (1 + s) ** (2 * l + 3))
+    )
     return prefactor * cn  # type: ignore[no-any-return]
 
 

--- a/tests/unit/potential/scf/test_scf.py
+++ b/tests/unit/potential/scf/test_scf.py
@@ -271,19 +271,8 @@ def _quadrupole() -> gp.SCFPotential:
     ],
 )
 @pytest.mark.parametrize("method", ["potential", "gradient", "density", "hessian"])
-def test_finite_on_coordinate_singularities(request, name, xyz, method) -> None:
+def test_finite_on_coordinate_singularities(name, xyz, method) -> None:
     """Value and derivatives stay finite at r=0 and along the z-axis."""
-    if name == "origin" and method == "hessian":
-        request.applymarker(
-            pytest.mark.xfail(
-                reason="The second derivative of |q| at the origin is still "
-                "0/0 even with `safe_vector_norm`'s floor: the first "
-                "derivative is finite but discontinuous there. The value, "
-                "density and gradient are all finite; only the hessian is "
-                "not. See `scaled_radius_and_direction`.",
-            )
-        )
-
     pot = _quadrupole()
     q = u.Q(np.array(xyz), "kpc")
 


### PR DESCRIPTION
The last of the coordinate-singularity failures. Value, gradient and density were already finite at `r = 0`; only the hessian returned NaN, which is why `test_finite_on_coordinate_singularities` still carried one `xfail`.

Two independent causes, both `0 * inf`, both found by bisecting the chain rather than guessing at it.

## 1. The direction vector needs a bigger floor than the radius

`scaled_radius_and_direction` floors `r` with `safe_vector_norm`, at `sqrt(finfo.tiny)` — about `1e-154` in float64. That is enough for the *first* derivative, which is why the gradient was already fine. The hessian of `q / r` carries a `1/r**3` term, and `(1e-154)**3` falls off the bottom of float64 to zero, so the reciprocal is `inf`.

Measured directly — hessian of `(q / sqrt(sum(q**2) + eps))[2]` at the origin:

| `eps` | finite hessian? |
| --- | --- |
| `tiny` (current) | no |
| `1e-200` | yes |
| `1e-100` | yes |

The direction's denominator now floors at `tiny**(1/3)`, chosen so `r**3` stays representable rather than picked by trial. `s` is built from the unmodified `r` and is unchanged. The direction is bit-identical with and without the floor down to `|q| ~ 1e-90`, crossing over near `1e-92` — some eighty orders of magnitude below any physical position, though not literally "everywhere but the origin".

## 2. `s ** l` used a float exponent

`phi_nl` and `rho_nl` raised `s` to a float `l` array. The values are right, but:

```
s = 1e-155
s ** 0.0  ->  value 1.0,  second derivative nan
s ** 0    ->  value 1.0,  second derivative 0.0
```

The derivative of `s**0.0` is `0 * s**-1` — `0 * inf` at the origin. With an integer exponent JAX uses `lax.integer_pow`, whose derivative at zero is exact. `lmax` is static, so the powers are now built by a trace-time comprehension over integer exponents.

This one is worth noting for its blast radius: it made the hessian NaN at the origin for **every** SCF potential, including a pure monopole, regardless of the coordinate handling.

## Correctness

Not a tolerance change. Agreement with gala's C/GSL over 200 positions is unmoved:

- potential **1.883e-16**, density **5.733e-16** — identical to the pre-fix figures

`tests/unit/potential` + `tests/smoke`: **1519 passed, 71 skipped, 15 xfailed, 0 failed**. That is one fewer `xfail` than before; all twelve parametrizations of `test_finite_on_coordinate_singularities` now pass, so the marker is removed rather than reworded.

Rebased onto `main` after #838.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
